### PR TITLE
Improving the handling of interpolator id's that don't exist

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1296,7 +1296,12 @@ angular.module('pascalprecht.translate').provider('$translate', ['$STORAGE_KEY',
       var determineTranslationInstant = function (translationId, interpolateParams, interpolationId) {
 
         var result, table = $uses ? $translationTable[$uses] : $translationTable,
-            Interpolator = (interpolationId) ? interpolatorHashMap[interpolationId] : defaultInterpolator;
+            Interpolator = defaultInterpolator;
+
+        // if the interpolation id exists use custom interpolator
+        if (interpolatorHashMap && Object.prototype.hasOwnProperty.call(interpolatorHashMap, interpolationId)) {
+          Interpolator = interpolatorHashMap[interpolationId];
+        }
 
         // if the translation id exists, we can just interpolate it
         if (table && Object.prototype.hasOwnProperty.call(table, translationId)) {


### PR DESCRIPTION
Experienced an issue when loading the messageformat interpolator because I used the key messageFormat.

Perhaps it should error instead of falling back to the default interpolator?