### PR TITLE
docs(guide/uk,ru): "Loader configuration" and "Using a cache" chapters

### DIFF
--- a/docs/content/guide/ru/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/ru/12_asynchronous-loading.ngdoc
@@ -241,6 +241,50 @@ app.run(function ($rootScope, $translate) {
 **Внимание**: Заметьте, что при использовании `partialLoader` вам нужно сперва обновить таблицы
 перевода!
 
+## Настройка загрузчика
+
+В каждый загрузчик могут быть переданы настройки. Для этого используется такой синтаксис:
+
+<pre>
+$translationProvider.useLoader('customLoader', {
+  settingA: 'foobar'
+});
+$translationProvider.useStaticFilesLoader({
+  $http: {
+    method: 'POST'
+  }
+});
+</pre>
+
+Свойство `$http` будет использовано загрузчиками при запросе, однако атрибут `cache` может быть
+переопределен (см. следующий раздел).
+
+## Использование кэша
+
+Для контроля над кэшированием в существующих загрузчиках можно использовать объект cache. Более
+подробно об этом Вы можете прочитать в
+[официальной документации AngularJS](https://docs.angularjs.org/api/ng/type/$cacheFactory.Cache).
+
+Для включения стандартного кэширования используйте следующий метод:
+
+<pre>
+$translationProvider.useLoaderCache(true); // default is false which means disable
+</pre>
+
+Если же у Вас уже есть экземпляр кэша (специально настроенный), то привяжите его так:
+
+<pre>
+$translationProvider.useLoaderCache(yourSpecialCacheService);
+</pre>
+
+Angular-Translate также поддерживает ленивое связывание. Поэтому, такой вариант тоже будет работать:
+
+<pre>
+$translationProvider.useLoaderCache('yourSpecialCacheService');
+</pre>
+
+Экземпляр под названием `yourspecialCacheService` будет найден при необходимости.
+
 ## МНПК - Мигание не переведенного контента
 
 В использовании асинхронных загрузчиков для получения переводов есть один недостаток. При запуске

--- a/docs/content/guide/uk/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/uk/12_asynchronous-loading.ngdoc
@@ -240,6 +240,50 @@ UI Router.
 **Увага**: Відмітьте, що при використанні `partialLoader` вам треба спочатку оновити таблиці
 перекладів!
 
+## Налаштування завантажувача
+
+У будь-який завантажувач можна передати налаштування. для цього використовується такий синтаксис:
+
+<pre>
+$translationProvider.useLoader('customLoader', {
+  settingA: 'foobar'
+});
+$translationProvider.useStaticFilesLoader({
+  $http: {
+    method: 'POST'
+  }
+});
+</pre>
+
+Властивість `$http` буде використана завантажувачем під час запиту, проте атрибут `cache` може бути
+перевизначений (см. следующий раздел).
+
+## Використання кеша
+
+Для контролю над кешуванням в існуючих завантажувачах можна використовувати об'єкт cache. Докладніше
+про це Ви можете прочитати в 
+[офіційній документації AngularJS](https://docs.angularjs.org/api/ng/type/$cacheFactory.Cache).
+
+Для увімкнення стандартного кешування використовується наступний метод:
+
+<pre>
+$translationProvider.useLoaderCache(true); // default is false which means disable
+</pre>
+
+Якщо ж у Вас вже є єкземпляр кеша (спеціально налаштований), то прив'яжіть його так:
+
+<pre>
+$translationProvider.useLoaderCache(yourSpecialCacheService);
+</pre>
+
+Angular-Translate також підтримує ліниве зв'язування. Тому, такий варіант також буде працювати:
+
+<pre>
+$translationProvider.useLoaderCache('yourSpecialCacheService');
+</pre>
+
+Екземпляр під назвою `yourspecialCacheService` буде знайдено при необхідності.
+
 ## МНПК - Миготіння не перекладеного контента
 
 У використання асинхронних завантажувачів для отримання перекладів є один недолік. При запуску


### PR DESCRIPTION
Chapters about loader configuration and usage of a cache are translated into Ukrainian and Russian languages.
