### PR TITLE
Using the 'useLegacyPromiseExtensions' flag into the tests

### DIFF
--- a/test/unit/service/loader-partial.spec.js
+++ b/test/unit/service/loader-partial.spec.js
@@ -261,7 +261,11 @@ describe('pascalprecht.translate', function() {
 
   describe('$translatePartialLoader', function () {
 
-    beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('pascalprecht.translate', function ($httpProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
+    }));
 
     var $translatePartialLoader, $rootScope;
 
@@ -457,7 +461,11 @@ describe('pascalprecht.translate', function() {
 
   describe('$translatePartialLoader', function () {
 
-    beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('pascalprecht.translate', function ($httpProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
+    }));
 
     it('should use error handler if it is specified', function() {
       inject(function($translatePartialLoader, $httpBackend) {
@@ -513,6 +521,9 @@ describe('pascalprecht.translate', function() {
       counter = 0;
 
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -536,6 +547,9 @@ describe('pascalprecht.translate', function() {
       counter = 0;
 
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -564,6 +578,9 @@ describe('pascalprecht.translate', function() {
     it('shouldn\'t load a part if it was loaded, deleted and added again', function() {
       counter = 0;
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -594,6 +611,9 @@ describe('pascalprecht.translate', function() {
       counter = 0;
 
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -621,6 +641,9 @@ describe('pascalprecht.translate', function() {
 
     it('should put a part into a cache and remove from the cache if the part was deleted', function() {
       module(function($httpProvider, $translateProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
         $translateProvider.useLoaderCache();
       });
@@ -656,6 +679,9 @@ describe('pascalprecht.translate', function() {
       counter = 0;
 
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -682,6 +708,9 @@ describe('pascalprecht.translate', function() {
       counter = 0;
 
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -716,6 +745,9 @@ describe('pascalprecht.translate', function() {
     it('shouldn\'t load a part if it was loaded, deleted and added again', function() {
       counter = 0;
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 
@@ -752,6 +784,9 @@ describe('pascalprecht.translate', function() {
       counter = 0;
 
       module(function($httpProvider) {
+        if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+          $httpProvider.useLegacyPromiseExtensions(false);
+        }
         $httpProvider.defaults.transformRequest.push(CounterHttpInterceptor);
       });
 

--- a/test/unit/service/loader-static-files.spec.js
+++ b/test/unit/service/loader-static-files.spec.js
@@ -8,7 +8,11 @@ describe('pascalprecht.translate', function () {
 
     var $translate, $httpBackend, $translateStaticFilesLoader, $translationCache;
 
-    beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('pascalprecht.translate', function ($httpProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
+    }));
 
     beforeEach(inject(function (_$translate_, _$httpBackend_, _$translateStaticFilesLoader_, _$translationCache_) {
       $httpBackend = _$httpBackend_;
@@ -88,7 +92,11 @@ describe('pascalprecht.translate', function () {
 
     var $translate, $httpBackend, $translateStaticFilesLoader;
 
-    beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('pascalprecht.translate', function ($httpProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
+    }));
 
     beforeEach(inject(function (_$translate_, _$httpBackend_, _$translateStaticFilesLoader_) {
       $httpBackend = _$httpBackend_;

--- a/test/unit/service/loader-url.spec.js
+++ b/test/unit/service/loader-url.spec.js
@@ -8,7 +8,11 @@ describe('pascalprecht.translate', function () {
 
     var $translate, $httpBackend, $translateUrlLoader, $translationCache;
 
-    beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('pascalprecht.translate', function ($httpProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
+    }));
 
     beforeEach(inject(function (_$translate_, _$httpBackend_, _$translateUrlLoader_, _$translationCache_) {
       $translate = _$translate_;
@@ -88,7 +92,10 @@ describe('pascalprecht.translate', function () {
   });
 
   describe('$translateProvider#useUrlLoader', function () {
-    beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+    beforeEach(module('pascalprecht.translate', function ($httpProvider, $translateProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
       $translateProvider.useUrlLoader('foo/bar.json');
     }));
 
@@ -114,7 +121,10 @@ describe('pascalprecht.translate', function () {
   });
 
   describe('$translateProvider#useUrlLoader with custom $http options (method=POST)', function () {
-    beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+    beforeEach(module('pascalprecht.translate', function ($httpProvider, $translateProvider) {
+      if (angular.isDefined($httpProvider.useLegacyPromiseExtensions)) {
+        $httpProvider.useLegacyPromiseExtensions(false);
+      }
       $translateProvider.useUrlLoader('foo/bar.json', {
         $http: {
           method: 'POST'


### PR DESCRIPTION
Angular 1.4.x provides a flag to disable the "old" success/error callbacks of $http. This commit updates the test code to avoid regressions.