### PR TITLE
feat(service): Add method to provider to get locale at config time.

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -845,6 +845,25 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
 
   /**
    * @ngdoc function
+   * @name pascalprecht.translate.$translateProvider#getProposedLanguage
+   * @methodOf pascalprecht.translate.$translateProvider
+   *
+   * @description
+   * Retrieves the language will initially be fetched, this could have been set through the use method or determined
+   * by {@link pascalprecht.translate.$translateProvider#determinePreferredLanguage determinePreferredLanguage}.
+   *
+   * This language may not be available and another fallback will actually be used, but that cannot be determined until
+   * runtime. The intent of this method is to give a hint at config time as to what language should be used, mostly so
+   * other libraries that are translated outside of angular-translate can stay in lock step with angular-translate's language.
+   *
+   * @returns {string} A key in the format `[lang]_[country]` or `[lang]` depending on what the browser provides.
+   */
+  this.getProposedLanguage = function() {
+    return $uses || $preferredLanguage;
+  };
+
+  /**
+   * @ngdoc function
    * @name pascalprecht.translate.$translateProvider#registerAvailableLanguageKeys
    * @methodOf pascalprecht.translate.$translateProvider
    *


### PR DESCRIPTION
I am using the angular-google-maps library along with angular-translate, which requires that a config time option be sent to google for which language the maps should be localized too. Rather than re-implement what angular-translate already does, I have added a method on the provider for returning the language that angular-translate is at least going to try first.

Of course this method will only provide a proposed language, because it's not until the languages are fetched that angular-translate can fully determine what language will be used, but I think that fallback mechanism can be handled differently, due to a different set of translations, for the library consuming this value.

It seems like it breaks the chaining that is presently in all the provider methods, but I didn't see a way around that without exposing some of the local variables as properties. Thoughts?