### PR TITLE
feat($translateUrlLoader): allow to use custom query parameter name for url loader

### DIFF
--- a/src/service/loader-url.js
+++ b/src/service/loader-url.js
@@ -7,12 +7,14 @@ angular.module('pascalprecht.translate')
  *
  * @description
  * Creates a loading function for a typical dynamic url pattern:
- * "locale.php?lang=en_US", "locale.php?lang=de_DE", etc. Prefixing the specified
- * url, the current requested, language id will be applied with "?lang={key}".
+ * "locale.php?lang=en_US", "locale.php?lang=de_DE", "locale.php?language=nl_NL" etc.
+ * Prefixing the specified url, the current requested, language id will be applied
+ * with "?{queryParameter}={key}".
  * Using this service, the response of these urls must be an object of
  * key-value pairs.
  *
- * @param {object} options Options object, which gets the url and key.
+ * @param {object} options Options object, which gets the url, key and
+ * optional queryParameter ('lang' is used by default).
  */
 .factory('$translateUrlLoader', ['$q', '$http', function ($q, $http) {
 
@@ -22,11 +24,14 @@ angular.module('pascalprecht.translate')
       throw new Error('Couldn\'t use urlLoader since no url is given!');
     }
 
-    var deferred = $q.defer();
+    var deferred = $q.defer(),
+        requestParams = {};
+
+    requestParams[options.queryParameter || 'lang'] = options.key;
 
     $http(angular.extend({
       url: options.url,
-      params: { lang: options.key },
+      params: requestParams,
       method: 'GET'
     }, options.$http)).success(function (data) {
       deferred.resolve(data);

--- a/test/unit/service/loader-url.spec.js
+++ b/test/unit/service/loader-url.spec.js
@@ -15,6 +15,10 @@ describe('pascalprecht.translate', function () {
       $httpBackend.when('GET', 'foo/bar.json?lang=de_DE').respond({
         it: 'works'
       });
+
+      $httpBackend.when('GET', 'foo/bar.json?language=de_DE').respond({
+        it: 'works too'
+      });
     }));
 
     afterEach(function () {
@@ -41,6 +45,16 @@ describe('pascalprecht.translate', function () {
       $translateUrlLoader({
         key: 'de_DE',
         url: 'foo/bar.json'
+      });
+      $httpBackend.flush();
+    });
+
+    it('should use custom query parameter name when invoking with queryParameter', function () {
+      $httpBackend.expectGET('foo/bar.json?language=de_DE');
+      $translateUrlLoader({
+        key: 'de_DE',
+        url: 'foo/bar.json',
+        queryParameter: 'language'
       });
       $httpBackend.flush();
     });


### PR DESCRIPTION
Make the $translateUrlLoader more flexible by allowing user to pass name of
query parameter that will be used to fetch translations.
