### PR TITLE
chore(run): Comment a logic

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -17,6 +17,8 @@ angular.module('pascalprecht.translate', ['ng'])
 
       if (angular.isString($translate.preferredLanguage())) {
         $translate.use($translate.preferredLanguage());
+        // $translate.use() will also remember the language.
+        // So, we don't need to call storage.set() here.
       } else {
         storage.set(key, $translate.use());
       }


### PR DESCRIPTION
Add a comment to show why `storage.set()` is not called after setting the language based on the preferred language
