### PR TITLE
fix(translatePartialLoader, translateStaticLoader, translateUrlLoader): ...

### DIFF
--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -22,6 +22,7 @@ angular.module('pascalprecht.translate')
     this.name = name;
     this.isActive = true;
     this.tables = {};
+    this.langPromises = {};
   }
 
   /**
@@ -41,9 +42,13 @@ angular.module('pascalprecht.translate')
   };
 
   Part.prototype.getTable = function(lang, $q, $http, urlTemplate, errorHandler) {
-    var deferred = $q.defer();
 
-    if (!this.tables[lang]) {
+    var deferred = $q.defer();
+    if (this.tables[lang]) {
+      deferred.resolve(this.tables[lang]);
+      return deferred.promise;
+
+    } else if (!this.langPromises[lang]) {
       var self = this;
 
       $http({
@@ -65,10 +70,12 @@ angular.module('pascalprecht.translate')
         }
       });
 
+      this.langPromises[lang] = deferred.promise;
+      return deferred.promise;
+
     } else {
-      deferred.resolve(this.tables[lang]);
+      return this.langPromises[lang];
     }
-    return deferred.promise;
   };
 
   var parts = {};

--- a/src/service/loader-static-files.js
+++ b/src/service/loader-static-files.js
@@ -29,7 +29,8 @@ angular.module('pascalprecht.translate')
         options.suffix
       ].join(''),
       method: 'GET',
-      params: ''
+      params: '',
+      cache: true
     }).success(function (data) {
       deferred.resolve(data);
     }).error(function (data) {

--- a/src/service/loader-url.js
+++ b/src/service/loader-url.js
@@ -27,7 +27,8 @@ angular.module('pascalprecht.translate')
     $http({
       url: options.url,
       params: { lang: options.key },
-      method: 'GET'
+      method: 'GET',
+      cache: true
     }).success(function (data) {
       deferred.resolve(data);
     }).error(function (data) {

--- a/test/unit/service/loader-partial.spec.js
+++ b/test/unit/service/loader-partial.spec.js
@@ -598,5 +598,32 @@ describe('pascalprecht.translate', function() {
         expect(counter).toEqual(2);
       });
     });
+
+    it('shouldn\'t load a part more than once', function() {
+      // This case happens when $translate.refresh is called before the file has been retrieved from the server.
+      counter = 0;
+
+      module(function($httpProvider) {
+        $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
+      });
+
+      inject(function($translatePartialLoader, $httpBackend) {
+        $httpBackend.whenGET('/locales/part-en.json').respond(200, '{}');
+
+        $translatePartialLoader.addPart('part');
+        $translatePartialLoader({
+          key : 'en',
+          urlTemplate : '/locales/{part}-{lang}.json'
+        });
+        $translatePartialLoader({
+          key : 'en',
+          urlTemplate : '/locales/{part}-{lang}.json'
+        });
+
+        $httpBackend.flush();
+
+        expect(counter).toEqual(1);
+      });
+    });
   });
 });


### PR DESCRIPTION
This fixes angular-translate/angular-translate#519. The problem with the current is it only fixes one specific issue with multiple XHR requests. Namely, what happens if you have a preferred language and fallback language.

This fix handles all of the different async loaders, so that resources are only requested once. $translatePartialLoader#deletePart can still handle deleting data.

There is also a test to demonstrate an issue with the partial loader. When the partial loader is used and multiple parts are loaded, if the previously requested parts have not loaded yet, then multiple XHR request are made for each part.
