### PR TITLE
Enable translate directive to be used as an element.

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -80,7 +80,7 @@ angular.module('pascalprecht.translate')
   var translate = $filter('translate');
 
   return {
-    restrict: 'A',
+    restrict: 'AE',
     scope: true,
     link: function linkFn(scope, element, attr) {
 
@@ -91,7 +91,7 @@ angular.module('pascalprecht.translate')
       // be re-stored to the scope's "translationId".
       // If the attribute has no content, the element's text value (white spaces trimmed off) will be used.
       attr.$observe('translate', function (translationId) {
-        if (angular.equals(translationId , '')) {
+        if (angular.equals(translationId , '') || translationId === undefined) {
           scope.translationId = $interpolate(element.text().replace(/^\s+|\s+$/g,''))(scope.$parent);
         } else {
           scope.translationId = translationId;

--- a/test/unit/translateDirectiveSpec.js
+++ b/test/unit/translateDirectiveSpec.js
@@ -112,6 +112,19 @@ describe('pascalprecht.translate', function () {
           expect(element.text()).toBe('foo');
         });
       });
+
+      it('should return translation when used as an element', function () {
+        inject(function ($rootScope, $compile) {
+          element =
+            $compile('<translate>TRANSLATION_ID</translate>')($rootScope);
+          $rootScope.$digest();
+          expect(element.text()).toBe('foo');
+
+          element = $compile('<translate>BLANK_VALUE</translate>')($rootScope);
+          $rootScope.$digest();
+          expect(element.text()).toBe('');
+        });
+      });
     });
 
     describe('Passing values', function () {


### PR DESCRIPTION
Translate directive can now be used as an element in addition to an attribute.
