### PR TITLE
$translate.instant is not using the return value of the missingTranslationHandlerFactory

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1577,7 +1577,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
           // Return translation if not found anything.
           result = translationId;
           if ($missingTranslationHandlerFactory && !pendingLoader) {
-            result = $injector.get($missingTranslationHandlerFactory)(translationId, $uses);
+            result = $injector.get($missingTranslationHandlerFactory)(translationId, $uses) || translationId;
           }
         }
 


### PR DESCRIPTION
$translate.instant() did not respect the return value of the missingTranslationHandlerFactory, resulting in the translate filter and $translate.instant() always returning the translationId instead of the value returned by the missingTranslationHandlerFactory
