### PR TITLE
Add PsuedoTranslation helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ components
 bower_components
 dist
 demo/js/angular-translate-latest.js
+
+.idea/

--- a/src/translate.js
+++ b/src/translate.js
@@ -28,3 +28,104 @@ angular.module('pascalprecht.translate', ['ng'])
     $translate.uses($translate.preferredLanguage());
   }
 }]);
+
+
+angular.module('pascalprecht.translate').constant('PsuedoTranslation', function (translation, shouldInflate) {
+    var uppercaseRegex = new RegExp("[A-Z]");
+    var lowercaseRegex = new RegExp("[a-z]");
+    var variablesRegEx = new RegExp("{{.*}}", "g")
+
+    var calcInflationRate = function (length) {
+        // Ratios provided by http://www.w3.org/International/articles/article-text-size.en
+        if (length < 10) {
+            return 2.7;
+        } else if (length < 20) {
+            return 1.9;
+        } else if (length < 30) {
+            return 1.7;
+        } else if (length < 50) {
+            return 1.6;
+        } else if (length < 70) {
+            return 1.5;
+        } else {
+            return 1.3;
+        }
+    }
+
+    var translate = function (word) {
+        var shouldTranslate = true;
+        var output = "";
+        for (var i = 0; i < word.length; i++) {
+            var letter = word[i] ? word[i] : "x";
+
+            if (lowercaseRegex.test(letter)) {
+                output += 'x'
+            } else if (uppercaseRegex.test(letter)) {
+                output += 'X'
+            } else {
+                //Keep punctuation characters
+                output += letter;
+            }
+        }
+        return output;
+    }
+
+    var inflate = function (word, length) {
+        //Don't inflate if the beginning and end of the word is a variable
+        if (word.length > 4 && word.indexOf("{{") === 0 && word.indexOf("}}") === (word.length - 2)) {
+            return word;
+        }
+
+        while (word.length < length) {
+            word += "x";
+        }
+        return word;
+    }
+
+    var psuedoString = function (input, shouldInflate) {
+        var words = input.split(" ");
+
+        var output = [];
+        //translate
+        for (var i = 0; i < words.length; i++) {
+            output[i] = translate(words[i]); //, words[i].length * inflation
+        }
+        var outputStr = output.join(" ");
+
+        //add variables back
+        var match, indexes = [];
+        while (match = variablesRegEx.exec(input)) {
+            indexes.push([match.index, match.index + match[0].length, match]);
+        }
+
+        for (var i = 0; i < indexes.length; i++) {
+            //substring before match + match + substring after match
+            outputStr = outputStr.substr(0, indexes[i][0]) + indexes[i][2] + outputStr.substr(indexes[i][1], outputStr.length);
+        }
+
+        //inflate
+        var inflation = 1;
+        if (shouldInflate) {
+            inflation = calcInflationRate(input.length);
+
+            //split words
+            words = outputStr.split(" ");
+            var inflated = [];
+            for (var i = 0; i < words.length; i++) {
+                inflated[i] = inflate(words[i], words[i].length * inflation);
+            }
+
+            outputStr = inflated.join(" ");
+        }
+
+        return outputStr;
+    }
+
+    var psuedoTranslation = {};
+    for (var key in translation) {
+        if (translation.hasOwnProperty(key)) {
+            psuedoTranslation[key] = psuedoString(translation[key], shouldInflate)
+        }
+    }
+    return psuedoTranslation;
+});

