### PR TITLE
feat($translatePartialLoader): accept function in urlTemplate

### DIFF
--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -38,6 +38,9 @@ angular.module('pascalprecht.translate')
    * @return {string} Parsed url template string
    */
   Part.prototype.parseUrl = function(urlTemplate, targetLang) {
+    if(angular.isFunction(urlTemplate)) {
+      return urlTemplate(this.name, targetLang);
+    }
     return urlTemplate.replace(/\{part\}/g, this.name).replace(/\{lang\}/g, targetLang);
   };
 
@@ -272,8 +275,8 @@ angular.module('pascalprecht.translate')
         throw new TypeError('Unable to load data, a key is not a non-empty string.');
       }
 
-      if (!isStringValid(options.urlTemplate)) {
-        throw new TypeError('Unable to load data, a urlTemplate is not a non-empty string.');
+      if (!isStringValid(options.urlTemplate) && !angular.isFunction(options.urlTemplate)) {
+        throw new TypeError('Unable to load data, a urlTemplate is not a non-empty string or not a function.');
       }
 
       var errorHandler = options.loadFailureHandler;

--- a/test/unit/service/loader-partial.spec.js
+++ b/test/unit/service/loader-partial.spec.js
@@ -418,6 +418,26 @@ describe('pascalprecht.translate', function() {
       });
     });
 
+    it('should support function in url template', function() {
+      inject(function($translatePartialLoader, $httpBackend) {
+        var getUrlTemplate = jasmine.createSpy('getUrlTemplate')
+          .and.returnValue('/locales/data.json');
+
+        $httpBackend.expectGET('/locales/data.json').respond(200, '{}');
+
+        $translatePartialLoader.addPart('part');
+        $translatePartialLoader({
+          key : 'en',
+          urlTemplate : getUrlTemplate
+        });
+
+        $httpBackend.flush();
+        expect(getUrlTemplate).toHaveBeenCalledWith('part', 'en');
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+      });
+    });
+
     it('should parse url template with multiple pattern occurrences', function () {
       inject(function($translatePartialLoader, $httpBackend) {
         $httpBackend.expectGET('/locales/part/part-en.json').respond(200, '{}');


### PR DESCRIPTION
It allows to solve a lot of issues in compicated app structure.

For example I have a translation of common texts in my app: `/app/locales/en.json`.
And there is plugins which also have a translation `/plugins/{part}/en.json`.

Now I can't build so complex urls. But if I could pass a function inside, it would be possible