### PR TITLE
fix($translate): Ensuring that languages will be set based on the order they are requested

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1291,10 +1291,13 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         if (!$translationTable[key] && $loaderFactory) {
           $nextLang = key;
           langPromises[key] = loadAsync(key).then(function (translation) {
-            $nextLang = undefined;
             translations(translation.key, translation.table);
             deferred.resolve(translation.key);
-            useLanguage(translation.key);
+
+            if ($nextLang === key) {
+              useLanguage(translation.key);
+              $nextLang = undefined;
+            }
           }, function (key) {
             $nextLang = undefined;
             $rootScope.$emit('$translateChangeError');


### PR DESCRIPTION
This is a pretty small change - turns out I could use `$nextLang`, which is already available, to solve the issue.

This is a fix for #376.

I tried to make the tests match the existing style, but let me know if I should change anything.
