### PR TITLE
Feature $translate.invalidate()

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -872,33 +872,44 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
       function onLoadingEnd() {
         $rootScope.$broadcast('$translateRefreshEnd');
       }
-      
+
+      if (!$loaderFactory) {
+        throw new Error('Couldn\'t refresh translation table, no loader registered!');
+      }
+
       if (!langKey) {
-      
-        if ($loaderFactory) {
-          $rootScope.$broadcast('$translateRefreshStart');  
-          for (var lang in $translationTable) {
-            if ($translationTable.hasOwnProperty(lang)) {
-              delete $translationTable[lang];
-            }
+
+        $rootScope.$broadcast('$translateRefreshStart'); 
+
+        for (var lang in $translationTable) {
+          if ($translationTable.hasOwnProperty(lang)) {
+            delete $translationTable[lang];
           }
-          var loaders = [];
-          if ($fallbackLanguage) loaders.push(loadAsync($fallbackLanguage));
-          if ($uses) loaders.push($translate.uses($uses));
-          $q.all(loaders).then(onLoadingEnd(), onLoadingEnd());
-        } else throw new Error('There are no loaders registered.');
-        
+        }
+
+        var loaders = [];
+        if ($fallbackLanguage) {
+          loaders.push(loadAsync($fallbackLanguage));
+        }
+        if ($uses) {
+          loaders.push($translate.uses($uses));
+        }
+        $q.all(loaders).then(onLoadingEnd(), onLoadingEnd());
+
       } else if ($translationTable.hasOwnProperty(langKey)) {
-        
-        if ($loaderFactory) {
-          $rootScope.$broadcast('$translateRefreshStart');  
-          delete $translationTable[langKey];
-          var loader = null;
-          if (langKey === $uses) loader = $translate.uses($uses);
-          else loader = loadAsync(langKey);
-          loader.then(onLoadingEnd(), onLoadingEnd());
-        } else throw new Error('There are no loaders registered.');
-        
+
+        $rootScope.$broadcast('$translateRefreshStart');
+
+        delete $translationTable[langKey];
+
+        var loader = null;
+        if (langKey === $uses) {
+          loader = $translate.uses($uses);
+        } else {
+          loader = loadAsync(langKey);
+        }
+        loader.then(onLoadingEnd(), onLoadingEnd());
+
       }
     };
     

--- a/test/unit/translateRefreshSpec.js
+++ b/test/unit/translateRefreshSpec.js
@@ -57,7 +57,7 @@ describe('pascalprecht.translate', function() {
           inject(function($translate) {
             expect(function() {
               $translate.refresh();
-            }).toThrow();
+            }).toThrow('Couldn\'t refresh translation table, no loader registered!');
           });
         });
         


### PR DESCRIPTION
Adds `invalidate()` method to $translate service.

This method provides user an ability to invalidate translation tables which are used by the module. As a result of invalidation the module will drop target tables and try to load new versions of them (if it's possible and needed).

Having such method user has much more control on what exactly the module doing. It is a first possible step to add new features like "partial" loading (#71) or custom caching (#102).
