### PR TITLE
feat(directive): Support for camel casing interpolation variables.

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -119,7 +119,7 @@ angular.module('pascalprecht.translate')
         if (translateValueExist) {
           var fn = function (attrName) {
             iAttr.$observe(attrName, function (value) {
-              scope.interpolateParams[angular.lowercase(attrName.substr(14))] = value;
+              scope.interpolateParams[angular.lowercase(attrName.substr(14, 1)) + attrName.substr(15)] = value;
             });
           };
           for (var attr in iAttr) {

--- a/test/unit/directive/translate.spec.js
+++ b/test/unit/directive/translate.spec.js
@@ -283,7 +283,8 @@ describe('pascalprecht.translate', function () {
           'FOO': 'hello my name is {{name}}',
           'BAR': 'and I\'m {{age}} years old',
           'BAZINGA': 'hello my name is {{name}} and I\'m {{age}} years old.',
-          'YAY': 'hello my name is {{name}} and I\'m {{age}} years old. {{foo}}'
+          'YAY': 'hello my name is {{name}} and I\'m {{age}} years old. {{foo}}',
+          'CAMEL': 'hello my name is {{firstName}} {{lastName}}.'
         })
         .preferredLanguage('en');
     }));
@@ -321,6 +322,12 @@ describe('pascalprecht.translate', function () {
       element = $compile('<p translate="BAZINGA" translate-value-name="{{name}}" translate-value-age="{{age}}"></p>')($rootScope);
       $rootScope.$digest();
       expect(element.text()).toEqual('hello my name is Pascal and I\'m 22 years old.');
+    });
+
+    it('should handle interpolation variables with camel casing', function() {
+      element = $compile('<p translate="CAMEL" translate-value-first-name="Glenn" translate-value-last-name="Jorde"></p>')($rootScope);
+      $rootScope.$digest();
+      expect(element.text()).toEqual('hello my name is Glenn Jorde.');
     });
   });
 


### PR DESCRIPTION
When using a directive with interpolation variables with camel cased
words (camelCase), there was no nice way to specify the values of the
variables with the `translate-value-*` attributes.

You can specify attributes like this `translate-value-first-name="Glenn"`,
which would work together with this translation string `'Hello {{firstName}}'`.
