### PR TITLE
fix(loader-static-files.js): Now allows empty string as prefix and postfix

### DIFF
--- a/src/service/loader-static-files.js
+++ b/src/service/loader-static-files.js
@@ -16,7 +16,7 @@ angular.module('pascalprecht.translate')
 
   return function (options) {
 
-    if (!options || (!options.prefix || !options.suffix)) {
+    if (!options || (!angular.isString(options.prefix) || !angular.isString(options.suffix))) {
       throw new Error('Couldn\'t load static files, no prefix or suffix specified!');
     }
 


### PR DESCRIPTION
Ok, following up on https://github.com/PascalPrecht/angular-translate/pull/257

Now with angular.isString()

I hope I got the PR right this time! :)
