### PR TITLE
Add predefined namespace for storing language-specific information

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -25,6 +25,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
       $loaderOptions,
       $notFoundIndicatorLeft,
       $notFoundIndicatorRight,
+      $langInfoNamespace = '___',
       NESTED_OBJECT_DELIMITER = '.';
 
   /**
@@ -444,6 +445,15 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
     return this;
   };
 
+  this.langInfoNamespace = function(namespace) {
+    if (!angular.isString(namespace)) {
+      return $langInfoNamespace;
+    } else {
+      $langInfoNamespace = namespace;
+      return this;
+    }
+  };
+
   /**
    * @ngdoc function
    * @name pascalprecht.translate.$translateProvider#useMissingTranslationHandlerLog
@@ -802,6 +812,14 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         return storageKey();
       };
 
+      $translate.getLangInfo = function(infoKey) {
+        var table = $uses ? $translationTable[$uses] : $translationTable;
+        if (table) {
+          return table[$langInfoNamespace + '.' + infoKey];
+        }
+        return undefined;
+      };
+      
       /**
        * @ngdoc function
        * @name pascalprecht.translate.$translate#refresh

--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -445,6 +445,16 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
     return this;
   };
 
+  /**
+   * @ngdoc function
+   * @name pascalprecht.translate.$translateProvider#langInfoNamespace
+   * @methodOf pascalprecht.translate.$translateProvider
+   *
+   * @description
+   * Gets or sets a name of the predefined namespace used as a storage for language-specific data
+   *
+   * @param {string} namespace A name for the predefined namespace
+   */
   this.langInfoNamespace = function(namespace) {
     if (!angular.isString(namespace)) {
       return $langInfoNamespace;
@@ -812,6 +822,16 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         return storageKey();
       };
 
+      /**
+       * @ngdoc function
+       * @name pascalprecht.translate.$translate#getLangInfo
+       * @methodOf pascalprecht.translate.$translate
+       *
+       * @description
+       * Returns an information about the current language represented by the given key.
+       *
+       * @return {string} An information about the current language
+       */
       $translate.getLangInfo = function(infoKey) {
         var table = $uses ? $translationTable[$uses] : $translationTable;
         if (table) {

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -1647,4 +1647,145 @@ describe('pascalprecht.translate', function () {
 
     });
   });
+
+
+
+
+  // getLangInfo
+  describe('provider', function () {
+
+    var $translateProvider,
+        $translate;
+
+    beforeEach(module('pascalprecht.translate', function (_$translateProvider_) {
+      $translateProvider = _$translateProvider_;
+    }));
+
+    beforeEach(inject(function (_$translate_) {
+      $translate = _$translate_;
+    }));
+
+    it('should has a langInfoNamespace() method', function () {
+      expect($translateProvider.langInfoNamespace).toBeDefined();
+      expect(typeof $translateProvider.langInfoNamespace).toBe('function');
+    });
+
+    describe('langInfoNamespace() method', function() {
+
+      it('has to return a name of predefined namespace', function () {
+        $translateProvider.langInfoNamespace('1');
+        expect($translateProvider.langInfoNamespace()).toEqual('1');
+      });
+
+      it('has to be able to change a predefined namespace', function () {
+        var prevNS = $translateProvider.langInfoNamespace();
+        $translateProvider.langInfoNamespace('-' + prevNS + '-');
+        expect($translateProvider.langInfoNamespace()).toEqual('-' + prevNS + '-');
+      });
+
+      it('has to be chainable when called with args', function () {
+        expect($translateProvider.langInfoNamespace('1')).toEqual($translateProvider);
+      });
+      
+    });
+
+  });
+
+  describe('service', function() {
+
+    beforeEach(module('pascalprecht.translate'));
+
+    it('should has a getLangInfo() method', function () {
+      inject(function ($translate) {
+        expect($translate.getLangInfo).toBeDefined();
+        expect(typeof $translate.getLangInfo).toBe('function');
+      });
+    });
+
+    describe('getLangInfo() method', function() {
+
+      describe('with one lang', function() {
+
+        beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+          $translateProvider.translations({
+            '___' : {
+              'dir' : 'ltr'
+            },
+            '___.key' : 'val'
+          });
+        }));
+
+        it ('should return a valid values for keys from object-based namespace', function() {
+          inject(function($translate) {
+            expect($translate.getLangInfo('dir')).toEqual('ltr');
+          });
+        });
+
+        it ('should return a valid values for keys from delimiter-based namespace', function() {
+          inject(function($translate) {
+            expect($translate.getLangInfo('key')).toEqual('val');
+          });
+        });
+
+        it ('should return undefined if there are no such key in the predefined ns', function() {
+          inject(function($translate) {
+            expect($translate.getLangInfo('foo')).toEqual(undefined);
+          });
+        });
+
+      });
+
+      describe('with many langs', function() {
+
+        beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+          $translateProvider.translations('foo', {
+            '___' : {
+              'dir' : 'ltr'
+            },
+            '___.isfoo' : 'yes'
+          });
+
+          $translateProvider.translations('bar', {
+            '___' : {
+              'dir' : 'rtl'
+            },
+            '___.isfoo' : 'no'
+          });
+
+          $translateProvider.uses('foo');
+        }));
+
+        it ('should return a valid values for keys from object-based namespace for the current ' +
+            'language', function() {
+          inject(function($translate) {
+            expect($translate.getLangInfo('dir')).toEqual('ltr');
+            $translate.uses('bar');
+            expect($translate.getLangInfo('dir')).toEqual('rtl');
+          });
+        });
+
+        it ('should return a valid values for keys from delimiter-based namespace for the current ' +
+            'language', function() {
+          inject(function($translate) {
+            expect($translate.getLangInfo('isfoo')).toEqual('yes');
+            $translate.uses('bar');
+            expect($translate.getLangInfo('isfoo')).toEqual('no');
+          });
+        });
+
+        it ('should return undefined if there are no such key in the predefined namespace for the ' +
+            'current language', function() {
+          inject(function($translate) {
+            expect($translate.getLangInfo('bar')).toEqual(undefined);
+            $translate.uses('bar');
+            expect($translate.getLangInfo('bar')).toEqual(undefined);
+          });
+        });
+
+      });
+
+    });
+
+  });
+
 });


### PR DESCRIPTION
Here is a little proposal which, probably, could be useful to solve #227 and to provide new features in the future.

This PR adds a functionality to provide a predefined namespace which could be used to store a language-specific information. For example, the direction of the text in the language, or it's plural rules, or something else.

The user can use the default name for this namespace or change it to his/her own if it's necessary. 

Actually, there is nothing new. The user is able to store such info in the translation table without these functions. So, this is just like a shortcut, angular-translate-way. This also can be used to let the angular-translate know which namespace is used by the user to store language-specific information. So, we, probably, can use such information in some modules.

Advantages:
* unlike extending a translations() method of the provider, this solution allows the users to add language-specific information also in the json-files loaded from the server
* this method allows us to keep translation tables as a simple hash maps without extending them to more complex structures

Example for handling ltr/rtl languages:
```js
$translateProvider.translations('foo', {
  '___' : {
    'dir' : 'ltr'
  }, ...
});
$translateProvider.translations('bar', {
  '___' : {
    'dir' : 'rtl'
  }, ...
});
// ___ is a default name for predefined language-specific namespace
// some code
var dir = $translate.getLangInfo('dir');
if (dir === 'rtl') {
  // do something
} else {
 // do something else
}
```