### PR TITLE
add method to remove fallback language

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1386,6 +1386,31 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
 
       /**
        * @ngdoc function
+       * @name pascalprecht.translate.$translate#removeFallback
+       * @methodOf pascalprecht.translate.$translate
+       *
+       * @description
+       * Tells angular-translate to forget about a specific fallback language.
+       * 
+       * It will no longer try to load translations for it.
+       *
+       * @example
+       * var oldLanguage = $translate.use();
+       * $translate.use("en_US");
+       * $translate.removeFallback(oldLanguage);
+       *
+       * @param {string} key Language key
+       */
+      $translate.removeFallback = function(langKey) {
+        var idx = $fallbackLanguage.indexOf(langKey);
+        if (idx < 0) {
+            return;
+        }
+        $fallbackLanguage.splice(idx, 1);
+      };
+
+      /**
+       * @ngdoc function
        * @name pascalprecht.translate.$translate#storageKey
        * @methodOf pascalprecht.translate.$translate
        *


### PR DESCRIPTION
I have created a custom partial loader which depends on the HTTP content negotiation headers to function.

I noticed that when I `use()` another language, whenever I call refresh(), it will still try to load translations for the old language. This method will allow you to stop that from happening.

If the method is ok with you, I will add a test for it
