### PR TITLE
fix (filter): pass scope object to parse getter

### DIFF
--- a/src/filter/translate.js
+++ b/src/filter/translate.js
@@ -53,7 +53,7 @@ angular.module('pascalprecht.translate')
   return function (translationId, interpolateParams, interpolation) {
 
     if (!angular.isObject(interpolateParams)) {
-      interpolateParams = $parse(interpolateParams)();
+      interpolateParams = $parse(interpolateParams)(this);
     }
 
     return $translate.instant(translationId, interpolateParams, interpolation);


### PR DESCRIPTION
Pass `this` (= current scope) into parse getter. It execute expressions in scope
