### PR TITLE
function $translate.refresh() does not trigger "deferred.reject()" in case the translation part fails to load

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1457,7 +1457,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
               useLanguage($uses);
             }
             resolve();
-          });
+          }, reject);
 
         } else if ($translationTable[langKey]) {
 


### PR DESCRIPTION
then we cannot properly handle a loading failure.

This fix allows to write :

$translatePartialLoader.addPart('login');
$translate.refresh().then(function() {
  console.log('the login part has been loaded successfully');
}, function () {
  console.log('the login part faild to load');      
});