### PR TITLE
fix($translate): use case-insensitive check for language key aliases

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -60,12 +60,14 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
     }
 
     if ($languageKeyAliases) {
-
-      if ($languageKeyAliases[preferred]) {
-        var alias = $languageKeyAliases[preferred];
-
-        if (avail.indexOf(angular.lowercase(alias)) > -1) {
-          return alias;
+      var alias;
+      for (var langKeyAlias in $languageKeyAliases) {
+        if ($languageKeyAliases.hasOwnProperty(langKeyAlias) &&
+          angular.lowercase(langKeyAlias) === angular.lowercase(preferred)) {
+          alias = $languageKeyAliases[langKeyAlias];
+          if (avail.indexOf(angular.lowercase(alias)) > -1) {
+            return alias;
+          }
         }
       }
     }

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -1158,6 +1158,49 @@ describe('pascalprecht.translate', function () {
         });
       });
     });
+
+    describe('with locale negotiation and lower-case navigation language', function () {
+
+      beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+        $translateProvider
+          .translations('en', { FOO: 'bar' })
+          .translations('de', { FOO: 'foo' })
+          .registerAvailableLanguageKeys(['en', 'de'], {
+            'en_US': 'en',
+            'de_DE': 'de'
+          })
+          .determinePreferredLanguage(function () {
+            // mocking
+            // Work's like `window.navigator.lang = 'en_US'`
+            var nav = {
+              language: 'en_us'
+            };
+            return ((
+              nav.language ||
+                nav.browserLanguage ||
+                nav.systemLanguage ||
+                nav.userLanguage
+              ) || '').split('-').join('_');
+          });
+      }));
+
+      it('should determine browser language', function () {
+        inject(function ($translate, $q, $rootScope) {
+          var deferred = $q.defer(),
+            promise = deferred.promise,
+            value;
+
+          promise.then(function (foo) {
+            value = foo;
+          });
+          $translate('FOO').then(function (translation) {
+            deferred.resolve(translation);
+          });
+          $rootScope.$digest();
+          expect(value).toEqual('bar');
+        });
+      });
+    });
   });
 
   describe('$translate.instant', function () {


### PR DESCRIPTION
When language key aliases are available they are now compared to the browsers locale in a case-insensitive manner.

Closes Issue #431
