### PR TITLE
Fix: QUOTAEXCEEDEDERROR (safari private browsing)

### DIFF
--- a/src/service/storage-local.js
+++ b/src/service/storage-local.js
@@ -44,8 +44,16 @@ angular.module('pascalprecht.translate')
     }
   };
 
-  var $translateLocalStorage = ('localStorage' in $window && $window.localStorage !== null) ?
-  localStorageAdapter : $translateCookieStorage;
-
+  var hasLocalStorageSupport = 'localStorage' in $window && $window.localStorage !== null;
+  if (hasLocalStorageSupport) {
+    var testKey = 'pascalprecht.translate.storageTest';
+    try {
+      $window.localStorage.setItem(testKey, 'foo');
+      $window.localStorage.removeItem(testKey);
+    } catch (e){
+      hasLocalStorageSupport = false;
+    }
+  }
+  var $translateLocalStorage = hasLocalStorageSupport ? localStorageAdapter : $translateCookieStorage;
   return $translateLocalStorage;
 }]);


### PR DESCRIPTION
This will handle localStorage errors on Safari private browsing (desktop/iOS) and fallback to cookie storage (see issue #384)
