### PR TITLE
fixing fallback languages a bit

### DIFF
--- a/src/filter/translate.js
+++ b/src/filter/translate.js
@@ -63,6 +63,6 @@ angular.module('pascalprecht.translate')
       deferred.reject(translationId);
     });
 
-    return deferred.promise
+    return deferred.promise;
   };
 }]);

--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -796,10 +796,10 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
 
           if (angular.isArray(data)) {
             angular.forEach(data, function (table) {
-              angular.extend(translationTable, table);
+              angular.extend(translationTable, flatObject(table));
             });
           } else {
-            angular.extend(translationTable, data);
+            angular.extend(translationTable, flatObject(data));
           }
           pendingLoader = false;
           deferred.resolve({


### PR DESCRIPTION
fix fallback languages flattened
plus one fix for a missing semicolon

What is missing or discussable: How do we handle if the selected language cookie is set and it is DIFFERENT from the default language?! In this case, the translation currently won't be set if it is not also in the fallback stack. 
I think we need to iterate also over the default language...
