### PR TITLE
Added isPartLoaded and getRegisteredParts to $translatePartialLoader

### DIFF
--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -415,12 +415,6 @@ angular.module('pascalprecht.translate')
      * type. Please, note that the `name` and `lang` params have to be non-empty **string**.
      */
     service.isPartLoaded = function(name, lang) {
-      if (!isStringValid(name)) {
-        throw new TypeError('Couldn\'t delete part, first arg has to be string');
-      }
-      if (!isStringValid(lang)) {
-        throw new TypeError('Couldn\'t delete part, first arg has to be string');
-      }
       return angular.isDefined(parts[name]) && angular.isDefined(parts[name].tables[lang]);
     };
 

--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -404,12 +404,12 @@ angular.module('pascalprecht.translate')
      * @methodOf pascalprecht.translate.$translatePartialLoader
      *
      * @description
-     * Checks if a registered translation part is loded into the translation table.
+     * Checks if the registered translation part is loaded into the translation table.
      *
      * @param {string} name A name of the part
-     * @param {string} lang The key of the language
+     * @param {string} lang A key of the language
      *
-     * @returns {boolean} Returns **true** if the translation of the part is loaded to the translation table **false** if not.
+     * @returns {boolean} Returns **true** if the translation of the part is loaded to the translation table and **false** if not.
      *
      * @throws {TypeError} The method could throw a **TypeError** if you pass the param of the wrong
      * type. Please, note that the `name` and `lang` params have to be non-empty **string**.
@@ -430,7 +430,7 @@ angular.module('pascalprecht.translate')
      * @methodOf pascalprecht.translate.$translatePartialLoader
      *
      * @description
-     * Gets the names of the parts that were added with the `addPart`.
+     * Gets names of the parts that were added with the `addPart`.
      *
      * @returns {array} Returns array of registered parts, if none were registered then an empty array is returned.
      */

--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -400,6 +400,54 @@ angular.module('pascalprecht.translate')
 
     /**
      * @ngdoc function
+     * @name pascalprecht.translate.$translatePartialLoader#isPartLoaded
+     * @methodOf pascalprecht.translate.$translatePartialLoader
+     *
+     * @description
+     * Checks if a registered translation part is loded into the translation table.
+     *
+     * @param {string} name A name of the part
+     * @param {string} lang The key of the language
+     *
+     * @returns {boolean} Returns **true** if the translation of the part is loaded to the translation table **false** if not.
+     *
+     * @throws {TypeError} The method could throw a **TypeError** if you pass the param of the wrong
+     * type. Please, note that the `name` and `lang` params have to be non-empty **string**.
+     */
+    service.isPartLoaded = function(name, lang) {
+      if (!isStringValid(name)) {
+        throw new TypeError('Couldn\'t delete part, first arg has to be string');
+      }
+      if (!isStringValid(lang)) {
+        throw new TypeError('Couldn\'t delete part, first arg has to be string');
+      }
+      return angular.isDefined(parts[name]) && angular.isDefined(parts[name].tables[lang]);
+    };
+
+    /**
+     * @ngdoc function
+     * @name pascalprecht.translate.$translatePartialLoader#getRegisteredParts
+     * @methodOf pascalprecht.translate.$translatePartialLoader
+     *
+     * @description
+     * Gets the names of the parts that were added with the `addPart`.
+     *
+     * @returns {array} Returns array of registered parts, if none were registered then an empty array is returned.
+     */
+    service.getRegisteredParts = function() {
+      var registeredParts = [];
+      angular.forEach(parts, function(p){
+        if(p.isActive) {
+          registeredParts.push(p.name);
+        }
+      });
+      return registeredParts;
+    };
+
+
+
+    /**
+     * @ngdoc function
      * @name pascalprecht.translate.$translatePartialLoader#isPartAvailable
      * @methodOf pascalprecht.translate.$translatePartialLoader
      *


### PR DESCRIPTION
I needed these changes to write a more robust translate-cloak. The problem is $translateLoadingSuccess is fired on every part load. Therefore current implementation of translate-cloak doesn't work correctly.

So I added a couple of methods and wrote my own cloaker.