### PR TITLE
WIP chore(*): introduce additional scopes for testing different AJS versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /node_modules/
 /components/
 /bower_components/
-/test_scopes/angular_1.3/bower_components/
+/test_scopes/angular_1.2.x/bower_components/
+/test_scopes/angular_1.3.x/bower_components/
 /dist/
 /demo/js/angular-translate-latest.js
 

--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@
 /identity/
 /src/
 /test/
+/test_scopes/
 /.bowerrc
 /.editorconfig
 /.jshintrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,8 @@ before_install:
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+
+env:
+  - TEST_SCOPE=
+  - TEST_SCOPE=angular_1.2.x
+  - TEST_SCOPE=angular_1.3.x

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,32 @@
+var fs = require('fs');
+
 module.exports = function (grunt) {
 
   require('load-grunt-tasks')(grunt);
+
+  // Returns configuration for bower-install plugin
+  var loadTestScopeConfigurations = function () {
+    var scopes = fs.readdirSync('./test_scopes').filter(function (filename) {
+      return filename[0] !== '.';
+    });
+    var config = {
+      options : {
+        color : false,
+        interactive : false
+      }
+    };
+    // Create a sub config for each test scope
+    for (var idx in scopes) {
+      var scope = scopes[idx];
+      config['test_scopes_' + scope] = {
+        options : {
+          cwd : 'test_scopes/' + scope,
+          production : false
+        }
+      };
+    }
+    return  config;
+  };
 
   grunt.initConfig({
 
@@ -507,7 +533,9 @@ module.exports = function (grunt) {
         defaults: {
             src: ['<%= concat.core.dest %>']
         }
-    }
+    },
+
+    'bower-install-simple': loadTestScopeConfigurations()
 
   });
 
@@ -516,6 +544,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('default', ['jshint:all', 'karma']);
   grunt.registerTask('test', ['karma:unit', 'karma:midway']);
+  grunt.registerTask('install-test', ['bower-install-simple']);
 
   // Advanced test tasks
   grunt.registerTask('test-headless', ['karma:headless-unit', 'karma:headless-midway']);

--- a/karma.midway.conf.js
+++ b/karma.midway.conf.js
@@ -1,6 +1,12 @@
 // Karma configuration
 
