### PR TITLE
use default interpolator instead of return original translationId

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1666,8 +1666,8 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
         }
 
         if (!result && result !== '') {
-          // Return translation if not found anything.
-          result = translationId;
+          // Return translation of default interpolator if not found anything.
+          result = defaultInterpolator.interpolate(translationId, interpolateParams);
           if ($missingTranslationHandlerFactory && !pendingLoader) {
             result = translateByHandler(translationId);
           }

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -1639,5 +1639,9 @@ describe('pascalprecht.translate', function () {
     it('should return translation id if translation id nost exist', function () {
       expect($translate.instant('FOO3')).toEqual('FOO3');
     });
+
+    it('should return translation id with default interpolator if translation id nost exist', function () {
+      expect($translate.instant('FOO4 {{value}}', {'value': 'PARAM'})).toEqual('FOO4 PARAM');
+    });
   });
 });


### PR DESCRIPTION
if not define translationId

before:
$filter("translate")("Name: {{name}}", {name: "User"}) // "Name: {{name}}"

after:
$filter("translate")("Name: {{name}}", {name: "User"}) // "Name: User"

Add test case for @knalli asking.
I'm not sure how to refer the #716 , so I send a new pull request.
