### PR TITLE
fixed issue #547

### DIFF
--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -94,7 +94,7 @@ angular.module('pascalprecht.translate')
       if (src[property] && src[property].constructor &&
        src[property].constructor === Object) {
         dst[property] = dst[property] || {};
-        arguments.callee(dst[property], src[property]);
+        deepExtend(dst[property], src[property]);
       } else {
         dst[property] = src[property];
       }


### PR DESCRIPTION
Since arguments.callee is deprecated in ECMA5, switched to the function's name.
Fixed issue #547
