### PR TITLE
fix(service): load fallback languages also for instant and filter

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -286,7 +286,7 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
       $preferredLanguage = langKey;
     }
     return $preferredLanguage;
-  }
+  };
   /**
    * @ngdoc function
    * @name pascalprecht.translate.$translateProvider#translationNotFoundIndicator
@@ -1624,9 +1624,11 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         // Also, if there are any fallback language registered, we start
         // loading them asynchronously as soon as we can.
         if ($fallbackLanguage && $fallbackLanguage.length) {
-
+          var processAsyncResult = function (translation) {
+            translations(translation.key, translation.table);
+          };
           for (var i = 0, len = $fallbackLanguage.length; i < len; i++) {
-            langPromises[$fallbackLanguage[i]] = loadAsync($fallbackLanguage[i]);
+            langPromises[$fallbackLanguage[i]] = loadAsync($fallbackLanguage[i]).then(processAsyncResult);
           }
         }
       }


### PR DESCRIPTION
This PR enables filters and instant translations to retrieve the fallback languages. Be aware, that this is in case of static loaders etc definately an async task being in the "sync" functionality - therefore it will be a kind of async for sure.
