### PR TITLE
docs(guide/async-loading): fix typo $rootProvider->$rootScope

### DIFF
--- a/docs/content/guide/de/10_asynchronous-loading.ngdoc
+++ b/docs/content/guide/de/10_asynchronous-loading.ngdoc
@@ -225,8 +225,8 @@ Man kann außerdem den `$translatePartialLoaderStructuredChanged`- Event in
 Kombination mit `$rootScope` verwenden um den Prozess zu automatisieren.
 
 <pre>
-app.run(function ($rootProvider, $translate) {
-  $rootProvider.$on('$translatePartialLoaderStructureChanged', function () {
+app.run(function ($rootScope, $translate) {
+  $rootScope.$on('$translatePartialLoaderStructureChanged', function () {
     $translate.refresh();
   });
 });

--- a/docs/content/guide/en/10_asynchronous-loading.ngdoc
+++ b/docs/content/guide/en/10_asynchronous-loading.ngdoc
@@ -233,12 +233,12 @@ angular.module('contact')
 </pre>
 
 You can also use the `$translatePartialLoaderStructureChanged` event to automate
-the process, by listening to that event with `$rootProvider` and refreshing
+the process, by listening to that event with `$rootScope` and refreshing
 translation tables everytime it gets fired.
 
 <pre>
-app.run(function ($rootProvider, $translate) {
-  $rootProvider.$on('$translatePartialLoaderStructureChanged', function () {
+app.run(function ($rootScope, $translate) {
+  $rootScope.$on('$translatePartialLoaderStructureChanged', function () {
     $translate.refresh();
   });
 });

--- a/docs/content/guide/ru/10_asynchronous-loading.ngdoc
+++ b/docs/content/guide/ru/10_asynchronous-loading.ngdoc
@@ -212,12 +212,12 @@ angular.module('contact')
 </pre>
 
 Для автоматизации процесса вы можете использовать событие `$translatePartialLoaderStructureChanged`.
-Просто прослушивайте его при помощи `$rootProvider` и обновляйте таблицы перевода каждый раз, когда
+Просто прослушивайте его при помощи `$rootScope` и обновляйте таблицы перевода каждый раз, когда
 оно вызывается.
 
 <pre>
-app.run(function ($rootProvider, $translate) {
-  $rootProvider.$on('$translatePartialLoaderStructureChanged', function () {
+app.run(function ($rootScope, $translate) {
+  $rootScope.$on('$translatePartialLoaderStructureChanged', function () {
     $translate.refresh();
   });
 });

--- a/docs/content/guide/uk/10_asynchronous-loading.ngdoc
+++ b/docs/content/guide/uk/10_asynchronous-loading.ngdoc
@@ -212,12 +212,12 @@ angular.module('contact')
 </pre>
 
 Для автоматизації процесу ви можете використати подію `$translatePartialLoaderStructureChanged`.
-Просто прослуховуйте його з допомогою `$rootProvider` і оновлюєте таблиці перекладів кожного разу,
+Просто прослуховуйте його з допомогою `$rootScope` і оновлюєте таблиці перекладів кожного разу,
 коли воно викликається.
 
 <pre>
-app.run(function ($rootProvider, $translate) {
-  $rootProvider.$on('$translatePartialLoaderStructureChanged', function () {
+app.run(function ($rootScope, $translate) {
+  $rootScope.$on('$translatePartialLoaderStructureChanged', function () {
     $translate.refresh();
   });
 });


### PR DESCRIPTION
Fix typo in example of translations refresh on event emit
