### PR TITLE
Add a setPart() method to the $translatePartialLoader

### DIFF
--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -109,7 +109,47 @@ angular.module('pascalprecht.translate')
     if (!hasPart(name)) {
       parts[name] = new Part(name);
     }
+    parts[name].isActive = true;
     
+    return this;
+  };
+  
+  /**
+   * @ngdocs function
+   * @name pascalprecht.translate.$translatePartialLoaderProvider#setPart
+   * @methodOf pascalprecht.translate.$translatePartialLoaderProvider
+   *
+   * @description
+   * Sets a translation table to the specified part. This method does not make the specified part
+   * available, but only avoids loading this part from the server.
+   *
+   * @param {string} lang A language of the given translation table
+   * @param {string} part A name of the target part
+   * @param {object} table A translation table to set to the specified part
+   *
+   * @return {object} $translatePartialLoaderProvider, so this method is chainable
+   *
+   * @throws {TypeError} The method could throw a **TypeError** if you pass params of the wrong 
+   * type. Please, note that the `lang` and `part` params have to be a non-empty **string**s and
+   * the `table` param has to be an object.
+   */
+  this.setPart = function(lang, part, table) {
+    if (!isStringValid(lang)) {
+      throw new TypeError('Invalid type of a first argument, a non-empty string expected.');
+    }
+    if (!isStringValid(part)) {
+      throw new TypeError('Invalid type of a second argument, a non-empty string expected.');
+    }
+    if (typeof table !== 'object' || table === null) {
+      throw new TypeError('Invalid type of a third argument, an object expected.');
+    }
+    
+    if (!hasPart(part)) {
+      parts[part] = new Part(part);
+      parts[part].isActive = false;
+    }
+    
+    parts[part].tables[lang] = table;
     return this;
   };
   
@@ -134,7 +174,9 @@ angular.module('pascalprecht.translate')
       throw new TypeError('Invalid type of a first argument, a non-empty string expected.');
     }
     
-    delete parts[name];
+    if (hasPart(name)) {
+      parts[name].isActive = false;
+    }
     
     return this;
   };

--- a/test/unit/service/loader-partial.spec.js
+++ b/test/unit/service/loader-partial.spec.js
@@ -148,6 +148,132 @@ describe('pascalprecht.translate', function() {
       });
       
       
+      describe('setPart()', function() {
+      
+        it('should be defined', function() {
+          inject(function($translatePartialLoader) {
+            expect($provider.setPart).toBeDefined();
+          });
+        });
+      
+        it('should be a function', function() {
+          inject(function($translatePartialLoader) {
+            expect(typeof $provider.setPart).toBe('function');
+          });
+        });
+        
+        it('should throw an error if a first arg is not a non-empty string', function() {
+          inject(function($translatePartialLoader) {
+            var message = 'Invalid type of a first argument, a non-empty string expected.';
+            expect(function() { $provider.setPart(function(){}); }).toThrow(message);
+            expect(function() { $provider.setPart(false);        }).toThrow(message);
+            expect(function() { $provider.setPart(null);         }).toThrow(message);
+            expect(function() { $provider.setPart(NaN);          }).toThrow(message);
+            expect(function() { $provider.setPart([]);           }).toThrow(message);
+            expect(function() { $provider.setPart({});           }).toThrow(message);
+            expect(function() { $provider.setPart(2);            }).toThrow(message);
+            expect(function() { $provider.setPart();             }).toThrow(message);
+          });
+        });
+        
+        it('should throw an error if a second arg is not a non-empty string', function() {
+          inject(function($translatePartialLoader) {
+            var message = 'Invalid type of a second argument, a non-empty string expected.';
+            expect(function() { $provider.setPart('l', function(){}); }).toThrow(message);
+            expect(function() { $provider.setPart('l', false);        }).toThrow(message);
+            expect(function() { $provider.setPart('l', null);         }).toThrow(message);
+            expect(function() { $provider.setPart('l', NaN);          }).toThrow(message);
+            expect(function() { $provider.setPart('l', []);           }).toThrow(message);
+            expect(function() { $provider.setPart('l', {});           }).toThrow(message);
+            expect(function() { $provider.setPart('l', 2);            }).toThrow(message);
+            expect(function() { $provider.setPart('l');               }).toThrow(message);
+          });
+        });
+        
+        it('should throw an error if a third arg is not an object', function() {
+          inject(function($translatePartialLoader) {
+            var message = 'Invalid type of a third argument, an object expected.';
+            expect(function() { $provider.setPart('l', 'p', function(){}); }).toThrow(message);
+            expect(function() { $provider.setPart('l', 'p', false);        }).toThrow(message);
+            expect(function() { $provider.setPart('l', 'p', null);         }).toThrow(message);
+            expect(function() { $provider.setPart('l', 'p', NaN);          }).toThrow(message);
+            expect(function() { $provider.setPart('l', 'p', 's');          }).toThrow(message);
+            expect(function() { $provider.setPart('l', 'p', 2);            }).toThrow(message);
+            expect(function() { $provider.setPart('l', 'p');               }).toThrow(message);
+          });
+        });
+        
+        it('shouldn\'t broadcast any event', function() {
+          inject(function($translatePartialLoader, $rootScope) {
+            spyOn($rootScope, '$broadcast');
+            $provider.setPart('lang', 'part', { foo : 'Foo' });
+            expect($rootScope.$broadcast).not.toHaveBeenCalled();
+          });
+        });
+        
+        it('should be chainable if called with args', function() {
+          inject(function($translatePartialLoader) {
+            expect($provider.setPart('lang', 'part', {})).toEqual($provider);
+          });
+        });
+      
+        it('shouldn\'t make the setted part available', function() {
+          inject(function($translatePartialLoader) {
+            $provider.setPart('lang', 'part', { foo : 'Foo' });
+            expect($provider.isPartAvailable('part')).toEqual(false);
+          });
+        });
+        
+        it('should set a translation table for the part', function() {
+          module(function($httpProvider) {
+            $httpProvider.defaults.transformRequest.push(ThrowErrorHttpInterceptor);
+          });
+        
+          inject(function($translatePartialLoader, $rootScope) {
+            $provider.setPart('en', 'part', { foo : 'Foo' });
+            $provider.addPart('part');
+            
+            var table;
+            expect(function() {
+              $translatePartialLoader({
+                key : 'en',
+                urlTemplate : '/locales/{part}-{lang}.json'
+              }).then(function(data) {
+                table = data;
+              }, function() {
+                table = {};
+              });
+            }).not.toThrow('$http service was used!');
+            $rootScope.$digest();
+            expect(table.foo).toBeDefined();
+            expect(table.foo).toEqual('Foo');
+          });
+        });
+        
+        it('should override the previously setted translation table of the part', function() {
+          inject(function($translatePartialLoader, $rootScope) {
+            $provider.setPart('en', 'part', { foo : 'Foo' });
+            $provider.setPart('en', 'part', { foo : 'Bar' });
+            $provider.addPart('part');
+            
+            var table;
+            $translatePartialLoader({
+              key : 'en',
+              urlTemplate : '/locales/{part}-{lang}.json'
+            }).then(function(data) {
+              table = data;
+            }, function() {
+              table = {};
+            });
+            $rootScope.$digest();
+            expect(table.foo).toBeDefined();
+            expect(table.foo).toEqual('Bar');
+          });
+        });
+        
+      });
+      
+      
       describe('deletePart()', function() {
       
         it('should be defined', function() {


### PR DESCRIPTION
Adding the `setPart()` method to the $translatePartialLoader` would enable the user to set translation tables to some parts manually. The loader won't load such tables from the server, but will get the provided ones.
