### PR TITLE
docs(19_security):  Fix wrong link

### DIFF
--- a/docs/content/guide/de/19_security.ngdoc
+++ b/docs/content/guide/de/19_security.ngdoc
@@ -8,7 +8,7 @@ Für reguläre Ausgaben sorgt bereits AngularJS im Allgemeinen intern dafür, da
 die Ausgabe korrekt escaped ausgegeben wird. Allerdings kann es bei der Verwendung
 `angular-translate` dazu führen, dass dynamische Inhalte im Ergebnis nicht korrekt
 escaped werden. Dies führt zu ernsthaften Sicherheitslücken innerhalb der eigenen
-Applikation (siehe auch: [OWASP](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS))).
+Applikation (siehe auch: <a href="https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)">OWASP</a>).
 
 ## Allgemeine Benutzung
 

--- a/docs/content/guide/en/19_security.ngdoc
+++ b/docs/content/guide/en/19_security.ngdoc
@@ -7,7 +7,7 @@
 Speaking of regular output, AngularJS ensures the output will be escaped correctly.
 However, when using `angular-translate` and variable content, the result will not be
 escaped correctly. This means your app is vulnerable for serious attacks
-(see: [OWASP](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS))).
+(see: <a href="https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)">OWASP</a>).
 
 ## General use
 

--- a/docs/content/guide/fr/19_security.ngdoc
+++ b/docs/content/guide/fr/19_security.ngdoc
@@ -7,7 +7,7 @@
 Lorsqu'on parle de restitution normale, AngularJS garantit que la restitution sera échappée correctement.
 Toutefois, lorsque vous utilisez `angular-translate` et un contenu de variable, le résultat ne sera pas
 échappé correctement. Cela signifie que votre application est vulnérable aux attaques graves
-(voir : [OWASP](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)).
+(voir : <a href="https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)">OWASP</a>.
 
 ## Utilisation générale
 

--- a/docs/content/guide/ru/19_security.ngdoc
+++ b/docs/content/guide/ru/19_security.ngdoc
@@ -7,7 +7,7 @@
 Говоря об обычном выводе, AngularJS гарантирует, что он будет правильно экранирован. Тем не менее,
 при использовании `angular-translate` и динамического контента, результат не будет экранирован
 правильно. Это означает, что ваше приложение является уязвимым для серьезных атак
-(см: [OWASP](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS))).
+(см: <a href="https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)">OWASP</a>).
 
 ## Использование
 

--- a/docs/content/guide/uk/19_security.ngdoc
+++ b/docs/content/guide/uk/19_security.ngdoc
@@ -7,7 +7,7 @@
 Говорячи про звичайний вивід, AngularJS гарантує, що він буде правильно екранований. Проте, при
 використанні `angular-translate` і динамічного контента, результат не будет екрановано правильно.
 Це означає, що ваш застосунок є вразливим для серйозних атак
-(див: [OWASP](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS))).
+(див: <a href="https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)">OWASP</a>).
 
 ## Використання
 

--- a/docs/content/guide/zh-cn/19_security.ngdoc
+++ b/docs/content/guide/zh-cn/19_security.ngdoc
@@ -5,7 +5,7 @@
 # 转义的变量内容
 
 说到常规输出，AngularJS 确保输出将被正确转义。 然而，当使用 `angular-translate` 和可变内容时，结果将不会是正确转义。
-这意味着你的应用程序很容易受到严重的攻击(参见: [OWASP](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)))。
+这意味着你的应用程序很容易受到严重的攻击(参见: <a href="https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)">OWASP</a>)。
 
 ## 一般使用
 


### PR DESCRIPTION
As discussed in #1217 I changed the links in the documentation to regular html links. They should be rendered properly now.