### PR TITLE
Hack to make translations work with angular 1.3.2+

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -99,6 +99,10 @@ angular.module('pascalprecht.translate')
         scope.preText = "";
         scope.postText = "";
 
+         // hack: if there's no translate attribute in iAttr, we grab the innerText
+         if (!iAttr.translate) {
+            iAttr.translate = iElement.text().replace(/^\s+|\s+$/g, '');
+         }
         // Ensures any change of the attribute "translate" containing the id will
         // be re-stored to the scope's "translationId".
         // If the attribute has no content, the element's text value (white spaces trimmed off) will be used.


### PR DESCRIPTION
I'm not up-to-date on the internal workings of angular-translate, but this seems to be the culprit. There's no code path that grabs the element's text if there is no translate attribute in iAttr

re #822
