### PR TITLE
feat(instant): invoke missing handler within `$translate.instant(id)`

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1480,6 +1480,9 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         if (!result) {
           // Return translation if not found anything.
           result = translationId;
+          if ($missingTranslationHandlerFactory && !pendingLoader) {
+            $injector.get($missingTranslationHandlerFactory)(translationId, $uses);
+          }
         }
 
         return result;


### PR DESCRIPTION
Unless a translation was found, the `$missingTranslationHandlerFactory` will now be invoked (was already part of the async part)
