### PR TITLE
fix(service): update storage before triggering $translateChangeSuccess

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1113,11 +1113,14 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
        */
       var useLanguage = function (key) {
         $uses = key;
-        $rootScope.$emit('$translateChangeSuccess', {language: key});
 
+		// make sure to store new language key before triggering success event
         if ($storageFactory) {
           Storage.put($translate.storageKey(), $uses);
         }
+		
+        $rootScope.$emit('$translateChangeSuccess', {language: key});
+		
         // inform default interpolator
         defaultInterpolator.setLocale($uses);
 


### PR DESCRIPTION
Triggering $translateChangeSuccess before updating the stored language key causes fallback translation to fail the first time $translate.use() is called. The second time it is called with the same language code, it works. This is because promiseToWaitFor() reads what it thinks is the current language from storage, and then proceeds to ignore that as a fallback language. This is not correct behaviour unless the stored language has been updated first.

This bug occurs if you have languages AA and BB with storage enabled, and AA set up to as the fallback language. Changing to BB from AA causes AA to be ignored in the fallback chain, and all translations fail.