### PR TITLE
this.replace is not a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ so make sure to check this list.
 - [Examples and demos](https://github.com/angular-translate/angular-translate/wiki/Demos) - Currently on plnkr.co
 - [Tutorial on angularjs.de](http://angularjs.de/artikel/angularjs-i18n-ng-translate) - German article
 - [Tutorial on neoskop.de](http://www.neoskop.de/blog/angular-translate) - German article
-- [angular-translate on GitHub](httpw://github.com/angular-translate/angular-translate) - The GitHub repository
+- [angular-translate on GitHub](https://github.com/angular-translate/angular-translate) - The GitHub repository
 - [angular-translate on ngmodules.org](http://ngmodules.org/modules/angular-translate)
 - [angular-translate mailinglist](https://groups.google.com/forum/#!forum/angular-translate) - Discuss, ask et al!
 

--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -100,7 +100,7 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
    * @returns {string} The string stripped of whitespace from both ends
    */
   var trim = function() {
-    return this.replace(/^\s+|\s+$/g, '');
+    return this.toString().replace(/^\s+|\s+$/g, '');
   };
 
   return {

--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -134,7 +134,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
    * @returns {string} The string stripped of whitespace from both ends
    */
   var trim = function() {
-    return this.replace(/^\s+|\s+$/g, '');
+    return this.toString().replace(/^\s+|\s+$/g, '');
   };
 
   var negotiateLocale = function (preferred) {

--- a/test/unit/filter/translate.spec.js
+++ b/test/unit/filter/translate.spec.js
@@ -89,6 +89,10 @@ describe('pascalprecht.translate', function () {
       expect(value[5]).toEqual('10');
       expect(value[6]).toEqual('55');
     });
+	  
+	it('should not throw errors when translation id is a number', function() {
+		expect($translate(4.5)).toEqual('4.5');
+	});
 
     if (angular.version.major === 1 && angular.version.minor <= 2) {
       // Until and including AJS 1.2, a filter was bound to a context (current scope). This was removed in AJS 1.3


### PR DESCRIPTION
Hi,

when giving a non-string Id to the translate Filter, I am getting the error `TypeError: this.replace is not a function. Attached fix works for me.

(Use Case: I am using translation in tables that can contain labels as well as data.)
