### PR TITLE
Prevent calling then() on undefined for getTranslationTable() method.

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -953,6 +953,8 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         if ($translationTable.hasOwnProperty(langKey)) {
           deferred.resolve($translationTable[langKey]);
           return deferred.promise;
+        } else if(!langKey || !langPromises[langKey]) {
+        	deferred.reject();
         } else {
           langPromises[langKey].then(function (data) {
             translations(data.key, data.table);

--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -953,13 +953,13 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         if ($translationTable.hasOwnProperty(langKey)) {
           deferred.resolve($translationTable[langKey]);
           return deferred.promise;
-        } else if(!langKey || !langPromises[langKey]) {
-        	deferred.reject();
-        } else {
-          langPromises[langKey].then(function (data) {
+        } else if(langKey && langPromises[langKey]) {
+        	langPromises[langKey].then(function (data) {
             translations(data.key, data.table);
             deferred.resolve(data.table);
           }, deferred.reject);
+        } else {
+          deferred.reject();
         }
         return deferred.promise;
       };


### PR DESCRIPTION
`then()` is called on `undefined` when attempting to translate a non-existing key.