### PR TITLE
Instant interpolation of unkonwn

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1159,7 +1159,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         return (interpolationId) ? interpolatorHashMap[interpolationId] : defaultInterpolator;
       };
 
-      var interpolateTranslation = function (translation, interpolateParams, interpolationId) {
+      var interpolateTranslationInstant = function (translation, interpolateParams, interpolationId) {
         // If using link, rerun $translate with linked translationId and return it
         if (translation.substr(0, 2) === '@:') {
           return determineTranslationInstant(translation.substr(2), interpolateParams, interpolationId);
@@ -1176,7 +1176,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         if (table && table.hasOwnProperty(translationId)) {
           var translation = table[translationId];
 
-          result = interpolateTranslation(translation, interpolateParams, interpolationId);
+          result = interpolateTranslationInstant(translation, interpolateParams, interpolationId);
         } else {
           // looks like the requested translation id doesn't exists.
           // Now, if there is a registered handler for missing translations and no
@@ -1561,7 +1561,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
 
         if (!result && result !== '') {
           // Return interpolated translation if not found anything.
-          result = interpolateTranslation(translationId, interpolateParams, interpolationId);
+          result = interpolateTranslationInstant(translationId, interpolateParams, interpolationId);
           if ($missingTranslationHandlerFactory && !pendingLoader) {
             $injector.get($missingTranslationHandlerFactory)(translationId, $uses);
           }

--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1155,21 +1155,28 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         return deferred.promise;
       };
 
+      var Interpolator = function(interpolationId) {
+        return (interpolationId) ? interpolatorHashMap[interpolationId] : defaultInterpolator;
+      };
+
+      var interpolateTranslation = function (translation, interpolateParams, interpolationId) {
+        // If using link, rerun $translate with linked translationId and return it
+        if (translation.substr(0, 2) === '@:') {
+          return determineTranslationInstant(translation.substr(2), interpolateParams, interpolationId);
+        } else {
+          return Interpolator(interpolationId).interpolate(translation, interpolateParams);
+        }
+      };
+
       var determineTranslationInstant = function (translationId, interpolateParams, interpolationId) {
 
-        var result, table = $uses ? $translationTable[$uses] : $translationTable,
-            Interpolator = (interpolationId) ? interpolatorHashMap[interpolationId] : defaultInterpolator;
+        var result, table = $uses ? $translationTable[$uses] : $translationTable;
 
         // if the translation id exists, we can just interpolate it
         if (table && table.hasOwnProperty(translationId)) {
           var translation = table[translationId];
 
-          // If using link, rerun $translate with linked translationId and return it
-          if (translation.substr(0, 2) === '@:') {
-            result = determineTranslationInstant(translation.substr(2), interpolateParams, interpolationId);
-          } else {
-            result = Interpolator.interpolate(translation, interpolateParams);
-          }
+          result = interpolateTranslation(translation, interpolateParams, interpolationId);
         } else {
           // looks like the requested translation id doesn't exists.
           // Now, if there is a registered handler for missing translations and no
@@ -1183,7 +1190,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
           // configured.
           if ($uses && $fallbackLanguage && $fallbackLanguage.length) {
             fallbackIndex = 0;
-            result = fallbackTranslationInstant(translationId, interpolateParams, Interpolator);
+            result = fallbackTranslationInstant(translationId, interpolateParams, Interpolator(interpolationId));
           } else {
             result = applyNotFoundIndicators(translationId);
           }
@@ -1553,8 +1560,8 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         }
 
         if (!result && result !== '') {
-          // Return translation if not found anything.
-          result = translationId;
+          // Return interpolated translation if not found anything.
+          result = interpolateTranslation(translationId, interpolateParams, interpolationId);
           if ($missingTranslationHandlerFactory && !pendingLoader) {
             $injector.get($missingTranslationHandlerFactory)(translationId, $uses);
           }

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -1412,4 +1412,33 @@ describe('pascalprecht.translate', function () {
       expect($translate.instant('FOO3')).toEqual('FOO3');
     });
   });
+
+  describe('$translate.instant (with interpolation of non existing translation)', function () {
+
+    beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+      $translateProvider
+        .translations('en', translationMock)
+        .translations('en', {
+          'FOO {{foo}}': 'bar {{foo}}-{{foo}}'
+        })
+        .preferredLanguage('en');
+    }));
+
+    var $translate, $STORAGE_KEY, $q, $rootScope;
+
+    beforeEach(inject(function (_$translate_, _$STORAGE_KEY_, _$q_, _$rootScope_) {
+      $translate = _$translate_;
+      $STORAGE_KEY = _$STORAGE_KEY_;
+      $q = _$q_;
+      $rootScope = _$rootScope_;
+    }));
+
+    it('should return interpolated translation if translation id exist', function () {
+      expect($translate.instant('FOO {{foo}}', {foo: 'bar'})).toEqual('bar bar-bar');
+    });
+
+    it('should return interpolated translation if translation id does not exist', function () {
+      expect($translate.instant('BAR {{bar}}', {bar: 'foo'})).toEqual('BAR foo');
+    });
+  });
 });


### PR DESCRIPTION
If a translation id does not exists, $translate.instant() now interpolates the
translation id. This supports gettext-ish translations where the
translation id is the base translation text.

Example:

		// Configuration
		$translateProvider.translations('en', {});

		// Code
		var result = $translate.instant('Hi {{ name }}!', {name: 'John Doe'});
		// interpolated result is 'Hi John Doe!'

I refactored Interpolator() and interpolateTranslation() for DRY. Hope that is fine.