### PR TITLE
feat(missingFallbackDefaultText): enables a feature to return a default ...

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1002,7 +1002,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
           // If we have a handler factory - we might also call it here to determine if it provides
           // a default text for a translationid that can't be found anywhere in our tables
           if ($missingTranslationHandlerFactory) {
-            var resultString = $injector.get($missingTranslationHandlerFactory)(translationId, $uses, true);
+            var resultString = $injector.get($missingTranslationHandlerFactory)(translationId, $uses);
             if (resultString !== undefined) {
               deferred.resolve(resultString);
             }
@@ -1089,7 +1089,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
           // Now, if there is a registered handler for missing translations and no
           // asyncLoader is pending, we execute the handler
           if ($missingTranslationHandlerFactory && !pendingLoader) {
-            $injector.get($missingTranslationHandlerFactory)(translationId, $uses, false);
+            $injector.get($missingTranslationHandlerFactory)(translationId, $uses);
           }
 
           // since we couldn't translate the inital requested translation id,

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -466,10 +466,8 @@ describe('pascalprecht.translate', function () {
         // factory provides a default fallback text being defined in the factory
         // gives a maximum of flexibility
         $provide.factory('customTranslationHandler', function () {
-          return function (translationID, uses, fallbacks) {
-            if (fallbacks) {
+          return function (translationID, uses) {
               return 'NO KEY FOUND';
-            }
           };
         });
         $translateProvider.useMissingTranslationHandler('customTranslationHandler');


### PR DESCRIPTION
...text for displaying in case of missing translations including fallback stack

In case you have defined a missingTranslationHandlerFactory, you now have the possibility to define a return value which is set instead of the translationId.
This gives a lot of flexibility for certain use cases.
Example factory:

```
        $provide.factory('customTranslationHandler', function () {
          return function (translationID, uses, fallbacks) {
            if (fallbacks === true) {
              return 'NO KEY FOUND';
            }
          };
        });
```
