### PR TITLE
Adding some steps in contrib on how to checkout based on canary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,12 @@ at [demo/server_routes.js](demo/server_routes.js).
 - Checkout a new branch based on <code>master</code> and name it to what you intend to do:
   - Example:
     ````
-    $ git checkout -b BRANCH_NAME
+    $ git checkout -b BRANCH_NAME origin/canary
+    ````
+    If you get error, you may need to fetch canary first by 
+    ````
+    $ git remote update
+    $ git fetch
     ````
   - Use one branch per fix/feature
 - Make your changes


### PR DESCRIPTION
I always have to rework when contributing because I forget to checkout canary. so adding a few steps in contrib guideline in case anyone else have encountered the same obstacle.
