### PR TITLE
feat(directive): translate-namespace directive

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,6 +57,7 @@ module.exports = function (grunt) {
         'src/service/storage-key.js',
         'src/directive/translate.js',
         'src/directive/translate-cloak.js',
+        'src/directive/translate-namespace.js',
         'src/filter/translate.js'
       ],
 

--- a/demo/ex13_translate-namespace.htm
+++ b/demo/ex13_translate-namespace.htm
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+
+<head>
+  <meta charset="utf-8">
+  <title translate="TITLE">Translate namespace directive</title>
+  <style>body { text-align: center; }</style>
+</head>
+
+<body ng-controller="ctrl">
+
+  <p>
+    <a href="#" ng-click="setLang('en_US')">English</a>
+    |
+    <a href="#" ng-click="setLang('ru_RU')">Русский</a>
+  </p>
+
+  <div translate-namespace="ns1">
+    <h1 translate>.HEADER</h1>
+    <h2 translate>.SUBHEADER</h2>
+  </div>
+
+  <hr>
+
+  <div translate-namespace="ns2">
+    <h1 translate>.HEADER</h1>
+    <h2 translate>.SUBHEADER</h2>
+  </div>
+
+  <div translate-namespace="ns3">
+    <div translate-namespace=".HEADERS">
+      <h1 translate>
+        .HELLO
+      </h1>
+    </div>
+    <div>
+      <h1 translate>ns4.HEADERS.HELLO</h1>
+    </div>
+  </div>
+
+  <div translate-namespace="ns5">
+    <h1 translate>.HEADERS.HELLO</h1>
+  </div>
+
+<script src="../bower_components/angular/angular.js"></script>
+<script src="../bower_components/angular-cookies/angular-cookies.js"></script>
+<script src="../dist/angular-translate.js"></script>
+<script src="../dist/angular-translate-storage-cookie/angular-translate-storage-cookie.js"></script>
+
+<script>
+angular.module('app', ['pascalprecht.translate', 'ngCookies'])
+
+.config(['$translateProvider', function($translateProvider){
+
+  // Adding a translation table for the English language
+  $translateProvider.translations('en_US', {
+    "TITLE"     : "How to use translate namespace directive",
+    "ns1" : {
+      "HEADER"    : "A translations table supports namespaces.",
+      "SUBHEADER" : "So you can to structurize your translation table well."
+    },
+    "ns2" : {
+      "HEADER"    : "Do you want to have a structured translations table?",
+      "SUBHEADER" : "You can to use namespaces now."
+    },
+    "ns3": {
+      "HEADERS": {
+        "HELLO": "Hello"
+      }
+    },
+    "ns4": {
+      "HEADERS": {
+        "HELLO": "Hello from ns4"
+      }
+    },
+    "ns5.HEADERS.HELLO": "Also works for simple keys with dots"
+  });
+
+  // Adding a translation table for the Russian language
+  $translateProvider.translations('ru_RU', {
+    "TITLE"     : "Как использовать директиву перевести имен",
+    "ns1" : {
+      "HEADER"    : "Таблица переводов поддерживает пространства имен.",
+      "SUBHEADER" : "Таким образом, Вы можете хорошо структурировать ваши переводы."
+    },
+    "ns2" : {
+      "HEADER"    : "Вы хотите иметь структурированную таблицу переводов?",
+      "SUBHEADER" : "Теперь Вы можете использовать пространства имен."
+    },
+    "ns3": {
+      "HEADERS": {
+        "HELLO": "здравствуйте"
+      }
+    },
+    "ns4": {
+      "HEADERS": {
+        "HELLO": "Привет из ns4"
+      }
+    },
+    "ns5.HEADERS.HELLO": "Также работает для простых ключей с точками"
+  });
+
+  // Tell the module what language to use by default
+  $translateProvider.preferredLanguage('en_US');
+
+  // Tell the module to store the language in the cookies
+  $translateProvider.useCookieStorage();
+
+}])
+
+.controller('ctrl', ['$scope', '$translate', function($scope, $translate) {
+
+  $scope.setLang = function(langKey) {
+    // You can change the language during runtime
+    $translate.use(langKey);
+  };
+
+}]);
+</script>
+
+</body>
+</html>

