### PR TITLE
Performance improvement by limiting calls to localStorage.getItem().

### DIFF
--- a/src/service/storage-local.js
+++ b/src/service/storage-local.js
@@ -13,36 +13,44 @@ angular.module('pascalprecht.translate')
 .factory('$translateLocalStorage', ['$window', '$translateCookieStorage', function ($window, $translateCookieStorage) {
 
   // Setup adapter
-  var localStorageAdapter = {
-    /**
-     * @ngdoc function
-     * @name pascalprecht.translate.$translateLocalStorage#get
-     * @methodOf pascalprecht.translate.$translateLocalStorage
-     *
-     * @description
-     * Returns an item from localStorage by given name.
-     *
-     * @param {string} name Item name
-     * @return {string} Value of item name
-     */
-    get: function (name) {
-      return $window.localStorage.getItem(name);
-    },
-    /**
-     * @ngdoc function
-     * @name pascalprecht.translate.$translateLocalStorage#set
-     * @methodOf pascalprecht.translate.$translateLocalStorage
-     *
-     * @description
-     * Sets an item in localStorage by given name.
-     *
-     * @param {string} name Item name
-     * @param {string} value Item value
-     */
-    set: function (name, value) {
-      $window.localStorage.setItem(name, value);
-    }
-  };
+  var localStorageAdapter = (function(){
+    var langKey;
+    return {
+      /**
+       * @ngdoc function
+       * @name pascalprecht.translate.$translateLocalStorage#get
+       * @methodOf pascalprecht.translate.$translateLocalStorage
+       *
+       * @description
+       * Returns an item from localStorage by given name.
+       *
+       * @param {string} name Item name
+       * @return {string} Value of item name
+       */
+      get: function (name) {
+        if(!langKey) {
+          langKey = $window.localStorage.getItem(name);
+        }
+
+        return langKey;
+      },
+      /**
+       * @ngdoc function
+       * @name pascalprecht.translate.$translateLocalStorage#set
+       * @methodOf pascalprecht.translate.$translateLocalStorage
+       *
+       * @description
+       * Sets an item in localStorage by given name.
+       *
+       * @param {string} name Item name
+       * @param {string} value Item value
+       */
+      set: function (name, value) {
+        langKey=value;
+        $window.localStorage.setItem(name, value);
+      }
+    };
+  }());
 
   var $translateLocalStorage = ('localStorage' in $window && $window.localStorage !== null) ?
   localStorageAdapter : $translateCookieStorage;


### PR DESCRIPTION
The `get()` method of the `$translateLocalStorage` factory is called many times, so save the language key in memory and serve it from there.

Here's a demo of how often get() is called even if there's very few strings:
http://plnkr.co/edit/nlytP5RPIeIzfJ6ZhoPU?p=preview
(Look in JavaScript console.)
