### PR TITLE
feat(service): add possibility to translate a set of translation ids

### DIFF
--- a/docs/content/guide/de/03_using-translate-service.ngdoc
+++ b/docs/content/guide/de/03_using-translate-service.ngdoc
@@ -54,6 +54,24 @@ app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
 Das ist alles. Also, falls du darüber nachdenkst deinen `<title>` zu übersetzen,
 kannst du dies in deinem Controller machen.
 
+## Mehrere TranslationIds auf einmal
+Der Service kann auch mehrere Übersetzungen auf einmal laden.
+
+<pre>
+app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
+  $translate(['HEADLINE', 'PARAGRAPH', 'NAMESPACE.PARAGRAPH']).then(function (translations) {
+    $scope.headline = translations.HEADLINE;
+    $scope.paragraph = translations.PARAGRAPH;
+    $scope.namespaced_paragraph = translations['NAMESPACE.PARAGRAPH'];
+  });
+}]);
+</pre>
+
+Dabei muss jedoch beachtet werden, dass der Service immer ein Objekt mit allen
+Übersetzungen zurückgibt. Dabei spielt es keine Rolle, ob eine einzelne
+Übersetzung (oder sogar alle) nicht übersetzt werden konnten. Eine mögliche
+Fehlerbehandlung muss von Deiner Seite aus geschehen.
+
 ## Dinge die Beruecksichtigt werden sollten
 Bitte beachte dass `$translate` Service kein Two-Way Data-Binding unterstuetzt.
 `$translate` Service arbeitet asynchron, dass bedeteut aber nicht, dass er informiert

--- a/docs/content/guide/en/03_using-translate-service.ngdoc
+++ b/docs/content/guide/en/03_using-translate-service.ngdoc
@@ -58,6 +58,23 @@ app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
 That's all. Now when you think about translating the contents of a `<title>` you
 can do so within your controller.
 
+## Multiple translation IDs
+The translation service is also aware of requesting multiple translation at once.
+
+<pre>
+app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
+  $translate(['HEADLINE', 'PARAGRAPH', 'NAMESPACE.PARAGRAPH']).then(function (translations) {
+    $scope.headline = translations.HEADLINE;
+    $scope.paragraph = translations.PARAGRAPH;
+    $scope.namespaced_paragraph = translations['NAMESPACE.PARAGRAPH'];
+  });
+}]);
+</pre>
+
+However, the service will always return an object containing translations -- regardless whether
+a translation (or even all of them) has failed. When requesting multiple translations
+in one request, it is up to you to deal with the result.
+
 ## Things to keep in mind
 Please keep in mind that the usage of the `$translate` service doesn't provide a two-way
 data binding default! `$translate` service works asynchronously, which means

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -148,6 +148,24 @@ describe('pascalprecht.translate', function () {
       expect(value[1]).toEqual('');
     });
 
+    it('should return translations of multiple translation ids if exists', function () {
+      var deferred = $q.defer(),
+          promise = deferred.promise,
+          value;
+
+      promise.then(function (translation) {
+        value = translation;
+      });
+
+      $translate(["EXISTING_TRANSLATION_ID", "BLANK_VALUE"]).then(function (translations) {
+        deferred.resolve(translations);
+      });
+
+      $rootScope.$digest();
+      expect(value.EXISTING_TRANSLATION_ID).toEqual('foo');
+      expect(value.BLANK_VALUE).toEqual('');
+    });
+
     it('should return translation, if translation id exists with whitespace', function () {
       var deferred = $q.defer(),
           promise = deferred.promise,
@@ -1234,6 +1252,13 @@ describe('pascalprecht.translate', function () {
 
     it('should return empty string if translated string is empty', function () {
       expect($translate.instant('BLANK_VALUE')).toEqual('');
+    });
+
+   it('should return translations of multiple translation ids', function () {
+      var result = $translate.instant(['FOO', 'FOO2', 'BLANK_VALUE']);
+      expect(result.FOO).toEqual('bar');
+      expect(result.FOO2).toEqual('FOO2');
+      expect(result.BLANK_VALUE).toEqual('');
     });
   });
 


### PR DESCRIPTION
This enriches both `$translate()` and `$translate.instant()` with the
possibility to call them with an array rather than a string. This makes
the API more comfortable in some situations.

``` javascript
// for example...
$translate(['FOO', 'BAR']).then(function(translations){
  console.log(translations.FOO);
  console.log(translations.BAR);
});
// ... and
console.log($translate.instant(['FOO', 'BAR']).FOO);
console.log($translate.instant(['FOO', 'BAR']).BAR);
```

Resolves #444
