### PR TITLE
Expose the translations method in the service

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1201,6 +1201,8 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         return result;
       };
 
+      $translate.translations = translations;
+
       /**
        * @ngdoc function
        * @name pascalprecht.translate.$translate#preferredLanguage


### PR DESCRIPTION
Allows to use the `$translateProvider.translation()` in the `$translate` service to extend languages at runtime. see http://stackoverflow.com/questions/24326920/angular-translate-extend-existing-translations
