### PR TITLE
feat(module) : use same fallback for module.run when no storage key is s...

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -12,19 +12,21 @@ angular.module('pascalprecht.translate', ['ng'])
   var key = $translate.storageKey(),
       storage = $translate.storage();
 
+  var fallbackFromIncorrectStorageValue = function() {
+    if (angular.isString($translate.preferredLanguage())) {
+      $translate.use($translate.preferredLanguage());
+      // $translate.use() will also remember the language.
+      // So, we don't need to call storage.set() here.
+    } else {
+      storage.set(key, $translate.use());
+    }
+  };
+
   if (storage) {
     if (!storage.get(key)) {
-
-      if (angular.isString($translate.preferredLanguage())) {
-        $translate.use($translate.preferredLanguage());
-        // $translate.use() will also remember the language.
-        // So, we don't need to call storage.set() here.
-      } else {
-        storage.set(key, $translate.use());
-      }
-
+      fallbackFromIncorrectStorageValue();
     } else {
-      $translate.use(storage.get(key));
+      $translate.use(storage.get(key))['catch'](fallbackFromIncorrectStorageValue);
     }
   } else if (angular.isString($translate.preferredLanguage())) {
     $translate.use($translate.preferredLanguage());

--- a/test/unit/translate.spec.js
+++ b/test/unit/translate.spec.js
@@ -1,0 +1,102 @@
+describe('pascalprecht.translate', function () {
+
+  describe('$translateModule#run', function () {
+
+    describe('with no storage', function() {
+
+      describe('and no preferred language', function() {
+
+        beforeEach(module('pascalprecht.translate'));
+
+        it('should set used locale to undefined', inject(function($translate) {
+          expect($translate.use()).toBeUndefined();
+        }));
+      });
+
+      describe('but with a preferred language', function() {
+
+        beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+          $translateProvider.preferredLanguage('en');
+        }));
+
+        it('should use preferredLanguage', inject(function($translate) {
+          expect($translate.use()).toEqual('en');
+        }));
+      });
+    });
+
+    describe('with a storage', function() {
+
+      var storage;
+      var storageMockCreator = function(storageValue) {
+        var storage = jasmine.createSpyObj('storage', ['get', 'set']);
+        storage.get.andReturn(storageValue);
+        return storage;
+      };
+
+      describe('containing value', function() {
+
+        beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide) {
+          storage = storageMockCreator('en');
+          $provide.value('storageMock', storage);
+          
+          $translateProvider
+            .useStorage('storageMock')
+            .preferredLanguage('de');
+        }));
+
+        it('should use value from storage when provided', inject(function($translate) {
+          expect(storage.get).toHaveBeenCalled(); 
+          expect($translate.use()).toEqual('en');  
+        }));
+      });
+
+      describe('but not containing any value', function() {
+
+        beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide) {
+          storage = storageMockCreator(undefined);
+          $provide.value('storageMock', storage);
+          
+          $translateProvider
+            .useStorage('storageMock')
+            .preferredLanguage('de');
+        }));
+
+        it('should fallback to preferred locale', inject(function($translate) {
+          expect(storage.get).toHaveBeenCalled(); 
+          expect($translate.use()).toEqual('de');
+        }));
+      });
+
+      describe('but with no loadable translations', function() {
+
+        beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide) {
+          storage = storageMockCreator('en');
+          $provide.value('storageMock', storage);
+          $provide.factory('loaderMock', function($q) {
+            return function(options) {
+              if(options.key === 'en') {
+                return $q.reject('en');
+              } else if(options.key === 'de')
+              return $q.when({
+                key: 'de',
+                table: {}
+              });
+            }
+          });
+          
+          $translateProvider
+            .useStorage('storageMock')
+            .useLoader('loaderMock')
+            .preferredLanguage('de');
+        }));
+
+        it('should fallback to preferred locale', inject(function($translate, $rootScope) {
+          $rootScope.$digest();
+          expect(storage.get).toHaveBeenCalled(); 
+          expect($translate.use()).toEqual('de');  
+        }));
+      });
+    });
+  });
+});


### PR DESCRIPTION
...et and not being able to load locale from storage

Closes #739

Added common fallback for case when storage does not have key set and loader is not able to load translations for key from a storage.
Added tests for this case and other cases when bootstrapping angular-translate. Since it is a module.run writing a nice unit tests is a bit hard. Unfortunately, each test case had to set up everything from scratch just to provide different configuration for loading angular-translate. All suggestions how to test it in a better way are welcomed.

Reasons for commit:
Usually developer is able to easily handle cases when translation is not loaded properly. However, that is not a case for bootstrapping of angular-translate and value set from storage.
If server for some reasons removes translation for a locale that a user still keeps in own storage, angular-translate will now fall to preferred language instead of not providing any translations at all.

More here: #739 
Patched plunker from above issue: http://plnkr.co/edit/m2Pon0aFlrsgyHg6Fsds?p=preview
