### PR TITLE
Fixes bugs with refresh method

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1714,10 +1714,8 @@ function $translate($STORAGE_KEY, $windowProvider) {
           }
 
           var allTranslationsLoaded = function (tableData) {
+            $translationTable = {};
             angular.forEach(tableData, function (data) {
-              if ($translationTable[data.key]) {
-                delete $translationTable[data.key];
-              }
               translations(data.key, data.table);
             });
             if ($uses) {

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -1522,9 +1522,8 @@ describe('pascalprecht.translate', function () {
 
       beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide) {
         $translateProvider
-          .translations('de_DE', translationMock)
+          .translations('en_EN', translationMock)
           .preferredLanguage('en_EN')
-          .fallbackLanguage('en_EN')
           .useLoader('customLoader');
 
         $provide.factory('customLoader', ['$q', '$timeout', function ($q, $timeout) {
@@ -1557,19 +1556,27 @@ describe('pascalprecht.translate', function () {
       });
 
       it('should refresh the translation table', function () {
-        var deferred = $q.defer(),
-            promise = deferred.promise,
-            value;
+        var oldvalue, newValue;
 
-        promise.then(function (translation) {
-          value = translation;
-        });
-        $translate('EXISTING_TRANSLATION_ID').then(function (translationId) {
-          deferred.resolve(translationId);
-        });
+        function fetchTranslation() {
+          $translate(['EXISTING_TRANSLATION_ID', 'FOO']).then(function (translations) {
+            oldValue = translations.EXISTING_TRANSLATION_ID;
+            newValue = translations.FOO;
+          });
+          $rootScope.$digest();
+        }
+
+        fetchTranslation();
+        expect(oldValue).toEqual('foo');
+        expect(newValue).toEqual('FOO'); // not found
+
         $translate.refresh();
         $timeout.flush();
-        expect(value).toEqual('EXISTING_TRANSLATION_ID');
+        $rootScope.$digest();
+
+        fetchTranslation();
+        expect(oldValue).toEqual('EXISTING_TRANSLATION_ID'); // not found
+        expect(newValue).toEqual('bar');
       });
 
       it('should emit $translateRefreshStart event', function () {

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -1522,6 +1522,7 @@ describe('pascalprecht.translate', function () {
 
       beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide) {
         $translateProvider
+          .translations('de_DE', translationMock)
           .translations('en_EN', translationMock)
           .preferredLanguage('en_EN')
           .useLoader('customLoader');
@@ -1577,6 +1578,40 @@ describe('pascalprecht.translate', function () {
         fetchTranslation();
         expect(oldValue).toEqual('EXISTING_TRANSLATION_ID'); // not found
         expect(newValue).toEqual('bar');
+      });
+
+      it('should clear completelly inactive translation tables', function () {
+        var value;
+
+        function setValue(answer) {
+          value = answer;
+        }
+
+        function fetchTranslation() {
+          $translate('EXISTING_TRANSLATION_ID').then(setValue, setValue);
+          $rootScope.$digest();
+        }
+
+        function changeLanguage(lang) {
+          $translate.use(lang);
+          $rootScope.$digest();
+        }
+
+        changeLanguage('de_DE');
+        fetchTranslation();
+        expect(value).toEqual('foo'); // found
+
+        changeLanguage('en_EN');
+        $translate.refresh();
+        $timeout.flush();
+        $rootScope.$digest();
+
+        changeLanguage('de_DE');
+        $timeout.flush(); // Expect the `de_DE` language to be loaded
+        $rootScope.$digest();
+
+        fetchTranslation();
+        expect(value).toEqual('EXISTING_TRANSLATION_ID'); // not found
       });
 
       it('should emit $translateRefreshStart event', function () {


### PR DESCRIPTION
Fixes some tow bugs with the `$translate.refresh()` method:

1) Bad test for current table refreshing case
2) This method has to clear all translation tables if no language is specified (#988)