### PR TITLE
Support for loading multiple static files

### DIFF
--- a/docs/content/guide/en/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/en/12_asynchronous-loading.ngdoc
@@ -76,13 +76,32 @@ the following information is required:
 * **suffix** - specifies file suffix
 
 Let's say you have two localization files `locale-de.json` and  `locale-en.json`.
-You can simply use the staticFilesLoader with this pattern like this:
+You can simply use the loader like this:
 
 <pre>
 $translateProvider.useStaticFilesLoader({
     prefix: 'locale-',
     suffix: '.json'
 });
+$translateProvider.preferredLanguage('en');
+</pre>
+
+Alternatively, if you have multiple translation files in distinct locations, you
+may instead supply an array of files to the loader:
+
+<pre>
+$translateProvider.useStaticFilesLoader(
+    files: [{
+        prefix: 'locale-',
+        suffix: '.json'
+    }, {
+        prefix: '/absolute/path/to/locale-',
+        suffix: '.json'
+    }, {
+        prefix: 'another/path/to/locales/',
+        suffix: ''
+    }]
+);
 $translateProvider.preferredLanguage('en');
 </pre>
 

--- a/docs/content/guide/fr/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/fr/12_asynchronous-loading.ngdoc
@@ -86,6 +86,25 @@ $translateProvider.useStaticFilesLoader({
 $translateProvider.preferredLanguage('fr');
 </pre>
 
+Alternativement, si vous avez plusieurs fichiers de traduction à des endroits
+distincts, vous pouvez plutôt fournir un tableau de fichiers au chargeur:
+
+<pre>
+$translateProvider.useStaticFilesLoader(
+    files: [{
+        prefix: 'locale-',
+        suffix: '.json'
+    }, {
+        prefix: '/absolute/path/to/locale-',
+        suffix: '.json'
+    }, {
+        prefix: 'another/path/to/locales/',
+        suffix: ''
+    }]
+);
+$translateProvider.preferredLanguage('fr');
+</pre>
+
 angular-translate concatenera l'information donnée en
 `{{prefix}}{{langKey}}{{suffix}}`. Donc, cela chargera `locale-fr.json`. Et encore une fois,
 comme il n'y a pas de données de traduction qui sont encore disponibles, il les chargera

--- a/src/service/loader-static-files.js
+++ b/src/service/loader-static-files.js
@@ -16,24 +16,66 @@ angular.module('pascalprecht.translate')
 
   return function (options) {
 
-    if (!options || (!angular.isString(options.prefix) || !angular.isString(options.suffix))) {
-      throw new Error('Couldn\'t load static files, no prefix or suffix specified!');
+    if (!options || (!angular.isArray(options.files) && (!angular.isString(options.prefix) || !angular.isString(options.suffix)))) {
+      throw new Error('Couldn\'t load static files, no files and prefix or suffix specified!');
+    }
+    
+    if (!options.files) {
+      options.files = [{
+        prefix: options.prefix,
+        suffix: options.suffix
+      }];
     }
 
-    var deferred = $q.defer();
+    var load = function (file) {
+      if (!file || (!angular.isString(file.prefix) || !angular.isString(file.suffix))) {
+        throw new Error('Couldn\'t load static file, no prefix or suffix specified!');
+      }
 
-    $http(angular.extend({
-      url: [
-        options.prefix,
-        options.key,
-        options.suffix
-      ].join(''),
-      method: 'GET',
-      params: ''
-    }, options.$http)).success(function (data) {
-      deferred.resolve(data);
-    }).error(function (data) {
-      deferred.reject(options.key);
+      var deferred = $q.defer();
+
+      $http(angular.extend({
+        url: [
+          options.prefix,
+          options.key,
+          options.suffix
+        ].join(''),
+        method: 'GET',
+        params: ''
+      }, options.$http)).success(function (data) {
+        deferred.resolve(data);
+      }).error(function (data) {
+        deferred.reject(options.key);
+      });
+
+      return deferred.promise;
+    };
+
+    var deferred = $q.defer(),
+        promises = [],
+        length = options.files.length;
+
+    for (var i = 0; i < length; i++) {
+      promises.push(load({
+        prefix: options.files[i].prefix,
+        key: options.key,
+        suffix: options.files[i].suffix
+      }));
+    }
+
+    $q.all(promises).then(function (data) {
+      var length = data.length,
+          mergedData = {};
+
+      for (var i = 0; i < length; i++) {
+        for (var key in data[i]) {
+          mergedData[key] = data[i][key];
+        }
+      }
+
+      deferred.resolve(mergedData);
+    }, function (data) {
+      deferred.reject(data);
     });
 
     return deferred.promise;

--- a/test/unit/service/loader-static-files.spec.js
+++ b/test/unit/service/loader-static-files.spec.js
@@ -30,10 +30,18 @@ describe('pascalprecht.translate', function () {
       expect(typeof $translateStaticFilesLoader).toBe('function');
     });
 
-    it('should throw an error when called without prefix or suffix', function () {
+    it('should throw an error when called without files and prefix or suffix', function () {
       expect(function () {
         $translateStaticFilesLoader();
-      }).toThrow('Couldn\'t load static files, no prefix or suffix specified!');
+      }).toThrow('Couldn\'t load static files, no files and prefix or suffix specified!');
+    });
+
+    it('should throw an error when called without prefix or suffix in files object', function () {
+      expect(function () {
+        $translateStaticFilesLoader({
+          files: [{}]
+        });
+      }).toThrow('Couldn\'t load static file, no prefix or suffix specified!');
     });
 
     it('should fetch static files when invoking', function () {
@@ -100,15 +108,26 @@ describe('pascalprecht.translate', function () {
     it('should be a function', function () {
       expect(typeof $translateStaticFilesLoader).toBe('function');
     });
-
-    it('should throw an error when called without prefix or suffix', function () {
+    
+    it('should throw an error when called without files and prefix or suffix', function () {
       expect(function () {
         $translateStaticFilesLoader({
           $http: {
             method: 'POST'
           }
         });
-      }).toThrow('Couldn\'t load static files, no prefix or suffix specified!');
+      }).toThrow('Couldn\'t load static files, no files and prefix or suffix specified!');
+    });
+
+    it('should throw an error when called without prefix or suffix in files object', function () {
+      expect(function () {
+        $translateStaticFilesLoader({
+          $http: {
+            method: 'POST'
+          },
+          files: [{}]
+        });
+      }).toThrow('Couldn\'t load static file, no prefix or suffix specified!');
     });
 
     it('should fetch static files when invoking', function () {


### PR DESCRIPTION
I added support for loading multiple files from different locations by passing a `files` key containing an array of objects.

I reused the previous code, wrapping it in a `load(file)` function. In order to remain backward compatible while keeping code simple, if only an object is passed, it is inserted into the `files` array. Then, it loops through every file and waits for all promises to resolve before merging the returned data into a single object.

Since files are requested asynchronously and then merged, duplicate keys will be overwritten in an unpredictable manner.

**Examples**

*Single file*

    $translateProvider
      .useStaticFilesLoader({
        prefix: '/path/to/locales/',
        suffix: '.json'
      });

*Multiple files*

    $translateProvider
      .useStaticFilesLoader({
        files: [{
          prefix: '/path/to/locales/',
          suffix: '.json'
        }, {
          prefix: 'relative/path/to/locales/',
          suffix: ''
        }, {
          prefix: '/another/path/to/locales/',
          suffix: '.json'
        }]
      });

Perhaps this can be improved, but the downside is that the minified script goes from 616 bytes 997 bytes, *a 60% increase*.

Questions? Comments?