### PR TITLE
feat(): add an option for post processing compiling

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -2,6 +2,7 @@ angular.module('pascalprecht.translate')
 /**
  * @ngdoc directive
  * @name pascalprecht.translate.directive:translate
+ * @requires $compile
  * @requires $filter
  * @requires $interpolate
  * @restrict A
@@ -75,7 +76,7 @@ angular.module('pascalprecht.translate')
     </file>
    </example>
  */
-.directive('translate', ['$translate', '$q', '$interpolate', '$parse', '$rootScope', function ($translate, $q, $interpolate, $parse, $rootScope) {
+.directive('translate', ['$translate', '$q', '$interpolate', '$compile', '$parse', '$rootScope', function ($translate, $q, $interpolate, $compile, $parse, $rootScope) {
 
   return {
     restrict: 'AE',
@@ -130,6 +131,16 @@ angular.module('pascalprecht.translate')
           }
         }
 
+        var applyElementContent = function (value, scope) {
+          iElement.html(value);
+          var globallyEnabled = $translate.isPostCompilingEnabled();
+          var locallyDefined = typeof tAttr.translateCompile !== 'undefined';
+          var locallyEnabled = locallyDefined && tAttr.translateCompile !== 'false';
+          if ((globallyEnabled && !locallyDefined) || locallyEnabled) {
+            $compile(iElement.contents())(scope);
+          }
+        };
+
         var updateTranslationFn = (function () {
           if (!translateValuesExist && !translateValueExist) {
             return function () {
@@ -137,10 +148,10 @@ angular.module('pascalprecht.translate')
                 if (scope.translationId && value) {
                   $translate(value, {}, translateInterpolation)
                     .then(function (translation) {
-                      iElement.html(translation);
+                      applyElementContent(translation, scope);
                       unwatch();
                     }, function (translationId) {
-                      iElement.html(translationId);
+                      applyElementContent(translationId, scope);
                       unwatch();
                     });
                 }
@@ -152,9 +163,9 @@ angular.module('pascalprecht.translate')
                 if (scope.translationId && value) {
                   $translate(scope.translationId, value, translateInterpolation)
                     .then(function (translation) {
-                      iElement.html(translation);
+                      applyElementContent(translation, scope);
                     }, function (translationId) {
-                      iElement.html(translationId);
+                      applyElementContent(translationId, scope);
                     });
                 }
               }, true);

--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -28,6 +28,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
       $loaderOptions,
       $notFoundIndicatorLeft,
       $notFoundIndicatorRight,
+      $postCompilingEnabled = true,
       NESTED_OBJECT_DELIMITER = '.';
 
 
@@ -548,6 +549,29 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
    */
   this.useMissingTranslationHandler = function (factory) {
     $missingTranslationHandlerFactory = factory;
+    return this;
+  };
+
+  /**
+   * @ngdoc function
+   * @name pascalprecht.translate.$translateProvider#usePostCompiling
+   * @methodOf pascalprecht.translate.$translateProvider
+   *
+   * @description
+   * If post compiling is enabled, all translated values will be processed
+   * again with AngularJS' $compile.
+   *
+   * Example:
+   * <pre>
+   *  app.config(function ($translateProvider) {
+   *    $translateProvider.usePostCompiling(true);
+   *  });
+   * </pre>
+   *
+   * @param {string} factory Factory name
+   */
+  this.usePostCompiling = function (value) {
+    $postCompilingEnabled = !(!value);
     return this;
   };
 
@@ -1260,6 +1284,20 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
        */
       $translate.storageKey = function () {
         return storageKey();
+      };
+
+      /**
+       * @ngdoc function
+       * @name pascalprecht.translate.$translate#isPostCompilingEnabled
+       * @methodOf pascalprecht.translate.$translate
+       *
+       * @description
+       * Returns whether post compiling is enabled or not
+       *
+       * @return {bool} storage key
+       */
+      $translate.isPostCompilingEnabled = function () {
+        return $postCompilingEnabled;
       };
 
       /**


### PR DESCRIPTION
Finally. :fireworks: 

Using the optional directive attribute `translate-compile`, the result of a translation will be recompiled.

For example:

``` json
{
  'text': '<span>{{name}} is a citizen of <strong ng-bind="world"></strong>!</span>'
}
```

``` html
<p translate="text" translate-compile translate-values="{name: \'The Doctor\'}"></p>
```

this will result into (given a scope variable `world = 'Gallifrey'` the element text `The Doctor is a citizen of Gallifrey!` respectively in the corresponding HTML.

Ensuring backwards compatibility, this feature is not enabled globally. This feature can be enabled via `$translateProvider.usePostCompiling(true)` and read with `$translate.isPostCompilingEnabled()`. You can also disable locally the global feature.
1. if `$translate.isPostCompilingEnabled() === false`: use `translate-compile` within a directive to enable it locally.
2. if `$translate.isPostCompilingEnabled() === true`: use `translate-compile="false"` within a directive to disable it locally.
