### PR TITLE
Add version information during build task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -497,7 +497,17 @@ module.exports = function (grunt) {
         src: ['docs/content/guide/<%= language %>/*.ngdoc'],
         title: 'Guide'
       }
+    },
+
+    version: {
+        options: {
+            prefix: 'var version\\s+=\\s+[\'"]'
+        },
+        defaults: {
+            src: ['<%= concat.core.dest %>']
+        }
     }
+
   });
 
 
@@ -527,6 +537,7 @@ module.exports = function (grunt) {
   grunt.registerTask('build:core', [
     'jshint:core',
     'concat:core',
+    'version',
     'ngmin:core',
     'concat:banner_core',
     'uglify:core'

--- a/docs/content/guide/de/03_using-translate-service.ngdoc
+++ b/docs/content/guide/de/03_using-translate-service.ngdoc
@@ -72,6 +72,16 @@ Dabei muss jedoch beachtet werden, dass der Service immer ein Objekt mit allen
 Übersetzung (oder sogar alle) nicht übersetzt werden konnten. Eine mögliche
 Fehlerbehandlung muss von Deiner Seite aus geschehen.
 
+## angular-translate Versionsinformationen
+Für einige Anwendungen mag es sinnvoll sein, die eingesetzte Version im "Über uns"-Bereich o.ä. anzuzeigen.
+Damit dieses problemlos möglich ist, beinhaltet angular-translate eine Funktion, die sehr einfach verwendet werden
+kann und die aktuelle Modulversion zurückgibt:
+
+<pre>
+  $translate.versionInfo();
+  // returns e.g. "2.1.0"
+</pre>
+
 ## Dinge die berücksichtigt werden sollten
 Bitte beachte dass `$translate` Service kein Two-Way Data-Binding unterstützt.
 `$translate` Service arbeitet asynchron, dass bedeteut aber nicht, dass er informiert

--- a/docs/content/guide/en/03_using-translate-service.ngdoc
+++ b/docs/content/guide/en/03_using-translate-service.ngdoc
@@ -75,6 +75,16 @@ However, the service will always return an object containing translations -- reg
 a translation (or even all of them) has failed. When requesting multiple translations
 in one request, it is up to you to deal with the result.
 
+## angular-translate library version information
+As it may be useful for some "About" information in your application, we provide you a convenience
+function to display or use the installed library version information.
+
+Just call it this way:
+<pre>
+  $translate.versionInfo();
+  // returns e.g. "2.1.0"
+</pre>
+
 ## Things to keep in mind
 Please keep in mind that the usage of the `$translate` service doesn't provide a two-way
 data binding default! `$translate` service works asynchronously, which means

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "express": "~3.2.4",
     "grunt-contrib-clean": "~0.5.0",
     "load-grunt-tasks": "~0.2.0",
-    "grunt-ngdocs": "~0.1.11"
+    "grunt-ngdocs": "~0.1.11",
+    "grunt-version": "~0.3.0"
   }
 }

--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -32,6 +32,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
       $postCompilingEnabled = false,
       NESTED_OBJECT_DELIMITER = '.';
 
+  var version = 'x.y.z';
 
   // tries to determine the browsers locale
   var getLocale = function () {
@@ -1561,6 +1562,20 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         }
 
         return result;
+      };
+
+      /**
+       * @ngdoc function
+       * @name pascalprecht.translate.$translate#versionInfo
+       * @methodOf pascalprecht.translate.$translate
+       *
+       * @description
+       * Returns the current version information for the angular-translate library
+       *
+       * @return {string} angular-translate version
+       */
+      $translate.versionInfo = function () {
+        return version;
       };
 
       if ($loaderFactory) {


### PR DESCRIPTION
This PR adds the version string (simplest implementation) during the build phase to the dist version to be called via $translate.versionInfo() afterwards.
Provides an alternative approach to #464 - as discussed in that ticket.

See also #404.
