### PR TITLE
chore(.gitignore): Ignore generated documentation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ components
 bower_components
 dist
 demo/js/angular-translate-latest.js
+site


### PR DESCRIPTION
Add `site` folder to `.gitignore` file to ignore grunt generated documentation
