### PR TITLE
Add dedicated express server with own config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,7 +84,8 @@ module.exports = function (grunt) {
       server: {
         options: {
           port: 3005,
-          bases: '.'
+          bases: '.',
+          server: __dirname + '/server.js'
         }
       }
     }

--- a/demo/server_routes.js
+++ b/demo/server_routes.js
@@ -1,0 +1,8 @@
+module.exports = function (app, dir) {
+
+  // Example
+  app.get('/this-is-an-express-server', function (req, res) {
+    res.send(200);
+  });
+
+};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "grunt-conventional-changelog": "0.0.12",
     "grunt-express": "~0.3.3",
     "grunt-contrib-copy": "~0.4.1",
-    "grunt-ngmin": "0.0.2"
+    "grunt-ngmin": "0.0.2",
+    "express": "~3.2.4"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,23 @@
+var express = require('express');
+
+// Create express facility.
+var app = express()
+// Create a HTTP server object.
+var server = require('http').createServer(app);
+
+app.configure(function () {
+    app.use(express.logger('dev'));
+    app.use(express.bodyParser());
+    app.use(express.methodOverride());
+    app.use(express.errorHandler());
+    app.use(express.static(__dirname));
+    app.use(app.router);
+    require('./demo/server_routes')(app, __dirname);
+});
+
+module.exports = server;
+
+// Override: Provide an "use" used by grunt-express.
+module.exports.use = function () {
+    app.use.apply(app, arguments);
+};


### PR DESCRIPTION
Extents the existing `grunt server` with dynamic express routes.
