### PR TITLE
chore(uses): Rename uses -> use

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -165,7 +165,7 @@ angular.module('pascalprecht.translate')
         }());
 
         // Ensures the text will be refreshed after the current language was changed
-        // w/ $translate.uses(...)
+        // w/ $translate.use(...)
         var unbind = $rootScope.$on('$translateChangeSuccess', updateTranslationFn);
 
         updateTranslationFn();

--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -252,7 +252,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
    *
    * @description
    * Tells the module which of the registered translation tables to use for translation
-   * at initial startup by passing a language key. Similar to `$translateProvider#uses`
+   * at initial startup by passing a language key. Similar to `$translateProvider#use`
    * only that it says which language to **prefer**.
    *
    * @param {string} langKey A language key.
@@ -336,7 +336,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
    *
    * @description
    * Tells the module which of the registered translation tables to use when missing translations
-   * at initial startup by passing a language key. Similar to `$translateProvider#uses`
+   * at initial startup by passing a language key. Similar to `$translateProvider#use`
    * only that it says which language to **fallback**.
    *
    * @param {string||array} langKey A language key.
@@ -363,7 +363,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
 
   /**
    * @ngdoc function
-   * @name pascalprecht.translate.$translateProvider#uses
+   * @name pascalprecht.translate.$translateProvider#use
    * @methodOf pascalprecht.translate.$translateProvider
    *
    * @description
@@ -375,7 +375,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
    *
    * @param {string} langKey A language key.
    */
