### PR TITLE
Load a fallback language only if it is not loaded already

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1597,7 +1597,11 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         if ($fallbackLanguage && $fallbackLanguage.length) {
 
           for (var i = 0, len = $fallbackLanguage.length; i < len; i++) {
-            langPromises[$fallbackLanguage[i]] = loadAsync($fallbackLanguage[i]);
+            // Load a fallback language, only if it is not loaded already
+            //TODO: Check if this condition need to be applied in other places as well.
+            if($translationTable[$fallbackLanguage[i]]=== undefined){
+                langPromises[$fallbackLanguage[i]] = loadAsync($fallbackLanguage[i]);
+            }
           }
         }
       }


### PR DESCRIPTION
Load a fallback language only if it is not loaded already. If a lanaguage is already loaded through javaScript $translateProvider.translation(), we should not load it again.

TODO: Check if this condition need to be applied in other places as well.