### PR TITLE
Adding ability to register a transformer to manipulate the static files r...

### DIFF
--- a/src/service/loader-static-files.js
+++ b/src/service/loader-static-files.js
@@ -1,41 +1,77 @@
 angular.module('pascalprecht.translate')
 /**
  * @ngdoc object
- * @name pascalprecht.translate.$translateStaticFilesLoader
- * @requires $q
- * @requires $http
+ * @name pascalprecht.translate.$translateStaticFilesLoaderProvider
  *
  * @description
- * Creates a loading function for a typical static file url pattern:
+ * By using a $translateStaticFilesLoaderProvider you can configure 
+ * a formatter which transforms the received data into a valid object 
+ * of key-value pairs. This could be used for example if your
+ * server uses Java and your translation files are .properties file.
+ * 
+ * Otherwise, if your translation server immediately exposes 
+ * valid objects of key-value pairs. You do not have anything to 
+ * configure and can use directly the $translateStaticFilesLoader 
+ * which creates a loading function for a typical static file url pattern:
  * "lang-en_US.json", "lang-de_DE.json", etc. Using this builder,
  * the response of these urls must be an object of key-value pairs.
  *
- * @param {object} options Options object, which gets prefix, suffix and key.
  */
-.factory('$translateStaticFilesLoader', ['$q', '$http', function ($q, $http) {
-
-  return function (options) {
-
-    if (!options || (!angular.isString(options.prefix) || !angular.isString(options.suffix))) {
-      throw new Error('Couldn\'t load static files, no prefix or suffix specified!');
-    }
-
-    var deferred = $q.defer();
-
-    $http({
-      url: [
-        options.prefix,
-        options.key,
-        options.suffix
-      ].join(''),
-      method: 'GET',
-      params: ''
-    }).success(function (data) {
-      deferred.resolve(data);
-    }).error(function (data) {
-      deferred.reject(options.key);
-    });
-
-    return deferred.promise;
+.provider('$translateStaticFilesLoader', function () {
+  var transformer;
+  
+  /**
+   * @ngdoc function
+   * @name pascalprecht.translate.$translateStaticFilesLoader#setTransformer
+   * @methodOf pascalprecht.translate.$translateStaticFilesLoader
+   *
+   * @description
+   * Registers a transformer used to transform the static file received from the provided url to a valid 
+   * key-value pair object.
+   *
+   * @param {function} trans a function used to transform a recovered file into a key-value pair object.
+   *
+   * @returns {void}
+   */
+  this.setTransformer = function(trans) {
+    transformer = trans;
   };
-}]);
+  
+  /**
+   * @ngdoc object
+   * @name pascalprecht.translate.$translateStaticFilesLoader
+   *
+   * @requires $q
+   * @requires $http
+   *
+   * @description
+   *
+   * @param {object} options Options object, which gets prefix, suffix and key.
+   */
+  this.$get = ['$q', '$http', function ($q, $http) {
+    return function(options) {
+      if (!options || (!angular.isString(options.prefix) || !angular.isString(options.suffix))) {
+        throw new Error('Couldn\'t load static files, no prefix or suffix specified!');
+      }
+
+      var deferred = $q.defer();
+
+      $http({
+        url: [
+          options.prefix,
+          options.key,
+          options.suffix
+        ].join(''),
+        method: 'GET',
+        params: ''
+      }).success(function (data) {
+        deferred.resolve((transformer || angular.noop)(data));
+      }).error(function (data) {
+        deferred.reject(options.key);
+      });
+
+      return deferred.promise;
+    }
+  }];
+  
+});

--- a/test/unit/service/loader-static-files.spec.js
+++ b/test/unit/service/loader-static-files.spec.js
@@ -56,4 +56,43 @@ describe('pascalprecht.translate', function () {
       $httpBackend.flush();
     });
   });
+  
+  describe('Testing to use the provider to set a formatter', function() {
+    var $httpBackend, $translateStaticFilesLoader; 
+    
+    beforeEach(module('pascalprecht.translate'));
+    
+    beforeEach(module(function($translateStaticFilesLoaderProvider) {
+      var transformer = function(data) {
+        var splitted = data.split('\n');
+        var result = {};
+        angular.forEach(splitted, function(pair) {
+          result[pair.split('=')[0]] = pair.split('=')[1];
+        });
+        return result;
+      }
+      $translateStaticFilesLoaderProvider.setTransformer(transformer);
+    }));
+    
+    beforeEach(inject(function (_$httpBackend_, _$translateStaticFilesLoader_) {
+      $httpBackend = _$httpBackend_;
+      $translateStaticFilesLoader = _$translateStaticFilesLoader_;
+      // Used for testing the formatter
+      $httpBackend.when('GET', 'lang_en_US.properties').respond('foo=bar\nfoo1=bar1');
+    }));
+
+    it('should format the data before sending them back', function() {
+       var promise = $translateStaticFilesLoader({
+          key: 'en_US',
+          prefix: 'lang_',
+          suffix: '.properties'
+        });
+        expect(promise.then).toBeDefined();
+        expect(typeof promise.then).toBe('function');
+        $httpBackend.flush();
+        promise.then(function(data) {
+          expect(data).toBe({'foo': 'bar', 'foo1': 'bar1'})
+        });
+      });
+  });
 });


### PR DESCRIPTION
...eceived and transform them into JSON object.

The $translateStaticFilesLoader has been transformed into a provider so we can now
register a specific transformer in the case where the static files loaded from the
server would not be valid JSON object. For instance, if the files are .properties
(used for Java i18n) the file could be transformed into a valid key-value pair
object which would keep the compatibility with angular-translate.

I come from a Java background and I work on Java project, consequently our i18n files are written as .properties files so I would like to be able to keep using angular-translate which explains why I would like to integrate a transformer inside the static file loader. 