--- a/test/unit/service/psuedotranslation.spec.js
+++ b/test/unit/service/psuedotranslation.spec.js
@@ -1,0 +1,64 @@
+describe('PsuedoTranslation', function () {
+    var trans;
+
+    //excuted before each "it" is run.
+    beforeEach(function () {
+
+        //load the module.
+        module('pascalprecht.translate');
+
+        //inject your service for testing.
+        inject(function (PsuedoTranslation) {
+            trans = PsuedoTranslation;
+        });
+    });
+
+
+    it('should be a config helper function', function () {
+        expect(angular.isFunction(trans)).toBe(true);
+    });
+
+    it('should give a good error message if it is missing parameters', function () {
+        var output = trans();
+        expect(output).toEqual({})
+    });
+
+
+    it('should convert letters and keep their case but not punctuation', function () {
+        var output = trans({key1: 'Abc, def ghi'});
+        expect(output.key1).toEqual('Xxx, xxx xxx')
+    });
+
+
+    it('should not escape interpolated variables', function () {
+        var output = trans({key1: 'Abc, def {notAVariable} {{name}} qwerTy'});
+        expect(output.key1).toEqual('Xxx, xxx {xxxXXxxxxxxx} {{name}} xxxxXx')
+    });
+
+    it('should inflate values based on total length', function () {
+        var output = trans({
+            key1: 'Abc', //<10
+            key2: 'Abcdeabcde', //<20
+            key3: 'Abcdeabcde Abcdeabcde', //<30
+            key4: 'Abcdeabcde Abcdeabcde Abcdeabcde', //<50
+            key5: 'Abcdeabcde Abcdeabcde Abcdeabcde Abcdeabcde Abcdeabcde', //<70
+            key6: 'Abcdeabcde Abcdeabcde Abcdeabcde Abcdeabcde Abcdeabcde Abcdeabcde Abcdeabcde'
+        }, true);
+        expect(output.key1).toEqual('Xxxxxxxxx')
+        expect(output.key2).toEqual('Xxxxxxxxxxxxxxxxxxx');
+        expect(output.key3).toEqual('Xxxxxxxxxxxxxxxxx Xxxxxxxxxxxxxxxxx')
+        expect(output.key4).toEqual('Xxxxxxxxxxxxxxxx Xxxxxxxxxxxxxxxx Xxxxxxxxxxxxxxxx')
+        expect(output.key5).toEqual('Xxxxxxxxxxxxxxx Xxxxxxxxxxxxxxx Xxxxxxxxxxxxxxx Xxxxxxxxxxxxxxx Xxxxxxxxxxxxxxx')
+        expect(output.key6).toEqual('Xxxxxxxxxxxxx Xxxxxxxxxxxxx Xxxxxxxxxxxxx Xxxxxxxxxxxxx Xxxxxxxxxxxxx Xxxxxxxxxxxxx Xxxxxxxxxxxxx')
+    });
+
+
+    it('should inflate values but not stand alone variables', function () {
+        var output = trans({
+            key1: 'Abc {{name}} def'
+        }, true);
+        expect(output.key1).toEqual('Xxxxxx {{name}} xxxxxx')
+    });
+
+
+});


### PR DESCRIPTION
Here is the example usage of the helper:

``` js
app.config(['$translateProvider', 'PsuedoTranslation', function ($translateProvider, PsuedoTranslation) {
    // add translation tables
    $translateProvider.translations('en', translationsEN);
    $translateProvider.translations('xx', PsuedoTranslation(translationsEN, false));
    $translateProvider.translations('xl', PsuedoTranslation(translationsEN, true));
    $translateProvider.preferredLanguage('en');
}]);
```

English isn't too interesting
![image-3](https://f.cloud.github.com/assets/416063/1385559/733fddd0-3b60-11e3-9197-8768a4e3e38f.png)

Psuedo Language (without inflation, called 'xx' in sample)
![image-1](https://f.cloud.github.com/assets/416063/1385532/22929c4c-3b60-11e3-8b79-02adefb6400c.png)

Psuedo Language (with inflation, called 'xl' in sample)
![image-2](https://f.cloud.github.com/assets/416063/1385543/47019da8-3b60-11e3-92d9-1a8dbd046b21.png)

I think this can be evolved a fair bit (like change the function signature for the second parameter to be an object with various settings).
