### PR TITLE
fix(loader-static-files.js): Now allows empty string as prefix and postfix

### DIFF
--- a/src/service/loader-static-files.js
+++ b/src/service/loader-static-files.js
@@ -16,7 +16,7 @@ angular.module('pascalprecht.translate')
 
   return function (options) {
 
-    if (!options || (!options.prefix || !options.suffix)) {
+    if (!options || (options.prefix === undefined || options.suffix === undefined)) {
       throw new Error('Couldn\'t load static files, no prefix or suffix specified!');
     }
 


### PR DESCRIPTION
Following up on: https://github.com/PascalPrecht/bower-angular-translate-loader-static-files/issues/1

The issue came up because I need to download the dictionary files from a URL like the following example: /i18n/en-us

This URL has a prefix '/i18n' but the postfix is an empty string. This pull request allows such URLs to be composed by the static file loader.

BTW, first time issuing a pull request on github, so my apologies if I goofed the PR and didn't correctly follow the complete protocol. 

Also let me know if I should fix the PR somehow. 

EDIT: I just realized I should have posted the PR to the canary branch. Please let me know if I have to repost it.
