### PR TITLE
Fixes #566

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1583,6 +1583,20 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
 
         return result;
       };
+      
+      /**
+       * @ngdoc function
+       * @name pascalprecht.translate.$translate#getAvailableLanguageKeys
+       * @methodOf pascalprecht.translate.$translate
+       *
+       * @description
+       * Returns available language keys.
+       *
+       * @return {array} locales
+       */
+      $translate.getAvailableLanguageKeys = function (){
+        return Object.keys($translationTable);
+      };
 
       if ($loaderFactory) {
 


### PR DESCRIPTION
getAvailableLanguageKeys() reuses internal table management logic, in order to avoid user mistakes and redundancies.