### PR TITLE
feat(): Update required Node up `0.10`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.8.1"
+  - "0.10"
 
 before_install:
   - npm install -g grunt-cli karma bower


### PR DESCRIPTION
Updates the TravisCI configuration to use Node 0.10.*

Actually, Travis uses already 0.10 because it cannot find `0.8.1` (anymore).

For example: https://travis-ci.org/PascalPrecht/angular-translate/builds/12530681

```
$ nvm use 0.8.1
N/A version is not installed
v0.10.12  v0.11.3  v0.6.21  v0.8.23  v0.8.25
stable:     N/A
latest:     N/A
current:    v0.10.12
0.1 -> v0.10.12
0.10 -> v0.10.12
0.11 -> v0.11.3
0.6 -> v0.6.21
0.8 -> v0.8.25
default -> v0.10.12
$ node --version
v0.10.12
```
