### PR TITLE
docs(guide): update to keep up with the actual code

### DIFF
--- a/docs/content/guide/en/07_multi-language.ngdoc
+++ b/docs/content/guide/en/07_multi-language.ngdoc
@@ -81,6 +81,7 @@ Since version `2.0` there's also a method `determinePreferredLanguage()` on the
 language would be. It searches for values in the `window.navigator` object in the
 following properties (also in this order):
 
+- `navigator.languages[0]`
 - `navigator.language`
 - `navigator.browserLanguage`
 - `navigator.systemLanguage`


### PR DESCRIPTION
As of today, language negotiation tries to use `navigator.languages` first element, if available.