+var shared = require('./karma.util.conf.js');
+
 module.exports = function (config) {
+
+  var scope = process.env.TEST_SCOPE;
+  shared.log(scope);
+
   config.set({
 
     basePath: '',
@@ -8,10 +14,10 @@ module.exports = function (config) {
     frameworks: ['jasmine'],
 
     files: [
-      'bower_components/angular/angular.js',
-      'bower_components/ngMidwayTester/src/ngMidwayTester.js',
+      shared.injectByScope(scope, 'angular/angular.js'),
+      shared.injectByScope(scope, 'ngMidwayTester/src/ngMidwayTester.js'),
       'src/translate.js',
-      'bower_components/angular-translate-interpolation-default/angular-translate-interpolation-default.js',
+      shared.injectByScope(scope, 'angular-translate-interpolation-default/angular-translate-interpolation-default.js'),
       'src/**/*.js',
       'test/midway/**/*Spec.js'
     ],

--- a/karma.unit.conf.js
+++ b/karma.unit.conf.js
@@ -1,6 +1,12 @@
 // Karma configuration
 
+var shared = require('./karma.util.conf.js');
+
 module.exports = function (config) {
+
+  var scope = process.env.TEST_SCOPE;
+  shared.log(scope);
+
   config.set({
 
     basePath: '',
@@ -8,10 +14,10 @@ module.exports = function (config) {
     frameworks: ['jasmine'],
 
     files: [
-      'bower_components/messageformat/messageformat.js',
-      'bower_components/angular/angular.js',
-      'bower_components/angular-cookies/angular-cookies.js',
-      'bower_components/angular-mocks/angular-mocks.js',
+      shared.injectByScope(scope, 'messageformat/messageformat.js'),
+      shared.injectByScope(scope, 'angular/angular.js'),
+      shared.injectByScope(scope, 'angular-cookies/angular-cookies.js'),
+      shared.injectByScope(scope, 'angular-mocks/angular-mocks.js'),
       'src/translate.js',
       'src/**/*.js',
       'test/unit/**/*.spec.js'

--- a/karma.util.conf.js
+++ b/karma.util.conf.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var fs = require('fs');
+
+var AVAILABLE_SCOPES = [], isValidScope, injectByScope, getAffectiveScope, log;
+
+(function(undefined){
+  AVAILABLE_SCOPES = fs.readdirSync('./test_scopes').filter(function (filename) {
+    return filename[0] !== '.';
+  });
+  isValidScope = function (scope) {
+    return AVAILABLE_SCOPES.indexOf(scope) > -1;
+  };
+  getAffectiveScope = function (scope) {
+    if (isValidScope(scope)) {
+      return scope;
+    } else {
+      return '(default)';
+    }
+  };
+  injectByScope = function (scope, path) {
+    var prefix = '';
+    // unless a scope is given, use the default resources
+    if (scope && isValidScope(scope)) {
+      prefix = 'test_scopes/' + scope + '/';
+    }
+    return prefix + 'bower_components/' + path;
+  },
+  log = function (scope) {
+    console.log('Available test scopes: ', AVAILABLE_SCOPES);
+    console.log('Currently selected scope: ', getAffectiveScope(scope));
+  };
+})();
+
+module.exports = {
+  AVAILABLE_SCOPES: AVAILABLE_SCOPES,
+  isValidScope: isValidScope,
+  injectByScope: injectByScope,
+  getAffectiveScope: getAffectiveScope,
+  log: log
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "prepublish": "bower install",
     "shipit": "bower install && bower update && grunt prepare-release",
-    "test": "grunt test"
+    "test": "grunt install-test && grunt test",
+    "test-scopes": "grunt install-test && for f in test_scopes/*; do TEST_SCOPE=\"`basename $f`\" grunt test; done"
   },
   "author": {
     "name": "Pascal Precht"
@@ -21,6 +22,7 @@
     "karma": "~0.10.9",
     "grunt-karma": "~0.6.x",
     "grunt": "~0.4.1",
+    "grunt-bower-install-simple": "^1.0.3",
     "grunt-contrib-watch": "~0.4.2",
     "grunt-contrib-concat": "~0.3.x",
     "grunt-contrib-uglify": "~0.2.x",

--- a/test_scopes/angular_1.2.x/.bowerrc
+++ b/test_scopes/angular_1.2.x/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}

--- a/test_scopes/angular_1.2.x/bower.json
+++ b/test_scopes/angular_1.2.x/bower.json
@@ -1,0 +1,26 @@
+{
+  "author": "Pascal Precht",
+  "name": "angular-translate",
+  "description": "A translation module for AngularJS",
+  "version": "0.0.0",
+  "homepage": "http://github.com/angular-translate/angular-translate",
+  "ignore": [],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/angular-translate/angular-translate"
+  },
+  "devDependencies": {
+    "ngMidwayTester": "yearofmoo/ngMidwayTester",
+    "angular-translate-interpolation-messageformat": "~0.1.2",
+    "angular": "~1.2.0",
+    "angular-mocks": "~1.2.0",
+    "angular-cookies": "~1.2.0"
+  },
+  "resolutions": {
+    "angular": "~1.2.0"
+  },
+  "licenses": [{
+    "type": "MIT",
+    "url": "http://www.opensource.org/licenses/MIT"
+  }]
+}

--- a/test_scopes/angular_1.3.x/.bowerrc
+++ b/test_scopes/angular_1.3.x/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}

--- a/test_scopes/angular_1.3.x/bower.json
+++ b/test_scopes/angular_1.3.x/bower.json
@@ -1,0 +1,26 @@
+{
+  "author": "Pascal Precht",
+  "name": "angular-translate",
+  "description": "A translation module for AngularJS",
+  "version": "0.0.0",
+  "homepage": "http://github.com/angular-translate/angular-translate",
+  "ignore": [],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/angular-translate/angular-translate"
+  },
+  "devDependencies": {
+    "ngMidwayTester": "yearofmoo/ngMidwayTester",
+    "angular-translate-interpolation-messageformat": "~0.1.2",
+    "angular": "~1.3.0",
+    "angular-mocks": "~1.3.0",
+    "angular-cookies": "~1.3.0"
+  },
+  "resolutions": {
+    "angular": "~1.3.0"
+  },
+  "licenses": [{
+    "type": "MIT",
+    "url": "http://www.opensource.org/licenses/MIT"
+  }]
+}


### PR DESCRIPTION
Usage: `TEST_SCOPE=angular_1.3.x grunt test`

Run `grunt install-test` ensure all scopes' dependencies are fully available.

Travis/CI will run multiple times (defined in travis.yaml).

``` sh
TEST_SCOPE= npm test
TEST_SCOPE=angular_1.0.x npm test
TEST_SCOPE=angular_1.2.x npm test
TEST_SCOPE=angular_1.3.x npm test
```

This will fail atm because of unresolved issues in different versions.