-  this.uses = function (langKey) {
+  this.use = function (langKey) {
     if (langKey) {
       if (!$translationTable[langKey] && (!$loaderFactory)) {
         // only throw an error, when not loading translation data asynchronously
@@ -1068,11 +1068,11 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
 
       /**
        * @ngdoc function
-       * @name pascalprecht.translate.$translate#uses
+       * @name pascalprecht.translate.$translate#use
        * @methodOf pascalprecht.translate.$translate
        *
        * @description
-       * Tells angular-translate which language to uses by given language key. This method is
+       * Tells angular-translate which language to use by given language key. This method is
        * used to change language at runtime. It also takes care of storing the language
        * key in a configured store to let your app remember the choosed language.
        *
@@ -1081,14 +1081,14 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
        *
        * Returns promise object with loaded language file data
        * @example
-       * $translate.uses("en_US").then(function(data){
+       * $translate.use("en_US").then(function(data){
        *   $scope.text = $translate("HELLO");
        * });
        *
        * @param {string} key Language key
        * @return {string} Language key
        */
-      $translate.uses = function (key) {
+      $translate.use = function (key) {
         if (!key) {
           return $uses;
         }
@@ -1229,7 +1229,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         // If at least one async loader is defined and there are no
         // (default) translations available we should try to load them.
         if (angular.equals($translationTable, {})) {
-          $translate.uses($translate.uses());
+          $translate.use($translate.use());
         }
 
         // Also, if there are any fallback language registered, we start

--- a/src/translate.js
+++ b/src/translate.js
@@ -16,15 +16,15 @@ angular.module('pascalprecht.translate', ['ng'])
     if (!storage.get(key)) {
 
       if (angular.isString($translate.preferredLanguage())) {
-        $translate.uses($translate.preferredLanguage());
+        $translate.use($translate.preferredLanguage());
       } else {
-        storage.set(key, $translate.uses());
+        storage.set(key, $translate.use());
       }
 
     } else {
-      $translate.uses(storage.get(key));
+      $translate.use(storage.get(key));
     }
   } else if (angular.isString($translate.preferredLanguage())) {
-    $translate.uses($translate.preferredLanguage());
+    $translate.use($translate.preferredLanguage());
   }
 }]);

--- a/test/unit/service/loader-partial.spec.js
+++ b/test/unit/service/loader-partial.spec.js
@@ -1024,7 +1024,7 @@ describe('pascalprecht.translate', function() {
   //           inject(function($translate, $translatePartialLoader, $httpBackend) {
   //             $translatePartialLoader.addPart('foo');
   //             expect(function() {
-  //               $translate.uses('en');
+  //               $translate.use('en');
   //               $httpBackend.flush();
   //             }).not.toThrow();
   //           });
@@ -1040,7 +1040,7 @@ describe('pascalprecht.translate', function() {
 
   //             $translatePartialLoader.addPart('foo');
   //             $translatePartialLoader.addPart('bar');
-  //             $translate.uses('en');
+  //             $translate.use('en');
   //             $httpBackend.flush();
   //           });
   //         });
@@ -1054,7 +1054,7 @@ describe('pascalprecht.translate', function() {
 
   //             $translatePartialLoader.addPart('foo');
   //             $translatePartialLoader.addPart('bar');
-  //             $translate.uses('en');
+  //             $translate.use('en');
 
   //             var deferred = $q.defer(),
   //                 promise = deferred.promise,
@@ -1081,7 +1081,7 @@ describe('pascalprecht.translate', function() {
 
   //             $translatePartialLoader.addPart('foo');
   //             $translatePartialLoader.addPart('bar');
-  //             $translate.uses('ne');
+  //             $translate.use('ne');
   //             $httpBackend.flush();
 
   //             expect(resolveHandlerCounter).toEqual(1);
@@ -1097,7 +1097,7 @@ describe('pascalprecht.translate', function() {
 
   //             $translatePartialLoader.addPart('foo');
   //             $translatePartialLoader.addPart('bar');
-  //             $translate.uses('ne');
+  //             $translate.use('ne');
   //             $httpBackend.flush();
 
   //             expect($translate('foo')).toEqual('foo');

--- a/test/unit/service/loader-url.spec.js
+++ b/test/unit/service/loader-url.spec.js
@@ -74,9 +74,9 @@ describe('pascalprecht.translate', function () {
       $httpBackend.verifyNoOutstandingRequest();
     });
 
-    it('should fetch url when invoking #uses', function () {
+    it('should fetch url when invoking #use', function () {
       $httpBackend.expectGET('foo/bar.json?lang=de_DE');
-      $translate.uses('de_DE');
+      $translate.use('de_DE');
       $httpBackend.flush();
     });
   });

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -44,8 +44,8 @@ describe('pascalprecht.translate', function () {
       expect(typeof $translate).toBe("function");
     });
 
-    it('should have a method uses()', function () {
-      expect($translate.uses).toBeDefined();
+    it('should have a method use()', function () {
+      expect($translate.use).toBeDefined();
     });
 
     it('should have a method preferredLanguage()', function () {
@@ -243,7 +243,7 @@ describe('pascalprecht.translate', function () {
     });
   });
 
-  describe('$translate#uses()', function () {
+  describe('$translate#use()', function () {
 
     beforeEach(module('pascalprecht.translate', function ($translateProvider) {
       $translateProvider
@@ -263,15 +263,15 @@ describe('pascalprecht.translate', function () {
     }));
 
     it('should be a function', function () {
-      expect(typeof $translate.uses).toBe('function');
+      expect(typeof $translate.use).toBe('function');
     });
 
     it('should return a string', function () {
-      expect(typeof $translate.uses()).toBe('string');
+      expect(typeof $translate.use()).toBe('string');
     });
 
     it('should return language key', function () {
-      expect($translate.uses()).toEqual('de_DE');
+      expect($translate.use()).toEqual('de_DE');
     });
 
     it('should change language at runtime', function () {
@@ -283,7 +283,7 @@ describe('pascalprecht.translate', function () {
         value = translation;
       });
 
-      $translate.uses('en_EN');
+      $translate.use('en_EN');
       $translate('YET_ANOTHER').then(function (translation) {
         deferred.resolve(translation);
       });


### PR DESCRIPTION
Rename `uses` method to `use` on both `$translate` and `$translateProvider`

BREAKING CHANGE: API of both $translate and $translateProvider is changed. To migrate you
have to change all `uses` method call to `use`

Before:

$translate.uses('en');
$translateProvider.uses('en');

After:

$translate.use('en');
$translateProvider.use('en');
