### PR TITLE
Don't display translationId if translation exists but is empty

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1480,7 +1480,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
           }
         }
 
-        if (!result) {
+        if (result === null) {
           // Return translation if not found anything.
           result = translationId;
           if ($missingTranslationHandlerFactory && !pendingLoader) {


### PR DESCRIPTION
Use explicit null check instead of testing for falsey value. Currently it's not possible to have translations that have an empty string as their assigned value.

The assumed functionality is that angular-translate wouldn't show anything there, but currently it displays the translationId.
