### PR TITLE
fix(loader): multiple static translation files

### DIFF
--- a/docs/content/guide/de/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/de/12_asynchronous-loading.ngdoc
@@ -85,7 +85,7 @@ Falls mehrere Dateien an verschiedenen Orten zusammengefügt werden sollen,
 kann alternativ auch ein Array von Dateien definiert werden:
 
 <pre>
-$translateProvider.useStaticFilesLoader(
+$translateProvider.useStaticFilesLoader({
     files: [{
         prefix: 'locale-',
         suffix: '.json'
@@ -96,7 +96,7 @@ $translateProvider.useStaticFilesLoader(
         prefix: 'another/path/to/locales/',
         suffix: ''
     }]
-);
+});
 $translateProvider.preferredLanguage('en');
 </pre>
 

--- a/docs/content/guide/en/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/en/12_asynchronous-loading.ngdoc
@@ -90,7 +90,7 @@ Alternatively, if you have multiple translation files in distinct locations, you
 may instead supply an array of files to the loader:
 
 <pre>
-$translateProvider.useStaticFilesLoader(
+$translateProvider.useStaticFilesLoader({
     files: [{
         prefix: 'locale-',
         suffix: '.json'
@@ -101,7 +101,7 @@ $translateProvider.useStaticFilesLoader(
         prefix: 'another/path/to/locales/',
         suffix: ''
     }]
-);
+});
 $translateProvider.preferredLanguage('en');
 </pre>
 

--- a/docs/content/guide/fr/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/fr/12_asynchronous-loading.ngdoc
@@ -90,7 +90,7 @@ Alternativement, si vous avez plusieurs fichiers de traduction à des endroits
 distincts, vous pouvez plutôt fournir un tableau de fichiers au chargeur:
 
 <pre>
-$translateProvider.useStaticFilesLoader(
+$translateProvider.useStaticFilesLoader({
     files: [{
         prefix: 'locale-',
         suffix: '.json'
@@ -101,7 +101,7 @@ $translateProvider.useStaticFilesLoader(
         prefix: 'another/path/to/locales/',
         suffix: ''
     }]
-);
+});
 $translateProvider.preferredLanguage('fr');
 </pre>
 

--- a/docs/content/guide/ru/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/ru/12_asynchronous-loading.ngdoc
@@ -81,11 +81,11 @@ $translateProvider.useStaticFilesLoader({
 $translateProvider.preferredLanguage('en');
 </pre>
 
-Кроме того, если у вас есть несколько файлов с переводами, которые находятся в разных местах, то 
+Кроме того, если у вас есть несколько файлов с переводами, которые находятся в разных местах, то
 можно предоставить загрузчику массив файлов:
 
 <pre>
-$translateProvider.useStaticFilesLoader(
+$translateProvider.useStaticFilesLoader({
     files: [{
         prefix: 'locale-',
         suffix: '.json'
@@ -96,7 +96,7 @@ $translateProvider.useStaticFilesLoader(
         prefix: 'another/path/to/locales/',
         suffix: ''
     }]
-);
+});
 $translateProvider.preferredLanguage('en');
 </pre>
 

--- a/docs/content/guide/uk/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/uk/12_asynchronous-loading.ngdoc
@@ -85,7 +85,7 @@ $translateProvider.preferredLanguage('en');
 передати завантажувачу масив файлів:
 
 <pre>
-$translateProvider.useStaticFilesLoader(
+$translateProvider.useStaticFilesLoader({
     files: [{
         prefix: 'locale-',
         suffix: '.json'
@@ -96,7 +96,7 @@ $translateProvider.useStaticFilesLoader(
         prefix: 'another/path/to/locales/',
         suffix: ''
     }]
-);
+});
 $translateProvider.preferredLanguage('en');
 </pre>
 
@@ -280,7 +280,7 @@ $translationProvider.useStaticFilesLoader({
 ## Використання кеша
 
 Для контролю над кешуванням в існуючих завантажувачах можна використовувати об'єкт cache. Докладніше
-про це Ви можете прочитати в 
+про це Ви можете прочитати в
 [офіційній документації AngularJS](https://docs.angularjs.org/api/ng/type/$cacheFactory.Cache).
 
 Для увімкнення стандартного кешування використовується наступний метод:

--- a/src/service/loader-static-files.js
+++ b/src/service/loader-static-files.js
@@ -19,7 +19,7 @@ angular.module('pascalprecht.translate')
     if (!options || (!angular.isArray(options.files) && (!angular.isString(options.prefix) || !angular.isString(options.suffix)))) {
       throw new Error('Couldn\'t load static files, no files and prefix or suffix specified!');
     }
-    
+
     if (!options.files) {
       options.files = [{
         prefix: options.prefix,
@@ -36,9 +36,9 @@ angular.module('pascalprecht.translate')
 
       $http(angular.extend({
         url: [
-          options.prefix,
-          options.key,
-          options.suffix
+          file.prefix,
+          file.key,
+          file.suffix
         ].join(''),
         method: 'GET',
         params: ''


### PR DESCRIPTION
Two problems:

1. The docs has a typo,  `files` parameter is an object

2. The `url` arr is not looking up values from the passed `file` object