### PR TITLE
fix(instant): $translate.instant(id) does not return correct fallback

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1475,6 +1475,9 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
               result = determineTranslationInstant(translationId, interpolateParams, interpolationId);
             }
           }
+          if (typeof result !== 'undefined') {
+            break;
+          }
         }
 
         if (!result) {


### PR DESCRIPTION
Accidently, `$translate.instant(id)` had returned the last found fallback instead of the first found one.
