### PR TITLE
chore(async): Improve loading configuration, assert and ensure invalids

### DIFF
--- a/test/unit/translateSpec.js
+++ b/test/unit/translateSpec.js
@@ -697,6 +697,49 @@ describe('ngTranslate', function () {
 
   describe('Asynchronous loading', function () {
 
+    describe('register loader=null', function () {
+
+      var exceptionMessage;
+
+      beforeEach(module('ngTranslate', function ($translateProvider) {
+        try {
+          $translateProvider.registerLoader(null);
+        } catch (ex) {
+          exceptionMessage = ex.message;
+        }
+      }));
+
+      it('should be throw an error', inject(function ($translate) {
+        expect($translate.uses()).toBeUndefined();
+        $translate.uses('de_DE');
+        expect($translate.uses()).toBeUndefined();
+        expect(exceptionMessage).toEqual('Please define a valid loader!');
+      }));
+
+    });
+
+    describe('register loader=undefined', function () {
+
+      var exceptionMessage;
+
+      beforeEach(module('ngTranslate', function ($translateProvider) {
+        try {
+          $translateProvider.registerLoader(undefined);
+        } catch (ex) {
+          exceptionMessage = ex.message;
+        }
+      }));
+
+      it('should be throw an error', inject(function ($translate) {
+        expect($translate.uses()).toBeUndefined();
+        $translate.uses('de_DE');
+        expect($translate.uses()).toBeUndefined();
+        expect(exceptionMessage).toEqual('Please define a valid loader!');
+      }));
+
+    });
+
+
     describe('register loader via a function', function () {
 
       beforeEach(module('ngTranslate', function ($translateProvider) {


### PR DESCRIPTION
- If the loader is not valid, it should not be used.
- If `invokeLoading` will be invoked, it is possible that no async loader is available (empty array).
- Assert the loader builder function returns a valid function.

Actually, if language is not available this had been created an error by design.