--- a/demo/index.htm
+++ b/demo/index.htm
@@ -18,6 +18,7 @@
     <li><a href="ex9_load_dynamic_files.htm">How to use $translateUrlLoader</a></li>
     <li><a href="ex10_translate-cloak.html">How to use translate-cloak</a></li>
     <li><a href="ex11_load_partial_files.html">How to load partial files</a></li>
+    <li><a href="ex13_translate-namespace.htm">How to use translate-namespace</a></li>
   </ul>
 </body>
 </html>

--- a/src/directive/translate-namespace.js
+++ b/src/directive/translate-namespace.js
@@ -1,0 +1,86 @@
+angular.module('pascalprecht.translate')
+/**
+ * @ngdoc directive
+ * @name pascalprecht.translate.directive:translateNamespace
+ * @restrict A
+ *
+ * @description
+ * Translates given translation id either through attribute or DOM content.
+ * Internally it uses `translate` filter to translate translation id. It possible to
+ * pass an optional `translate-values` object literal as string into translation id.
+ *
+ * @param {string=} translate namespace name which could be either string or interpolated string.
+ *
+ * @example
+   <example module="ngView">
+    <file name="index.html">
+      <div translate-namespace="CONTENT">
+
+        <div>
+            <h1 translate>.HEADERS.TITLE</h1>
+            <h1 translate>.HEADERS.WELCOME</h1>
+        </div>
+
+        <div translate-namespace=".HEADERS">
+            <h1 translate>.TITLE</h1>
+            <h1 translate>.WELCOME</h1>
+        </div>
+
+      </div>
+    </file>
+    <file name="script.js">
+      angular.module('ngView', ['pascalprecht.translate'])
+
+      .config(function ($translateProvider) {
+
+        $translateProvider.translations('en',{
+          'TRANSLATION_ID': 'Hello there!',
+          'CONTENT': {
+            'HEADERS': {
+                TITLE: 'Title'
+            }
+          },
+          'CONTENT.HEADERS.WELCOME': 'Welcome'
+        }).preferredLanguage('en');
+
+      });
+
+    </file>
+   </example>
+ */
+.directive('translateNamespace', translateNamespaceDirective);
+
+function translateNamespaceDirective() {
+
+  'use strict';
+
+  return {
+    restrict: 'A',
+    scope: true,
+    compile: function () {
+      return {
+        pre: function (scope, iElement, iAttrs) {
+          scope.translateNamespace = getTranslateNamespace(scope);
+
+          if (scope.translateNamespace && iAttrs.translateNamespace.charAt(0) === '.') {
+            scope.translateNamespace += iAttrs.translateNamespace;
+          } else {
+            scope.translateNamespace = iAttrs.translateNamespace;
+          }
+        }
+      };
+    }
+  };
+
+  function getTranslateNamespace(scope) {
+    if (scope.translateNamespace) {
+      return scope.translateNamespace;
+    }
+
+    if (scope.$parent) {
+      return getTranslateNamespace(scope.$parent);
+    }
+  }
+}
+
+translateNamespaceDirective.displayName = 'translateNamespaceDirective';

--- a/test/unit/directive/translate-namespace.spec.js
+++ b/test/unit/directive/translate-namespace.spec.js
@@ -1,0 +1,50 @@
+/* jshint camelcase: false, unused: false */
+/* global inject: false */
+'use strict';
+
+describe('pascalprecht.translate', function () {
+
+  describe('translate-namespace directive', function () {
+
+    var element;
+
+    beforeEach(module('pascalprecht.translate'));
+
+    var $compile, $rootScope;
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+    }));
+
+    it('should add translateNamespace to current scope', function () {
+      element = $compile('<div translate-namespace="NAMESPACE"></div>')($rootScope);
+      expect(element.scope().translateNamespace).toBe('NAMESPACE');
+    });
+
+    it('should append to existing namespace if new namespace starts with a dot', function () {
+      $rootScope.translateNamespace = 'NAMESPACE';
+      element = $compile('<div translate-namespace=".SUBNAMESPACE"></div>')($rootScope);
+      expect(element.scope().translateNamespace).toBe('NAMESPACE.SUBNAMESPACE');
+    });
+
+    it('should append to existing namespace out of isolated scope', function () {
+      $rootScope.translateNamespace = 'NAMESPACE';
+      var isolatedScope = $rootScope.$new({});
+      element = $compile('<div translate-namespace=".SUBNAMESPACE"></div>')(isolatedScope);
+      expect(element.scope().translateNamespace).toBe('NAMESPACE.SUBNAMESPACE');
+    });
+
+    it('should overwrite existing namespace if new namespace does not start with a dot', function () {
+      $rootScope.translateNamespace = 'NAMESPACE';
+      element = $compile('<div translate-namespace="SUBNAMESPACE"></div>')($rootScope);
+      expect(element.scope().translateNamespace).toBe('SUBNAMESPACE');
+    });
+
+    it('should not change parent scope namespace', function () {
+      $rootScope.translateNamespace = 'NAMESPACE';
+      element = $compile('<div translate-namespace="SUBNAMESPACE"></div>')($rootScope);
+      expect($rootScope.translateNamespace).toBe('NAMESPACE');
+    });
+  });
+});

