### PR TITLE
Added lang_only as new langTagResolver

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -54,7 +54,12 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
           var temp = (tag || '').split('_').join('-');
           var parts = temp.split('-');
           return parts.length > 1 ? (parts[0].toLowerCase() + '-' + parts[1].toUpperCase()) : temp;
-        }
+        },
+        lang_only: function(tag) {
+  			  var temp = (tag || '').split('_').join('-');
+  			  var parts = temp.split('-');
+  			  return parts[0].toLowerCase();
+  		  }
       };
 
   var version = 'x.y.z';


### PR DESCRIPTION
Added possibility to be able to get only the lang tag as result, in order to limit the language files to one for each language, i.e. locale-de.json, locale-en.json. Especially useful when using the staticFilesLoader.