### PR TITLE
Add option to define a default translation text …

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -106,6 +106,10 @@ angular.module('pascalprecht.translate')
           }
         });
 
+        iAttr.$observe('translateDefault', function (value) {
+          scope.defaultText = value;
+        });
+
         if (translateValuesExist) {
           iAttr.$observe('translateValues', function (interpolateParams) {
             if (interpolateParams) {
@@ -129,7 +133,10 @@ angular.module('pascalprecht.translate')
           }
         }
 
-        var applyElementContent = function (value, scope) {
+        var applyElementContent = function (value, scope, successful) {
+          if (!successful && typeof scope.defaultText !== 'undefined') {
+            value = scope.defaultText;
+          }
           iElement.html(value);
           var globallyEnabled = $translate.isPostCompilingEnabled();
           var locallyDefined = typeof tAttr.translateCompile !== 'undefined';
@@ -146,10 +153,10 @@ angular.module('pascalprecht.translate')
                 if (scope.translationId && value) {
                   $translate(value, {}, translateInterpolation)
                     .then(function (translation) {
-                      applyElementContent(translation, scope);
+                      applyElementContent(translation, scope, true);
                       unwatch();
                     }, function (translationId) {
-                      applyElementContent(translationId, scope);
+                      applyElementContent(translationId, scope, false);
                       unwatch();
                     });
                 }
@@ -162,9 +169,9 @@ angular.module('pascalprecht.translate')
                 if (scope.translationId && scope.interpolateParams) {
                   $translate(scope.translationId, scope.interpolateParams, translateInterpolation)
                     .then(function (translation) {
-                      applyElementContent(translation, scope);
+                      applyElementContent(translation, scope, true);
                     }, function (translationId) {
-                      applyElementContent(translationId, scope);
+                      applyElementContent(translationId, scope, false);
                     });
                   }
               };

--- a/test/unit/directive/translate.spec.js
+++ b/test/unit/directive/translate.spec.js
@@ -35,6 +35,25 @@ describe('pascalprecht.translate', function () {
       expect(element.text()).toBe('TEXT');
     });
 
+    it('should return default text if translation doesn\'t exist', function () {
+      element = $compile('<div translate="TEXT" translate-default="Not translated"></div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.text()).toBe('Not translated');
+    });
+
+    it('should return default text if translation doesn\'t exist', function () {
+      element = $compile('<div translate translate-default="Not translated">TEXT</div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.text()).toBe('Not translated');
+    });
+
+    it('should return interpolated default text if translation doesn\'t exist', function () {
+      $rootScope.v = '123';
+      element = $compile('<div translate="TEXT" translate-default="Not translated {{v}}"></div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.text()).toBe('Not translated 123');
+    });
+
     it('should return translation if translation id exist', function () {
       element = $compile('<div translate="TRANSLATION_ID"></div>')($rootScope);
       $rootScope.$digest();


### PR DESCRIPTION
This adds an optional opt-in feature:

``` html
<span translate=„my.key.for.a.welcome.message“ translate-default=„Welcome {{username}}!“></span>
```

or even

``` html
<span translate translate-default=„Welcome {{username}}!“>my.key.for.a.welcome.message</span>
```