--- a/test/unit/directive/translate.spec.js
+++ b/test/unit/directive/translate.spec.js
@@ -21,7 +21,12 @@ describe('pascalprecht.translate', function () {
           'TEXT_WITH_VALUE': 'This is a text with given value: {{value}}',
           'HOW_ABOUT_THIS': '{{value}} + {{value}}',
           'AND_THIS': '{{value + value}}',
-          'BLANK_VALUE': ''
+          'BLANK_VALUE': '',
+          'NAMESPACE': {
+            'SUBNAMESPACE': {
+              'TRANSLATION_ID': 'Namespaced translation'
+            }
+          }
         })
         .preferredLanguage('en');
     }));
@@ -192,6 +197,23 @@ describe('pascalprecht.translate', function () {
         element = $compile('<translate>BLANK_VALUE</translate>')($rootScope);
         $rootScope.$digest();
         expect(element.text()).toBe('');
+      });
+
+      describe('when id starts with a dot and translate namespace given', function () {
+        it('should return translation', function () {
+          $rootScope.translateNamespace = "NAMESPACE.SUBNAMESPACE";
+          element = $compile('<h4 translate>.TRANSLATION_ID</h4>')($rootScope);
+          $rootScope.$digest();
+          expect(element.text()).toBe('Namespaced translation');
+        });
+
+        it('should work with isolated scopes', function () {
+          $rootScope.translateNamespace = "NAMESPACE.SUBNAMESPACE";
+          var isolatedScope = $rootScope.$new({});
+          element = $compile('<h4 translate>.TRANSLATION_ID</h4>')(isolatedScope);
+          $rootScope.$digest();
+          expect(element.text()).toBe('Namespaced translation');
+        });
       });
     });
 
@@ -648,7 +670,12 @@ describe('pascalprecht.translate', function () {
           'ANOTHER_ONE': 'bar',
           'TRANSLATION_ID': 'foo',
           'TEXT_WITH_VALUE': 'This is a text with given value: {{value}}',
-          'ANOTHER_TEXT_WITH_VALUE': 'And here is another value: {{another_value}}'
+          'ANOTHER_TEXT_WITH_VALUE': 'And here is another value: {{another_value}}',
+          'NAMESPACE': {
+            'SUBNAMESPACE': {
+              'TRANSLATION_ID': 'Namespaced translation'
+            }
+          }
         })
         .preferredLanguage('en');
     }));
@@ -704,6 +731,12 @@ describe('pascalprecht.translate', function () {
       $rootScope.$digest();
       expect(element.attr('title')).toBe('Helloo there!');
     });
-  });
 
+    it('should return translation for prefixed id when translate namespace given and translation id starts with a dot', function () {
+      $rootScope.translateNamespace = "NAMESPACE.SUBNAMESPACE";
+      element = $compile('<div translate translate-attr-title=".TRANSLATION_ID"></div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.attr('title')).toBe('Namespaced translation');
+    });
+  });
 });


### PR DESCRIPTION
I've added translate-namespace directive to support "namespaced translation keys". In order to use  given translation namespace translation key should be prefixed by "."

E.g. to get translation for key "client.posts.title"

```
<div translate-namespace="client.posts">
  <h1 translate>.title</h1>
</div>
```
or you can also nest translate namespaces
```
<div translate-namespace="client">
  <div translate-namespace=".posts">
    <h1 translate>.title</h1>
  </div>
</div>
```
Relates #641, #744