### PR TITLE
chore(loader): Auto-recognize nested objects supporting namespaces

### DIFF
--- a/demo/async-loader/app_loader_static-files_with-ns.js
+++ b/demo/async-loader/app_loader_static-files_with-ns.js
@@ -1,0 +1,21 @@
+angular.module('app', ['ngTranslate'])
+
+.config(['$translateProvider', function($translateProvider){
+  $translateProvider.registerLoader({
+    type: 'static-files',
+    prefix: 'languages/ns_lang_',
+    suffix: '.json'
+  });
+  $translateProvider.uses('de_DE');
+}])
+
+.controller('ctrl', function ($translate, $scope){
+  $scope.tlData = {
+    randomValue : 42
+  };
+  $scope.selectLang = function(key) {
+    // "Click" invokes an implicit $scope.$apply
+    $translate.uses(key);
+    $scope.tlData.randomValue = Math.round(1000 * Math.random());
+  }
+});

--- a/demo/async-loader/index_loader_static-files_with-ns.html
+++ b/demo/async-loader/index_loader_static-files_with-ns.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ng-translate w/ async loader</title>
+
+    <script src="../../bower_components/angular/angular.js"></script>
+    <script src="../../bower_components/angular-cookies/angular-cookies.js"></script>
+    <script src="../angular-translate-latest.js"></script>
+    <script src="app_loader_static-files_with-ns.js"></script>
+
+</head>
+<body ng-app="app" ng-controller="ctrl">
+    <button ng-click="selectLang('de_DE')">de_DE</button>
+    <button ng-click="selectLang('en_US')">en_US</button>
+    <button ng-click="selectLang('nt_VD')">nt_VD</button>
+    <h1>{{'DOCUMENT.HEADER.TITLE' | translate}}</h1>
+    <h2 translate="DOCUMENT.SUBHEADER.TITLE">Subheader</h2>
+    <p>{{tlData.randomValue}}</p>
+    <p>{{'DOCUMENT.TEXT' | translate: tlData}}</p>
+</body>
+</html>

--- a/demo/async-loader/languages/ns_lang_de_DE.json
+++ b/demo/async-loader/languages/ns_lang_de_DE.json
@@ -1,0 +1,11 @@
+{
+  "DOCUMENT" : {
+    "HEADER" : {
+      "TITLE" : "Überschrift"
+    },
+    "SUBHEADER" : {
+      "TITLE" : "2. Überschrift"
+    },
+    "TEXT" : "<em>{{randomValue}}</em> ist die Antwort auf das Leben, das Universum und der ganzen Rest."
+  }
+}

--- a/demo/async-loader/languages/ns_lang_en_US.json
+++ b/demo/async-loader/languages/ns_lang_en_US.json
@@ -1,0 +1,11 @@
+{
+  "DOCUMENT" : {
+    "HEADER" : {
+      "TITLE" : "Header"
+    },
+    "SUBHEADER" : {
+      "TITLE" : "2. Header"
+    },
+    "TEXT" : "<em>{{randomValue}}</em> is the answer to life the universe and everything."
+  }
+}

--- a/test/unit/translateSpec.js
+++ b/test/unit/translateSpec.js
@@ -739,6 +739,48 @@ describe('ngTranslate', function () {
 
     });
 
+    describe('register a loader (function) where data is a nested object structure (namespace support)', function () {
+
+      beforeEach(module('ngTranslate', function ($translateProvider) {
+        $translateProvider.registerLoader(function ($q, $timeout) {
+          return function (key) {
+            var data = (key !== 'en_US') ? null : {
+                "DOCUMENT" : {
+                  "HEADER" : {
+                    "TITLE" : "Header"
+                  },
+                  "SUBHEADER" : {
+                    "TITLE" : "2. Header"
+                  }
+                }
+            };
+            var deferred = $q.defer();
+            $timeout(function () {
+              deferred.resolve(data);
+            }, 200);
+            return deferred.promise;
+          };
+        });
+      }));
+
+      it('implicit invoking loader should be successful', inject(function ($translate, $timeout) {
+        var called = false;
+        $translate.uses('en_US').then(function (){
+          called = true;
+        });
+        $timeout.flush();
+        expect(called).toEqual(true);
+      }));
+
+      it('implicit invoking loader should be successful', inject(function ($translate, $timeout) {
+        var called = false;
+        $translate.uses('en_US');
+        $timeout.flush();
+        expect($translate('DOCUMENT.HEADER.TITLE')).toEqual('Header');
+        expect($translate('DOCUMENT.SUBHEADER.TITLE')).toEqual('2. Header');
+      }));
+
+    });
 
     describe('register loader via a function', function () {
 


### PR DESCRIPTION
If the result of any asynchronous loader (regardless function or XHRs) is a nested object, each key will be traversed the object flatten down.

Example:

``` json
{
  "DOCUMENT" : {
    "HEADER" : {
      "TITLE" : "Header"
    },
    "SUBHEADER" : {
      "TITLE" : "2. Header"
    },
    "TEXT" : "<em>{{randomValue}}</em> is the answer to life the universe and everything."
  }
}
```

will result into this in `$translationId` internally:

``` json
{
  "DOCUMENT.HEADER.TITLE" : "Header",
  "DOCUMENT.SUBHEADER.TITLE" : "2. Header",
  "DOCUMENT.TEXT" : "<em>{{randomValue}}</em> is the answer to life the universe and everything."
}
```

Discussion already placed at #14
