### PR TITLE
Fix default interpolation of {{ value + value }} with "escaped" sanitize value strategy

### DIFF
--- a/src/service/default-interpolation.js
+++ b/src/service/default-interpolation.js
@@ -20,7 +20,7 @@ angular.module('pascalprecht.translate').factory('$translateDefaultInterpolation
           var result = {};
           for (var key in params) {
             if (Object.prototype.hasOwnProperty.call(params, key)) {
-              result[key] = angular.element('<div></div>').text(params[key]).html();
+              result[key] = (angular.isNumber(params[key]))? params[key] : angular.element('<div></div>').text(params[key]).html();
             }
           }
           return result;

--- a/test/unit/service/default-interpolation.spec.js
+++ b/test/unit/service/default-interpolation.spec.js
@@ -65,11 +65,28 @@ describe('pascalprecht.translate', function () {
     });
 
     it('should replace interpolateParams with concrete values', function () {
-      expect($translateDefaultInterpolation.interpolate('Foo bar {{value}}', { value: 5 })).toEqual('Foo bar 5');
+      expect($translateDefaultInterpolation.interpolate('Foo bar {{value}}', {value: 5})).toEqual('Foo bar 5');
     });
 
     it('should evaluate interpolateParams with concrete values the right way', function () {
-      expect($translateDefaultInterpolation.interpolate('Foo bar {{ value + value }}', { value: 5 })).toEqual('Foo bar 10');
+      expect($translateDefaultInterpolation.interpolate('Foo bar {{ value + value }}', {value: 5})).toEqual('Foo bar 10');
+    });
+
+    it('should evaluate interpolateParams with concrete values the right way when in escaped mode', function () {
+      $translateDefaultInterpolation.useSanitizeValueStrategy('escaped');
+      expect($translateDefaultInterpolation.interpolate('Foo bar {{ value + value }}', {value: 5})).toEqual('Foo bar 10');
+    });
+
+    it('should evaluate interpolateParams with values that contains html tags', function () {
+      $translateDefaultInterpolation.useSanitizeValueStrategy('escaped');
+
+      expect($translateDefaultInterpolation.interpolate('Foo bar {{ value + value }} with {{name}}', {value: 5, name: 'CaTz <xss>'})).toEqual('Foo bar 10 with CaTz &lt;xss&gt;');
+    });
+  });
+
+  describe('$translateDefaultInterpolation#useSanitizeValueStrategy', function () {
+    it('should be a function ', function () {
+      expect(typeof $translateDefaultInterpolation.useSanitizeValueStrategy).toBe('function');
     });
   });
 });


### PR DESCRIPTION
Also added related tests for escaping the values