### PR TITLE
fix(bower.json):

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "description": "A translation module for AngularJS",
   "version": "2.1.0",
   "homepage": "http://github.com/PascalPrecht/angular-translate",
+  "ignore": [],
   "repository": {
     "type": "git",
     "url": "git://github.com/PascalPrecht/angular-translate"


### PR DESCRIPTION
Avoid 'invalid-meta angular-translate is missing "ignore" entry in bower.json' when installing via bower. As suggested here: bower/bower#1388
