### PR TITLE
fix(typo): remove unnecessary semicolon

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -811,7 +811,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
 
         deferred.resolve(key);
         $rootScope.$broadcast('$translateChangeEnd');
-      };
+      }
 
       // if there isn't a translation table for the language we've requested,
       // we load it asynchronously


### PR DESCRIPTION
According to "grunt jshint" task this semicolon is unnecessary, so it's impossible to build module with "grunt build" task without this fix (
