### PR TITLE
fix issue #433

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -157,16 +157,21 @@ angular.module('pascalprecht.translate')
             };
           } else {
             return function () {
-              scope.$watch('interpolateParams', function (value) {
-                if (scope.translationId && value) {
-                  $translate(scope.translationId, value, translateInterpolation)
+
+              var updateTranslations = function () {
+                if (scope.translationId && scope.interpolateParams) {
+                  $translate(scope.translationId, scope.interpolateParams, translateInterpolation)
                     .then(function (translation) {
                       applyElementContent(translation, scope);
                     }, function (translationId) {
                       applyElementContent(translationId, scope);
                     });
-                }
-              }, true);
+                  }
+              };
+
+              // watch both interpolateParams and translationId, because watchers are triggered non-deterministic
+              scope.$watch('interpolateParams', updateTranslations, true);
+              scope.$watch('translationId', updateTranslations);
             };
           }
         }());

--- a/test/unit/directive/translate.spec.js
+++ b/test/unit/directive/translate.spec.js
@@ -329,6 +329,21 @@ describe('pascalprecht.translate', function () {
       $rootScope.$digest();
       expect(element.text()).toEqual('hello my name is Glenn Jorde.');
     });
+
+    // addresses [issue #433](https://github.com/angular-translate/angular-translate/issues/433)
+    it('should interpolate variables inside ng-if directives', function () {
+      var markup = '<div ng-if="true"><p translate="FOO" translate-value-name="{{name}}"></p></div>';
+      element = $compile(markup)($rootScope);
+      $rootScope.$digest();
+      expect(element.next().text()).toEqual('hello my name is Pascal');
+    });
+
+    iit('should interpolate variables inside ng-repeat directives', function () {
+      var markup = '<div><div ng-repeat="i in [1]"><p translate="FOO" translate-value-name="{{name}}"></p></div></div>';
+      element = $compile(markup)($rootScope);
+      $rootScope.$digest();
+      expect(element.children().text()).toEqual('hello my name is Pascal');
+    });
   });
 
   describe('translate sanitization', function () {


### PR DESCRIPTION
There is a problem (addressed by issue #433) where attributes like `translation-value-name="{{name}}"` result in an empty translation when used inside of an `ng-if` directive.

This problem is caused by `$observe('translate')` and `$watch('translationProperties')` being triggered in reversed order inside of `ng-if`. Hence, the translation is never set as the element content.

This commit adds a second watcher for `translationId` to resolve this problem.
