### PR TITLE
docs(guide): fix typo - missing parameter '$rootScope'

### DIFF
--- a/docs/content/guide/de/03_using-translate-service.ngdoc
+++ b/docs/content/guide/de/03_using-translate-service.ngdoc
@@ -95,7 +95,7 @@ wird.
 So würde das aussehen:
 
 <pre>
-app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate, $rootScope) {
+app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, $translate, $rootScope) {
   $rootScope.$on('$translateChangeSuccess', function () {
     $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;

--- a/docs/content/guide/en/03_using-translate-service.ngdoc
+++ b/docs/content/guide/en/03_using-translate-service.ngdoc
@@ -102,7 +102,7 @@ Once it's changed, you can simply re-execute the code, that gives you your neede
 Here's how it could look like:
 
 <pre>
-app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate, $rootScope) {
+app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, $translate, $rootScope) {
   $rootScope.$on('$translateChangeSuccess', function () {
     $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;

--- a/docs/content/guide/fr/03_using-translate-service.ngdoc
+++ b/docs/content/guide/fr/03_using-translate-service.ngdoc
@@ -101,7 +101,7 @@ Une fois qu'elle a changé, il vous suffit de ré-exécuter le code, qui vous do
 Voilà à quoi cela pourrait ressembler :
 
 <pre>
-app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate, $rootScope) {
+app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, $translate, $rootScope) {
   $rootScope.$on('$translateChangeSuccess', function () {
     $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;

--- a/docs/content/guide/ru/03_using-translate-service.ngdoc
+++ b/docs/content/guide/ru/03_using-translate-service.ngdoc
@@ -98,7 +98,7 @@ app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
 Вот как это выглядит:
 
 <pre>
-app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate, $rootScope) {
+app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, $translate, $rootScope) {
   $rootScope.$on('$translateChangeSuccess', function () {
     $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;

--- a/docs/content/guide/uk/03_using-translate-service.ngdoc
+++ b/docs/content/guide/uk/03_using-translate-service.ngdoc
@@ -99,7 +99,7 @@ app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
 Ось як це виглядає:
 
 <pre>
-app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate, $rootScope) {
+app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, $translate, $rootScope) {
   $rootScope.$on('$translateChangeSuccess', function () {
     $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;

--- a/docs/content/guide/zh-cn/03_using-translate-service.ngdoc
+++ b/docs/content/guide/zh-cn/03_using-translate-service.ngdoc
@@ -83,7 +83,7 @@ Just call it this way:
 下面是它的代码:
 
 <pre>
-app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate, $rootScope) {
+app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, $translate, $rootScope) {
   $rooScope.$on('$translateChangeSuccess', function () {
     $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;

--- a/docs/content/guide/zh-tw/03_using-translate-service.ngdoc
+++ b/docs/content/guide/zh-tw/03_using-translate-service.ngdoc
@@ -83,7 +83,7 @@ Just call it this way:
 下面是它的代碼:
 
 <pre>
-app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate, $rootScope) {
+app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, $translate, $rootScope) {
 $rooScope.$on('$translateChangeSuccess', function () {
 $translate('HEADLINE').then(function (translation) {
 $scope.headline = translation;


### PR DESCRIPTION
Add missing parameter '$rootScope' in examples