### PR TITLE
fix(service): `$nextLang` should be not unset parallel loadings

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1455,12 +1455,14 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
             translations(translation.key, translation.table);
             deferred.resolve(translation.key);
 
+            useLanguage(translation.key);
             if ($nextLang === key) {
-              useLanguage(translation.key);
               $nextLang = undefined;
             }
           }, function (key) {
-            $nextLang = undefined;
+            if ($nextLang === key) {
+              $nextLang = undefined;
+            }
             $rootScope.$emit('$translateChangeError', {language: key});
             deferred.reject(key);
             $rootScope.$emit('$translateChangeEnd', {language: key});


### PR DESCRIPTION
resolves #647

All tests are fine, but I would like to have a review on that one. 

Until now: If parallel (asynchronous) loadings would be invoked (by `use()`), the prior ones` `$nextLang` has been overridden by the next ones which causes the success handler NOT invoking `useLanguage(requestedKey)` (because of condition `$nextLang == requestedKey` is not true anymore)

Now with this change: Regardless which or how many languages are currently loading, `useLanguage(requestedKey)` will be invoked on success; even when there is still a running load.

Is someone unhappy with this?  I do not see a problem right now.

/cc @angular-translate/core 
