### PR TITLE
Emit ready event

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1698,14 +1698,17 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
        * When trying to 'use' a language which isn't available it tries to load it
        * asynchronously with registered loaders.
        *
-       * Returns promise object with loaded language file data
+       * Returns promise object with loaded language file data or string of the currently used language.
+       *
+       * If no or a falsy key is given it returns the currently used language key.
+       * The returned string will be ```undefined``` if setting up $translate hasn't finished.
        * @example
        * $translate.use("en_US").then(function(data){
        *   $scope.text = $translate("HELLO");
        * });
        *
-       * @param {string} key Language key
-       * @return {string} Language key
+       * @param {string} [key] Language key
+       * @return {object|string} Promise with loaded language data or the language key if a falsy param was given.
        */
       $translate.use = function (key) {
         if (!key) {

--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1698,17 +1698,14 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
        * When trying to 'use' a language which isn't available it tries to load it
        * asynchronously with registered loaders.
        *
-       * Returns promise object with loaded language file data or string of the currently used language.
-       *
-       * If no or a falsy key is given it returns the currently used language key.
-       * The returned string will be ```undefined``` if setting up $translate hasn't finished.
+       * Returns promise object with loaded language file data
        * @example
        * $translate.use("en_US").then(function(data){
        *   $scope.text = $translate("HELLO");
        * });
        *
-       * @param {string} [key] Language key
-       * @return {object|string} Promise with loaded language data or the language key if a falsy param was given.
+       * @param {string} key Language key
+       * @return {string} Language key
        */
       $translate.use = function (key) {
         if (!key) {

--- a/src/translate.js
+++ b/src/translate.js
@@ -8,21 +8,48 @@
 angular.module('pascalprecht.translate', ['ng'])
   .run(runTranslate);
 
-function runTranslate($translate) {
+
+
+function runTranslate($translate, $rootScope, $q) {
+
+  /**
+   * @ngdoc event
+   * @name pascalprecht.translate#$translateReadyToUse
+   * @eventOf pascalprecht.translate
+   * @eventType emit on root scope
+   *
+   * @description
+   * A $translateReadyToUse event is called when the run() method has completed and
+   * the promises from setting $translate.use() are resolved.
+   * After this event has been fired $translate.use() returns the actual used language
+   *
+   * @example
+   * angular.module('app', [])
+   *   .run(function($rootScope, $translate){
+   *     $rootScope.$on('$translateReadyToUse', function() {
+   *       $rootScope.interfaceLang = $translate.use();
+   *     });
+   *   });
+   *
+   *   *Note: In the case $translate is configured with no storage and no preferredLanguage this event is never fired*
+   */
 
   'use strict';
 
   var key = $translate.storageKey(),
-    storage = $translate.storage();
+      storage = $translate.storage(),
+      deferred = $q.defer(),
+      usePromise = deferred.promise;
 
   var fallbackFromIncorrectStorageValue = function () {
     var preferred = $translate.preferredLanguage();
     if (angular.isString(preferred)) {
-      $translate.use(preferred);
+      usePromise = $translate.use(preferred);
       // $translate.use() will also remember the language.
       // So, we don't need to call storage.put() here.
     } else {
-      storage.put(key, $translate.use());
+      deferred.resolve(storage.put(key, $translate.use()));
+
     }
   };
 
@@ -32,11 +59,17 @@ function runTranslate($translate) {
     if (!storage.get(key)) {
       fallbackFromIncorrectStorageValue();
     } else {
-      $translate.use(storage.get(key))['catch'](fallbackFromIncorrectStorageValue);
+      usePromise = $translate.use(storage.get(key))['catch'](fallbackFromIncorrectStorageValue);
     }
   } else if (angular.isString($translate.preferredLanguage())) {
-    $translate.use($translate.preferredLanguage());
+    usePromise = $translate.use($translate.preferredLanguage());
   }
+  usePromise.then(function(){
+    // in the case of 'with a storage but with no loadable translations', this would yield undefined,
+    // but $translate.use() returns correctly the preferredLanguage. Therefore this event does not emit data
+//    $rootScope.$emit('$translateReadyToUse', {language: $translate.use()});
+    $rootScope.$emit('$translateReadyToUse');
+  });
 }
 
 runTranslate.displayName = 'runTranslate';

--- a/test/unit/translate.spec.js
+++ b/test/unit/translate.spec.js
@@ -4,16 +4,25 @@
 describe('pascalprecht.translate', function () {
 
   describe('$translateModule#run', function () {
+    var $rootScope;
 
     describe('with no storage', function() {
 
       describe('and no preferred language', function() {
 
         beforeEach(module('pascalprecht.translate'));
-
+        //these have always to be called AFTER the module() functions
+        beforeEach(inject(function($injector){
+          $rootScope = $injector.get('$rootScope');
+          spyOn($rootScope, '$emit');
+        }));
         it('should set used locale to undefined', inject(function($translate) {
           expect($translate.use()).toBeUndefined();
         }));
+        it('should not emit $translateReadyToUse Event', function(){
+          $rootScope.$digest();
+          expect($rootScope.$emit).not.toHaveBeenCalled();
+        });
       });
 
       describe('but with a preferred language', function() {
@@ -21,9 +30,15 @@ describe('pascalprecht.translate', function () {
         beforeEach(module('pascalprecht.translate', function ($translateProvider) {
           $translateProvider.preferredLanguage('en');
         }));
-
+        beforeEach(inject(function($injector){
+          $rootScope = $injector.get('$rootScope');
+          spyOn($rootScope, '$emit');
+        }));
         it('should use preferredLanguage', inject(function($translate) {
+          $rootScope.$digest();
           expect($translate.use()).toEqual('en');
+          expect($rootScope.$emit).toHaveBeenCalledWith('$translateReadyToUse');
+
         }));
       });
     });
@@ -57,10 +72,17 @@ describe('pascalprecht.translate', function () {
             .useStorage('storageMock')
             .preferredLanguage('de');
         }));
+        beforeEach(inject(function($injector){
+          $rootScope = $injector.get('$rootScope');
+          spyOn($rootScope, '$emit');
+        }));
 
         it('should use value from storage when provided', inject(function($translate) {
+          $rootScope.$digest();
           expect(storage.get).toHaveBeenCalled();
           expect($translate.use()).toEqual('en');
+          expect($rootScope.$emit).toHaveBeenCalledWith('$translateReadyToUse');
+
         }));
       });
 
@@ -74,15 +96,20 @@ describe('pascalprecht.translate', function () {
             .useStorage('storageMock')
             .preferredLanguage('de');
         }));
-
+        beforeEach(inject(function($injector){
+          $rootScope = $injector.get('$rootScope');
+          spyOn($rootScope, '$emit');
+        }));
         it('should fallback to preferred locale', inject(function($translate) {
+          $rootScope.$digest();
           expect(storage.get).toHaveBeenCalled();
           expect($translate.use()).toEqual('de');
+          expect($rootScope.$emit).toHaveBeenCalledWith('$translateReadyToUse');
+
         }));
       });
 
       describe('but with no loadable translations', function() {
-
         beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide) {
           storage = storageMockCreator('en');
           $provide.value('storageMock', storage);
@@ -104,13 +131,47 @@ describe('pascalprecht.translate', function () {
             .useLoader('loaderMock')
             .preferredLanguage('de');
         }));
-
+        beforeEach(inject(function($injector){
+          $rootScope = $injector.get('$rootScope');
+          spyOn($rootScope, '$emit');
+        }));
         it('should fallback to preferred locale', inject(function($translate, $rootScope) {
           $rootScope.$digest();
           expect(storage.get).toHaveBeenCalled();
           expect($translate.use()).toEqual('de');
+          expect($rootScope.$emit).toHaveBeenCalledWith('$translateReadyToUse');
         }));
       });
     });
+  });
+});
+describe('Event $translateReadyToUse', function(){
+  var $rootScope;
+  var gotEvent = false;
+  var eventCallback = {
+    fn: function() {
+      gotEvent = true;
+    }
+  };
+  beforeEach(module('pascalprecht.translate', function($translateProvider) {
+        $translateProvider.preferredLanguage('de');
+  }));
+  beforeEach(inject(function($injector){
+
+    $rootScope = $injector.get('$rootScope');
+    $rootScope.$on('$translateReadyToUse', eventCallback.fn);
+    spyOn($rootScope, '$emit');
+    spyOn(eventCallback, 'fn');
+  }));
+
+  it('should emit the Event and use() should return the correct language', inject(function($translate){
+    expect($translate.use()).toEqual('de');
+    $rootScope.$digest();
+    expect($rootScope.$emit).toHaveBeenCalledWith('$translateReadyToUse');
+  }));
+  //can't figure out how to setup the the event listener before the module is instantiated
+  xit('should be received', function(){
+    expect(eventCallback.fn).toHaveBeenCalled();
+    expect(gotEvent).toBe(true);
   });
 });


### PR DESCRIPTION
emits an $translateReadyToUse after the promises in $translate.run() are resolved.
This shall indicate that it is now save and reliable to determinate that actually used language with $translate.use().
related to #1195 