### PR TITLE
this.replace is not a function

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -100,7 +100,7 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
    * @returns {string} The string stripped of whitespace from both ends
    */
   var trim = function() {
-    return this.replace(/^\s+|\s+$/g, '');
+    return this.toString().replace(/^\s+|\s+$/g, '');
   };
 
   return {

--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -134,7 +134,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
    * @returns {string} The string stripped of whitespace from both ends
    */
   var trim = function() {
-    return this.replace(/^\s+|\s+$/g, '');
+    return this.toString().replace(/^\s+|\s+$/g, '');
   };
 
   var negotiateLocale = function (preferred) {

--- a/test/unit/filter/translate.spec.js
+++ b/test/unit/filter/translate.spec.js
@@ -89,6 +89,10 @@ describe('pascalprecht.translate', function () {
       expect(value[5]).toEqual('10');
       expect(value[6]).toEqual('55');
     });
+	  
+	it('should not throw errors when translation id is a number', function() {
+		expect($translate(4.5)).toEqual('4.5');
+	});
 
     if (angular.version.major === 1 && angular.version.minor <= 2) {
       // Until and including AJS 1.2, a filter was bound to a context (current scope). This was removed in AJS 1.3

--- a/test/unit/filter/translate.spec.js
+++ b/test/unit/filter/translate.spec.js
@@ -90,8 +90,26 @@ describe('pascalprecht.translate', function () {
       expect(value[6]).toEqual('55');
     });
 	  
-	it('should not throw errors when translation id is a number', function() {
-		expect($translate(4.5)).toEqual('4.5');
+	it('should not throw errors when translation id is not a string', function() {
+		var value = [
+			$translate(4.5),
+			$translate(4),
+			$translate([]),
+			$translate({}),
+			$translate(true),
+			$translate(null),
+			$translate(undefined)	
+		];
+		
+		expect(value[0]).toEqual('4.5');
+		expect(value[1]).toEqual('4');
+		/* I don't care what these values are, as long as $translate doesn't throw an error.
+		expect(value[2]).toEqual({});
+		expect(value[3]).toEqual('[object Object]');	
+		expect(value[4]).toEqual('true');
+		expect(value[5]).toEqual(null);
+		expect(value[6]).toEqual(undefined);
+		*/
 	});
 
     if (angular.version.major === 1 && angular.version.minor <= 2) {


### PR DESCRIPTION
Hi,

when giving a non-string Id to the translate Filter, I am getting the error `TypeError: this.replace is not a function. Attached fix works for me.

(Use Case: I am using translation in tables that can contain labels as well as data.)
