### PR TITLE
chore(refresh): Avoid table deletion before a version is loaded

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -828,7 +828,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
                   delete $translationTable[lang];
                 }
               }
-              for (var i = 0; i < newTranslations.length; i++) {
+              for (var i = 0, len = newTranslations.length; i < len; i++) {
                 translations(newTranslations[i].key, newTranslations[i].table);
               }
               if ($uses) {


### PR DESCRIPTION
Deletes a current translation table only if it's new version is loaded successfully.

To achieve such behavior the loadAsync() and uses() were rewritten.
The loadAsync() method is now responsible only for loading a translation table.
A responsibility of handling $nextLang is moved to uses() to increase a reusability of
loadAsync() method.
