### PR TITLE
Russian translation support: move `function` to the correct place

### DIFF
--- a/docs/content/guide/ru/02_getting-started.ngdoc
+++ b/docs/content/guide/ru/02_getting-started.ngdoc
@@ -82,7 +82,7 @@ angular-translate поставляется с провайдером `$translate
 нему доступ).
 
 <pre>
-app.config(function ['$translateProvider', ($translateProvider) {
+app.config(['$translateProvider', function ($translateProvider) {
 
 }]);
 </pre>
@@ -137,7 +137,7 @@ var translations = {
 Мы можем ее добавить при помощи `$translateProvider.translations()`:
 
 <pre>
-app.config(function ['$translateProvider', ($translateProvider) {
+app.config(['$translateProvider', function ($translateProvider) {
   // add translation table
   $translateProvider.translations(translations);
 }]);


### PR DESCRIPTION
Similar to #190
