### PR TITLE
Update loader-url.js

### DIFF
--- a/src/service/loader-url.js
+++ b/src/service/loader-url.js
@@ -27,6 +27,7 @@ angular.module('pascalprecht.translate')
     $http({
       url: options.url,
       params: { lang: options.key },
+      headers: {'Accept-Language': options.key},
       method: 'GET'
     }).success(function (data) {
       deferred.resolve(data);


### PR DESCRIPTION
I would be nice to have the 'Accept-Language' header set like this when retrieving translations as many servers uses this as the users locale for the request.
