### PR TITLE
Support for custom handling of missing translations.

### DIFF
--- a/ngTranslate/translate.js
+++ b/ngTranslate/translate.js
@@ -18,6 +18,7 @@ angular.module('ngTranslate').provider('$translate', function () {
   var $translationTable = {},
       $uses,
       $rememberLanguage = false,
+      $missingTranslationHandler,
       $asyncLoaders = [];
 
   var LoaderGenerator = {
@@ -101,6 +102,13 @@ angular.module('ngTranslate').provider('$translate', function () {
     $rememberLanguage = boolVal;
   };
 
+  this.missingTranslationHandler = function (functionHandler) {
+    if (angular.isUndefined(functionHandler)) {
+      return $missingTranslationHandler;
+    }
+    $missingTranslationHandler = functionHandler;
+  };
+
   this.registerLoader = function (loader) {
 
     var $loader;
@@ -159,7 +167,12 @@ angular.module('ngTranslate').provider('$translate', function () {
         return $interpolate(translation)(interpolateParams);
       }
 
-      $log.warn("Translation for " + translationId + " doesn't exist");
+      if (!angular.isUndefined($missingTranslationHandler)) {
+        $missingTranslationHandler(translationId);
+      } else {
+        $log.warn("Translation for " + translationId + " doesn't exist");
+      }
+
       return translationId;
     };
 


### PR DESCRIPTION
This patch enables a developer to set a missingTranslationHandler function on the $translateProvider. Instead of firing the $log.warn(), the developer is able to handle this event in a custom way.

The use-case I am working toward is a console for real-time translation. Currently it isn't possible to programatically discover which translations the translator needs to work on.

My AngularJS skills are still developing. If this patch can be accomplished in another way I'm happy to hear about it.

Thanks
