### PR TITLE
docs fix - "Flash of untranslated content" section

### DIFF
--- a/docs/content/guide/de/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/de/12_asynchronous-loading.ngdoc
@@ -331,7 +331,7 @@ $translateProvider.useStaticFilesLoader({
     'prefix': 'locale-',
     'suffix': '.json'
 });
-$translateProvider.preferredLanguage('de');
+$translateProvider.preferredLanguage('en');
 </pre>
 
 **Hinweis:** Ein Benutzer von Angular Translate eine schöne Lösung

--- a/docs/content/guide/en/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/en/12_asynchronous-loading.ngdoc
@@ -389,7 +389,7 @@ $translateProvider.useStaticFilesLoader({
     'prefix': 'locale-',
     'suffix': '.json'
 });
-$translateProvider.preferredLanguage('de');
+$translateProvider.preferredLanguage('en');
 </pre>
 
 **Note:** An Angular Translate user has been posted a nice solution [using Grunt](https://github.com/angular-translate/angular-translate/issues/921).

--- a/docs/content/guide/fr/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/fr/12_asynchronous-loading.ngdoc
@@ -353,7 +353,7 @@ $translateProvider.useStaticFilesLoader({
     'prefix': 'locale-',
     'suffix': '.json'
 });
-$translateProvider.preferredLanguage('en');
+$translateProvider.preferredLanguage('fr');
 </pre>
 
 Mettons à jour notre exemple d'application en conséquence pour utiliser un chargeur asynchrone !

--- a/docs/content/guide/ru/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/ru/12_asynchronous-loading.ngdoc
@@ -365,7 +365,7 @@ $translateProvider.useStaticFilesLoader({
     'prefix': 'locale-',
     'suffix': '.json'
 });
-$translateProvider.preferredLanguage('de');
+$translateProvider.preferredLanguage('en');
 </pre>
 
 **Заметка:** Пользователь Angular-Translate поделился хорошим решением этой проблемы

--- a/docs/content/guide/uk/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/uk/12_asynchronous-loading.ngdoc
@@ -363,7 +363,7 @@ $translateProvider.useStaticFilesLoader({
     'prefix': 'locale-',
     'suffix': '.json'
 });
-$translateProvider.preferredLanguage('de');
+$translateProvider.preferredLanguage('en');
 </pre>
 
 **Примітка:** Користувач Angular-Translate поділився хорошим рішенням цієї проблеми

--- a/docs/content/guide/zh-cn/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/zh-cn/12_asynchronous-loading.ngdoc
@@ -231,7 +231,7 @@ $translateProvider.useStaticFilesLoader({
     'prefix': 'locale-',
     'suffix': '.json'
 });
-$translateProvider.preferredLanguage('de');
+$translateProvider.preferredLanguage('en');
 </pre>
 
 让我们来使用相应的异步加载器来更新我们的示例应用程序！我们将使用 staticFilesLoader。首先，我们要从代码中抽取翻译转换表出来

--- a/docs/content/guide/zh-tw/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/zh-tw/12_asynchronous-loading.ngdoc
@@ -231,7 +231,7 @@ $translateProvider.useStaticFilesL​​oader({
     'prefix': 'locale-',
     'suffix': '.json'
 });
-$translateProvider.preferredLanguage('de');
+$translateProvider.preferredLanguage('en');
 </pre>
 
 讓我們來使用相應的異步加載器來更新我們的示例應用程序！我們將使用 staticFilesL​​oader。首先，我們要從代碼中抽取翻譯轉換錶出來


### PR DESCRIPTION
If I understand the docs correctly, there is an important mistake in FOUC section - preferredLanguage is not the one which is loaded synchronously. Fixed it