### PR TITLE
feat (loaders): enable loaders cache

### DIFF
--- a/src/service/loader-static-files.js
+++ b/src/service/loader-static-files.js
@@ -12,7 +12,7 @@ angular.module('pascalprecht.translate')
  *
  * @param {object} options Options object, which gets prefix, suffix and key.
  */
-.factory('$translateStaticFilesLoader', ['$q', '$http', function ($q, $http) {
+.factory('$translateStaticFilesLoader', ['$q', '$http', '$translationCache', function ($q, $http, $translationCache) {
 
   return function (options) {
 
@@ -29,7 +29,8 @@ angular.module('pascalprecht.translate')
         options.suffix
       ].join(''),
       method: 'GET',
-      params: ''
+      params: '',
+      cache: $translationCache
     }).success(function (data) {
       deferred.resolve(data);
     }).error(function (data) {

--- a/src/service/loader-url.js
+++ b/src/service/loader-url.js
@@ -14,7 +14,7 @@ angular.module('pascalprecht.translate')
  *
  * @param {object} options Options object, which gets the url and key.
  */
-.factory('$translateUrlLoader', ['$q', '$http', function ($q, $http) {
+.factory('$translateUrlLoader', ['$q', '$http', '$translationCache', function ($q, $http, $translationCache) {
 
   return function (options) {
 
@@ -27,7 +27,8 @@ angular.module('pascalprecht.translate')
     $http({
       url: options.url,
       params: { lang: options.key },
-      method: 'GET'
+      method: 'GET',
+      cache: $translationCache
     }).success(function (data) {
       deferred.resolve(data);
     }).error(function (data) {

--- a/src/service/translationCache.js
+++ b/src/service/translationCache.js
@@ -1,0 +1,15 @@
+/**
+ * @ngdoc service
+ * @name $translationCache
+ * @requires $cacheFactory
+ *
+ * @description
+ * The first time a translation table is used, it is loaded in the translation cache for quick retrieval. You
+ * can load translation tables directly into the cache by consuming the
+ * `$translationCache` service directly.
+ *
+ * @return {object} $cacheFactory object.
+ */
+angular.module('pascalprecht.translate').factory('$translationCache', ['$cacheFactory', function ($cacheFactory) {
+    return $cacheFactory('translations');
+}]);

--- a/test/unit/service/loader-partial.spec.js
+++ b/test/unit/service/loader-partial.spec.js
@@ -598,5 +598,26 @@ describe('pascalprecht.translate', function() {
         expect(counter).toEqual(2);
       });
     });
+
+    it('should put a part into a cache and remove from the cache if the part was deleted', function() {
+      module(function($httpProvider) {
+        $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
+      });
+
+      inject(function($translatePartialLoader, $httpBackend, $translationCache) {
+        $httpBackend.whenGET('/locales/part-en.json').respond(200, '{}');
+
+        $translatePartialLoader.addPart('part');
+        $translatePartialLoader({
+          key : 'en',
+          urlTemplate : '/locales/{part}-{lang}.json'
+        });
+        $httpBackend.flush();
+        expect($translationCache.info().size).toEqual(1);
+
+        $translatePartialLoader.deletePart('part', true);
+        expect($translationCache.info().size).toEqual(0);
+      });
+    });
   });
 });

--- a/test/unit/service/loader-static-files.spec.js
+++ b/test/unit/service/loader-static-files.spec.js
@@ -6,10 +6,11 @@ describe('pascalprecht.translate', function () {
 
     beforeEach(module('pascalprecht.translate'));
 
-    beforeEach(inject(function (_$translate_, _$httpBackend_, _$translateStaticFilesLoader_) {
+    beforeEach(inject(function (_$translate_, _$httpBackend_, _$translateStaticFilesLoader_, _$translationCache_) {
       $httpBackend = _$httpBackend_;
       $translate = _$translate_;
       $translateStaticFilesLoader = _$translateStaticFilesLoader_;
+      $translationCache = _$translationCache_;
 
       $httpBackend.when('GET', 'lang_de_DE.json').respond({HEADER: 'Ueberschrift'});
       $httpBackend.when('GET', 'lang_en_US.json').respond({HEADER:'Header'});
@@ -54,6 +55,17 @@ describe('pascalprecht.translate', function () {
       expect(promise.then).toBeDefined();
       expect(typeof promise.then).toBe('function');
       $httpBackend.flush();
+    });
+
+    it('should put a translation table into a cache', function() {
+      $httpBackend.expectGET('lang_de_DE.json');
+      $translateStaticFilesLoader({
+        key: 'de_DE',
+        prefix: 'lang_',
+        suffix: '.json'
+      });
+      $httpBackend.flush();
+      expect($translationCache.info().size).toEqual(1);
     });
   });
 });

--- a/test/unit/service/loader-url.spec.js
+++ b/test/unit/service/loader-url.spec.js
@@ -6,10 +6,11 @@ describe('pascalprecht.translate', function () {
 
     beforeEach(module('pascalprecht.translate'));
 
-    beforeEach(inject(function (_$translate_, _$httpBackend_, _$translateUrlLoader_) {
+    beforeEach(inject(function (_$translate_, _$httpBackend_, _$translateUrlLoader_, _$translationCache_) {
       $translate = _$translate_;
       $httpBackend = _$httpBackend_;
       $translateUrlLoader = _$translateUrlLoader_;
+      $translationCache = _$translationCache_;
 
       $httpBackend.when('GET', 'foo/bar.json?lang=de_DE').respond({
         it: 'works'
@@ -42,6 +43,16 @@ describe('pascalprecht.translate', function () {
         url: 'foo/bar.json'
       });
       $httpBackend.flush();
+    });
+
+    it('should put a translation table into a cache', function() {
+      $httpBackend.expectGET('foo/bar.json?lang=de_DE');
+        $translateUrlLoader({
+        key: 'de_DE',
+        url: 'foo/bar.json'
+      });
+      $httpBackend.flush();
+      expect($translationCache.info().size).toEqual(1);
     });
 
     it('should return a promise', function () {


### PR DESCRIPTION
It useful if we disable cache in our project (for dynamic content), but want enable it for translation files (static content).
Also it useful if we need include translation into build file (cache in advance for production).

``` javascript
app.run(function($cacheFactory) { var cache = $cacheFactory.get('$http');
    cache.put('/compiled/module1/locals/en.json', '{"MODULE1.HELLO":"Hi!"}');
    // Other translations string added by Grunt
});
```

In conclusion, we never need uncached translations, because it is fixed content.
