### PR TITLE
feat(filter/select): Adds a 'select' filter

### DIFF
--- a/src/filter/select.js
+++ b/src/filter/select.js
@@ -1,0 +1,39 @@
+angular.module('pascalprecht.translate')
+/** 
+ * @ngdoc filter
+ * @name pascalprecht.translate.filter:translate
+ * 
+ * @description
+ * Filter allows to select one of the variants based on the value of some token.
+ *
+ * @param {string} A value of the token
+ * @param {object} An object which holds resulting values approproate to values of token
+ *
+ * @returns {string} Selected case
+ *
+ * @example:
+ * String
+ * "Утром {{ 'he' | select : { he : 'он проснулся', she : 'она проснулась', other : 'оно проснулось' } }} в своей постели."
+ * will become
+ * "Утром он проснулся в своей постели."
+ */
+.filter('select', [function() {
+
+  return function(value, replaceCases) {
+    
+    if (!angular.isObject(replaceCases)) {
+      return value;
+    }
+    
+    if (replaceCases.hasOwnProperty(value)) {
+      return replaceCases[value];
+    }
+    
+    if (replaceCases.other) {
+      return replaceCases.other;
+    } else {
+      return value;
+    }
+    
+  };
+}]);

--- a/test/unit/filter/select.spec.js
+++ b/test/unit/filter/select.spec.js
@@ -1,0 +1,57 @@
+describe('pascalprecht.translate', function () {
+
+  describe('$selectFilter', function () {
+
+    var $filter;
+
+    beforeEach(module('pascalprecht.translate'));
+    
+    beforeEach(inject(function (_$filter_) {
+      $filter = _$filter_;
+    }));
+
+    it('should be a function object', function () {
+      expect(typeof $filter('select')).toBe("function");
+    });
+
+    it('should return a correct case if possible', function () {
+      expect(
+        $filter('select')('he', { 
+          he : 'man',
+          she : 'woman',
+          other : 'table' }
+        )
+      ).toEqual('man');
+    });
+
+    it('should return the "other" case if no matching case is found', function () {
+      expect(
+        $filter('select')('it', {
+          he : 'man',
+          she : 'woman',
+          other : 'table' }
+        )
+      ).toEqual('table');
+    });
+    
+    it('should return a given value if no matching case is found and there is no "other" case ' +
+    'defined', function () {
+      expect(
+        $filter('select')('it', {
+          he : 'man',
+          she : 'woman' }
+        )
+      ).toEqual('it');
+    });
+    
+    it('should return a given value if non-object value given as a param', function () {
+      expect($filter('select')('he', '{he:"man",she:"woman",other:"table"}')).toEqual('he');
+    });
+    
+    it('should return a given value if second param if not specified', function () {
+      expect($filter('select')('he')).toEqual('he');
+    });
+    
+  });
+
+});


### PR DESCRIPTION
Adds a 'select' filter to angular-translate. This filter allows user to select some value
based on the value of a given token. This might be useful, for example, to pick gender or
something like that.

Example:

Dear {{ 'she' | select : {he : "Mr.", she : "Mrs.", other : "user"} }} Mary, nice to see
you again!

will become

Dear Mrs. Mary, nice to see you again!
