### PR TITLE
feat($translatePartialLoader): adds optional priority param to the addPart function

### DIFF
--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -103,6 +103,15 @@ angular.module('pascalprecht.translate')
     return dst;
   }
 
+  function getPrioritizedParts() {
+    var prioritizedParts = [];
+    for(var part in parts) {
+      prioritizedParts.push(parts[part]);
+    }
+    prioritizedParts.sort(function(a, b){return a.priority-b.priority;});
+    return prioritizedParts;
+  }
+
 
   /**
    * @ngdoc function
@@ -278,11 +287,8 @@ angular.module('pascalprecht.translate')
         tables.push(table);
       }
 
-      var prioritizedParts = [];
-      for(var part in parts) {
-        prioritizedParts.push(parts[part]);
-      }
-      prioritizedParts.sort(function(a, b){return a.priority-b.priority;});
+
+      var prioritizedParts = getPrioritizedParts();
 
       angular.forEach(prioritizedParts, function(part, index) {
         if (part.isActive) {
@@ -299,9 +305,9 @@ angular.module('pascalprecht.translate')
         $q.all(loaders).then(
           function() {
             var table = {};
-            for (var i = 0; i < tables.length; i++) {
-              deepExtend(table, tables[i]);
-            }
+            angular.forEach(prioritizedParts, function(part) {
+              deepExtend(table, part.tables[options.key]);
+            });
             deferred.resolve(table);
           },
           function() {

--- a/test/unit/service/loader-partial.spec.js
+++ b/test/unit/service/loader-partial.spec.js
@@ -762,6 +762,35 @@ describe('pascalprecht.translate', function() {
         expect(counter).toEqual(2);
       });
     });
+
+    it('should load parts in order of priority', function() {
+      inject(function($translatePartialLoader, $httpBackend) {
+        var table;
+
+        $httpBackend.whenGET('/locales/part1-en.json').respond(200, '{"key1":"value1","key2":"value2","key3":"value3","key4":"value4"}');
+        $httpBackend.whenGET('/locales/part2-en.json').respond(200, '{"key2" : "overridenby2","key4":"overridenby2"}');
+        $httpBackend.whenGET('/locales/part3-en.json').respond(200, '{"key3" : "overridenby3","key4":"overridenby3"}');
+
+        $translatePartialLoader.addPart('part1', 0);
+        $translatePartialLoader.addPart('part2', 1);
+        $translatePartialLoader.addPart('part3', 2);
+        $translatePartialLoader({
+          key : 'en',
+          urlTemplate : '/locales/{part}-{lang}.json'
+        }).then(function(data) {
+          table = data;
+        }, function() {
+          table = {};
+        });
+
+        $httpBackend.flush();
+
+        expect(table.key1).toEqual('value1');
+        expect(table.key2).toEqual('overridenby2');
+        expect(table.key3).toEqual('overridenby3');
+        expect(table.key4).toEqual('overridenby3');
+      });
+    });
   });
 
 });


### PR DESCRIPTION
Allows parts to be loaded in order of their specified priority to avoid race conditions
between parts. Before this change, you could not guarantee the order in
which translation tables would be overridden.

This commit also fixes some grammatical errors in the `addPart` documentation.