### PR TITLE
feat(): add an option for post processing compiling

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -1,4 +1,5 @@
 angular.module('pascalprecht.translate')
+.value('translateCompileEnabled', false)
 /**
  * @ngdoc directive
  * @name pascalprecht.translate.directive:translate
@@ -76,7 +77,7 @@ angular.module('pascalprecht.translate')
     </file>
    </example>
  */
-.directive('translate', ['$compile', '$filter', '$interpolate', '$parse', '$rootScope', function ($compile, $filter, $interpolate, $parse, $rootScope) {
+.directive('translate', ['$compile', '$filter', '$interpolate', '$parse', '$rootScope', 'translateCompileEnabled', function ($compile, $filter, $interpolate, $parse, $rootScope, translateCompileEnabled) {
 
   var translate = $filter('translate');
 
@@ -111,7 +112,7 @@ angular.module('pascalprecht.translate')
       // w/ $translate.uses(...)
       var unbind = $rootScope.$on('$translateChangeSuccess', function () {
         element.html(translate(scope.translationId, scope.interpolateParams, scope.interpolation));
-        if (attr.translateCompile !== undefined) {
+        if (translateCompileEnabled || attr.translateCompile !== undefined) {
           $compile(element.contents())(scope);
         }
       });
@@ -121,7 +122,7 @@ angular.module('pascalprecht.translate')
       scope.$watch('[translationId, interpolateParams]', function (nValue) {
         if (scope.translationId) {
           element.html(translate(scope.translationId, scope.interpolateParams, scope.interpolation));
-          if (attr.translateCompile !== undefined) {
+          if (translateCompileEnabled || attr.translateCompile !== undefined) {
             $compile(element.contents())(scope);
           }
         }

--- a/test/unit/directive/translate.spec.js
+++ b/test/unit/directive/translate.spec.js
@@ -427,7 +427,7 @@ describe('pascalprecht.translate', function () {
     });
   });
 
-  describe('translate-compiling extension', function () {
+  describe('translate-compiling extension (disabled at default)', function () {
 
     var $rootScope, $compile;
 
@@ -466,6 +466,53 @@ describe('pascalprecht.translate', function () {
 
     it('should consider even live binding in compiled value', function () {
       element = $compile('<p translate="text" translate-compile translate-values="{name: \'The Doctor\'}"></p>')($rootScope);
+      $rootScope.$digest();
+      $rootScope.world = 'Earth';
+      $rootScope.$digest();
+      // Verify that the new value of "world" is used.
+      expect(element.text()).toEqual('The Doctor is a citizen of Earth!');
+      // unfortunately, the order of tag attributes is not deterministic in all browsers
+      //expect(element.html()).toEqual('<span class="ng-scope">The Doctor is a citizen of <strong ng-bind="world" class="ng-binding">Earth</strong>!</span>');
+      expect(element.find('strong').html()).toEqual('Earth');
+    });
+  });
+
+  describe('translate-compiling extension (enabled at default)', function () {
+
+    var $rootScope, $compile;
+
+    beforeEach(function () {
+      // Override (improve test running time)
+      angular.module('pascalprecht.translate').value('translateCompileEnabled', true);
+    });
+
+    beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide) {
+
+      $translateProvider.translations('en', {
+        'text': '<span>{{name}} is a citizen of <strong ng-bind="world"></strong>!</span>'
+      });
+
+      $translateProvider.preferredLanguage('en');
+    }));
+
+    beforeEach(inject(function (_$rootScope_, _$compile_) {
+      $rootScope = _$rootScope_;
+      $compile = _$compile_;
+      $rootScope.world = 'Gallifrey';
+    }));
+
+    it('should be enabled at default', function () {
+      element = $compile('<p translate="text" translate-values="{name: \'The Doctor\'}"></p>')($rootScope);
+      $rootScope.$digest();
+      // Verify we have additional bindings (ng-bind)
+      expect(element.text()).toEqual('The Doctor is a citizen of Gallifrey!');
+      // unfortunately, the order of tag attributes is not deterministic in all browsers
+      //expect(element.html()).toEqual('<span class="ng-scope">The Doctor is a citizen of <strong ng-bind="world" class="ng-binding">Gallifrey</strong>!</span>');
+      expect(element.find('strong').html()).toEqual('Gallifrey');
+    });
+
+    it('should consider even live binding in compiled value', function () {
+      element = $compile('<p translate="text" translate-values="{name: \'The Doctor\'}"></p>')($rootScope);
       $rootScope.$digest();
       $rootScope.world = 'Earth';
       $rootScope.$digest();


### PR DESCRIPTION
Using the optional directive attribtue `translate-compile`, the result of a translation will be recompiled.

For example:

``` json
{
  "text": "<span>{{name}} is a citizen of <strong ng-bind=\"world\"></strong>!</span>"
}
```

and

``` html
<p translate="text" translate-compile translate-values="{name: \'The Doctor\'}"></p>
```

this will result into (given a scope variable `world = 'Gallifrey'` the element text `The Doctor is a citizen of Gallifrey!` respectively in the corresponding HTML.
