### PR TITLE
Handling of the 'useLegacyPromiseExtensions' flag

### DIFF
--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -59,10 +59,10 @@ function $translatePartialLoader() {
       $http(angular.extend({
         method : 'GET',
         url: this.parseUrl(urlTemplate, lang)
-      }, $httpOptions)).success(function(data){
-        self.tables[lang] = data;
-        deferred.resolve(data);
-      }).error(function() {
+      }, $httpOptions)).then(function(response){
+        self.tables[lang] = response.data;
+        deferred.resolve(response.data);
+      }, function() {
         if (errorHandler) {
           errorHandler(self.name, lang).then(function(data) {
             self.tables[lang] = data;

--- a/src/service/loader-static-files.js
+++ b/src/service/loader-static-files.js
@@ -46,9 +46,9 @@ function $translateStaticFilesLoader($q, $http) {
         ].join(''),
         method: 'GET',
         params: ''
-      }, options.$http)).success(function (data) {
-        deferred.resolve(data);
-      }).error(function () {
+      }, options.$http)).then(function (response) {
+        deferred.resolve(response.data);
+      }, function () {
         deferred.reject(options.key);
       });
 

--- a/src/service/loader-url.js
+++ b/src/service/loader-url.js
@@ -37,9 +37,9 @@ function $translateUrlLoader($q, $http) {
       url: options.url,
       params: requestParams,
       method: 'GET'
-    }, options.$http)).success(function (data) {
-      deferred.resolve(data);
-    }).error(function () {
+    }, options.$http)).then(function (response) {
+      deferred.resolve(response.data);
+    }, function () {
       deferred.reject(options.key);
     });
 

--- a/test/unit/service/loader-partial.spec.js
+++ b/test/unit/service/loader-partial.spec.js
@@ -261,7 +261,11 @@ describe('pascalprecht.translate', function() {
 
   describe('$translatePartialLoader', function () {
 
-    beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('pascalprecht.translate', function($httpProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
+    }));
 
     var $translatePartialLoader, $rootScope;
 
@@ -457,7 +461,11 @@ describe('pascalprecht.translate', function() {
 
   describe('$translatePartialLoader', function () {
 
-    beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('pascalprecht.translate', function($httpProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
+    }));
 
     it('should use error handler if it is specified', function() {
       inject(function($translatePartialLoader, $httpBackend) {
@@ -513,6 +521,9 @@ describe('pascalprecht.translate', function() {
       counter = 0;
 
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -536,6 +547,9 @@ describe('pascalprecht.translate', function() {
       counter = 0;
 
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -564,6 +578,9 @@ describe('pascalprecht.translate', function() {
     it('shouldn\'t load a part if it was loaded, deleted and added again', function() {
       counter = 0;
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -594,6 +611,9 @@ describe('pascalprecht.translate', function() {
       counter = 0;
 
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -621,6 +641,9 @@ describe('pascalprecht.translate', function() {
 
     it('should put a part into a cache and remove from the cache if the part was deleted', function() {
       module(function($httpProvider, $translateProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
         $translateProvider.useLoaderCache();
       });
@@ -656,6 +679,9 @@ describe('pascalprecht.translate', function() {
       counter = 0;
 
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -682,6 +708,9 @@ describe('pascalprecht.translate', function() {
       counter = 0;
 
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -716,6 +745,9 @@ describe('pascalprecht.translate', function() {
     it('shouldn\'t load a part if it was loaded, deleted and added again', function() {
       counter = 0;
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -752,6 +784,9 @@ describe('pascalprecht.translate', function() {
       counter = 0;
 
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 

--- a/test/unit/service/loader-static-files.spec.js
+++ b/test/unit/service/loader-static-files.spec.js
@@ -8,7 +8,11 @@ describe('pascalprecht.translate', function () {
 
     var $translate, $httpBackend, $translateStaticFilesLoader, $translationCache;
 
-    beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('pascalprecht.translate', function($httpProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
+    }));
 
     beforeEach(inject(function (_$translate_, _$httpBackend_, _$translateStaticFilesLoader_, _$translationCache_) {
       $httpBackend = _$httpBackend_;
@@ -24,6 +28,17 @@ describe('pascalprecht.translate', function () {
     afterEach(function() {
       $httpBackend.verifyNoOutstandingExpectation();
       $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    it('should return a promise 2', function () {
+      var promise = $translateStaticFilesLoader({
+        key: 'de_DE',
+        prefix: 'lang_',
+        suffix: '.json'
+      });
+      expect(promise.then).toBeDefined();
+      expect(typeof promise.then).toBe('function');
+      $httpBackend.flush();
     });
 
     it('should be defined', function () {
@@ -88,7 +103,11 @@ describe('pascalprecht.translate', function () {
 
     var $translate, $httpBackend, $translateStaticFilesLoader;
 
-    beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('pascalprecht.translate', function($httpProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
+    }));
 
     beforeEach(inject(function (_$translate_, _$httpBackend_, _$translateStaticFilesLoader_) {
       $httpBackend = _$httpBackend_;

--- a/test/unit/service/loader-url.spec.js
+++ b/test/unit/service/loader-url.spec.js
@@ -8,7 +8,11 @@ describe('pascalprecht.translate', function () {
 
     var $translate, $httpBackend, $translateUrlLoader, $translationCache;
 
-    beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('pascalprecht.translate', function($httpProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
+    }));
 
     beforeEach(inject(function (_$translate_, _$httpBackend_, _$translateUrlLoader_, _$translationCache_) {
       $translate = _$translate_;
@@ -88,7 +92,10 @@ describe('pascalprecht.translate', function () {
   });
 
   describe('$translateProvider#useUrlLoader', function () {
-    beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+    beforeEach(module('pascalprecht.translate', function ($httpProvider, $translateProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
       $translateProvider.useUrlLoader('foo/bar.json');
     }));
 
@@ -114,7 +121,10 @@ describe('pascalprecht.translate', function () {
   });
 
   describe('$translateProvider#useUrlLoader with custom $http options (method=POST)', function () {
-    beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+    beforeEach(module('pascalprecht.translate', function ($httpProvider, $translateProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
       $translateProvider.useUrlLoader('foo/bar.json', {
         $http: {
           method: 'POST'


### PR DESCRIPTION
Angular 1.4.x provides a flag to disable the "old" success/error callbacks of $http. This commit updates the code to use the "then" promise.