### PR TITLE
feat(loaders): add jsonp support

### DIFF
--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -40,14 +40,14 @@ angular.module('pascalprecht.translate')
     return urlTemplate.replace(/\{part\}/g, this.name).replace(/\{lang\}/g, targetLang);
   };
 
-  Part.prototype.getTable = function(lang, $q, $http, urlTemplate, errorHandler) {
+  Part.prototype.getTable = function(lang, $q, $http, urlTemplate, errorHandler, method) {
     var deferred = $q.defer();
 
     if (!this.tables[lang]) {
       var self = this;
 
       $http({
-        method : 'GET',
+        method : method || 'GET',
         url : this.parseUrl(urlTemplate, lang)
       }).success(function(data){
         self.tables[lang] = data;
@@ -278,7 +278,7 @@ angular.module('pascalprecht.translate')
         if (hasPart(part) && parts[part].isActive) {
           loaders.push(
             parts[part]
-              .getTable(options.key, $q, $http, options.urlTemplate, errorHandler)
+              .getTable(options.key, $q, $http, options.urlTemplate, errorHandler, options.method)
               .then(addTablePart)
           );
         }

--- a/src/service/loader-url.js
+++ b/src/service/loader-url.js
@@ -27,7 +27,7 @@ angular.module('pascalprecht.translate')
     $http({
       url: options.url,
       params: { lang: options.key },
-      method: 'GET'
+      method: options.method || 'GET'
     }).success(function (data) {
       deferred.resolve(data);
     }).error(function (data) {

--- a/test/unit/service/loader-partial.spec.js
+++ b/test/unit/service/loader-partial.spec.js
@@ -417,6 +417,23 @@ describe('pascalprecht.translate', function() {
       });
     });
 
+    it('should parse url template downloaded using jsonp', function() {
+      inject(function($translatePartialLoader, $httpBackend) {
+        $httpBackend.expectJSONP('/locales/part-en.json?callback=JSON_CALLBACK').respond(200, 'callback({})');
+
+        $translatePartialLoader.addPart('part');
+        $translatePartialLoader({
+          key : 'en',
+          urlTemplate : '/locales/{part}-{lang}.json?callback=JSON_CALLBACK',
+          method: 'JSONP'
+        });
+
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+      });
+    });
+
     it('should parse url template with multiple pattern occurrences', function () {
       inject(function($translatePartialLoader, $httpBackend) {
         $httpBackend.expectGET('/locales/part/part-en.json').respond(200, '{}');

--- a/test/unit/service/loader-url.spec.js
+++ b/test/unit/service/loader-url.spec.js
@@ -14,6 +14,10 @@ describe('pascalprecht.translate', function () {
       $httpBackend.when('GET', 'foo/bar.json?lang=de_DE').respond({
         it: 'works'
       });
+
+      $httpBackend.when('JSONP', 'foo/bar.json?callback=JSON_CALLBACK&lang=de_DE').respond({
+        it: 'jsonp works'
+      });
     }));
 
     afterEach(function () {
@@ -43,6 +47,16 @@ describe('pascalprecht.translate', function () {
       });
       $httpBackend.flush();
     });
+
+    it('should fetch url using jsonp when invoking', function () {
+      $httpBackend.expectJSONP('foo/bar.json?callback=JSON_CALLBACK&lang=de_DE');
+      $translateUrlLoader({
+        key: 'de_DE',
+        url: 'foo/bar.json?callback=JSON_CALLBACK',
+        method: 'JSONP'
+      });
+      $httpBackend.flush();
+    });    
 
     it('should return a promise', function () {
       var promise = $translateUrlLoader({


### PR DESCRIPTION
I needed jsonp support so I did this small patch. Very easy to use. Just pass `method: 'JSONP'` as an option on `$translateUrlLoader`.

``` javascript
$translateUrlLoader({
  key: 'de_DE',
  url: 'foo/bar.json?callback=JSON_CALLBACK',
  method: 'JSONP'
 });
```

``` javascript
$translateProvider.useLoader('$translatePartialLoader', {
  urlTemplate: 'https://your-site/translation/{part}?locale={lang}&callback=JSON_CALLBACK',
  method: 'JSONP'
});
```

Works on loader-partial and loader-url. 

Cheers.
