### PR TITLE
refactor(service): Remove use of legacy methods on $http promises.

### DIFF
--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -51,34 +51,32 @@ function $translatePartialLoader() {
   };
 
   Part.prototype.getTable = function(lang, $q, $http, $httpOptions, urlTemplate, errorHandler) {
-    var deferred = $q.defer();
 
     if (!this.tables[lang]) {
       var self = this;
 
-      $http(angular.extend({
+      return $http(angular.extend({
         method : 'GET',
         url: this.parseUrl(urlTemplate, lang)
-      }, $httpOptions)).success(function(data){
-        self.tables[lang] = data;
-        deferred.resolve(data);
-      }).error(function() {
+      }, $httpOptions)).then(function(result){
+        self.tables[lang] = result.data;
+        return result.data;
+      }, function() {
         if (errorHandler) {
-          errorHandler(self.name, lang).then(function(data) {
+          return errorHandler(self.name, lang).then(function(data) {
             self.tables[lang] = data;
-            deferred.resolve(data);
+            return data;
           }, function() {
-            deferred.reject(self.name);
+            return $q.reject(self.name);
           });
         } else {
-          deferred.reject(self.name);
+          return $q.reject(self.name);
         }
       });
 
     } else {
-      deferred.resolve(this.tables[lang]);
+      return $q.when(this.tables[lang]);
     }
-    return deferred.promise;
   };
 
   var parts = {};

--- a/src/service/loader-static-files.js
+++ b/src/service/loader-static-files.js
@@ -36,9 +36,7 @@ function $translateStaticFilesLoader($q, $http) {
         throw new Error('Couldn\'t load static file, no prefix or suffix specified!');
       }
 
-      var deferred = $q.defer();
-
-      $http(angular.extend({
+      return $http(angular.extend({
         url: [
           file.prefix,
           options.key,
@@ -46,13 +44,11 @@ function $translateStaticFilesLoader($q, $http) {
         ].join(''),
         method: 'GET',
         params: ''
-      }, options.$http)).success(function (data) {
-        deferred.resolve(data);
-      }).error(function () {
-        deferred.reject(options.key);
+      }, options.$http)).then(function(result) {
+        return result.data;
+      }, function () {
+        return $q.reject(options.key);
       });
-
-      return deferred.promise;
     };
 
     var deferred = $q.defer(),

--- a/src/service/loader-url.js
+++ b/src/service/loader-url.js
@@ -28,22 +28,19 @@ function $translateUrlLoader($q, $http) {
       throw new Error('Couldn\'t use urlLoader since no url is given!');
     }
 
-    var deferred = $q.defer(),
-        requestParams = {};
+    var requestParams = {};
 
     requestParams[options.queryParameter || 'lang'] = options.key;
 
-    $http(angular.extend({
+    return $http(angular.extend({
       url: options.url,
       params: requestParams,
       method: 'GET'
-    }, options.$http)).success(function (data) {
-      deferred.resolve(data);
-    }).error(function () {
-      deferred.reject(options.key);
+    }, options.$http)).then(function(result) {
+      return result.data;
+    }, function () {
+      return $q.reject(options.key);
     });
-
-    return deferred.promise;
   };
 }
 


### PR DESCRIPTION
Also saves a couple of lines of code.