### PR TITLE
fix($translate): if translation exists, use the translated string even if it's empty

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1471,7 +1471,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         for (var i = 0, c = possibleLangKeys.length; i < c; i++) {
           var possibleLangKey = possibleLangKeys[i];
           if ($translationTable[possibleLangKey]) {
-            if ($translationTable[possibleLangKey][translationId]) {
+            if (typeof $translationTable[possibleLangKey][translationId] !== 'undefined') {
               result = determineTranslationInstant(translationId, interpolateParams, interpolationId);
             }
           }
@@ -1480,7 +1480,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
           }
         }
 
-        if (!result) {
+        if (!result && result !== '') {
           // Return translation if not found anything.
           result = translationId;
           if ($missingTranslationHandlerFactory && !pendingLoader) {

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -1188,6 +1188,10 @@ describe('pascalprecht.translate', function () {
     it('should return translation id if translation id nost exist', function () {
       expect($translate.instant('FOO2')).toEqual('FOO2');
     });
+
+    it('should return empty string if translated string is empty', function () {
+      expect($translate.instant('BLANK_VALUE')).toEqual('');
+    });
   });
 
   describe('$translate.instant (with fallback)', function () {


### PR DESCRIPTION
Before:
$translate.instant() prints out the translation key if the string is empty. It doesn't, however, print out the translationNotFoundIndicators like it would do if the translation didn't exist at all.

After:
$translate.instant() always prints out the string you have set in the translated strings object, even if the string is empty (its length == 0).
