### PR TITLE
fix 'useful resources'

### DIFF
--- a/docs/content/guide/en/index.ngdoc
+++ b/docs/content/guide/en/index.ngdoc
@@ -80,7 +80,7 @@ There are some very useful things on the web that might be interesting for you,
 so make sure to check this list.
 
 - [Tutorial on ng-newsletter.com](http://www.ng-newsletter.com/posts/angular-translate.html)
-- [angular-translate and partial loading](http://technpol.wordpress.com/2013/11/02/adding-translation-using-angular-translate-to-an-angularjs-app/#comment-773)
+- [angular-translate and partial loading](http://technpol.wordpress.com/2013/11/02/adding-translation-using-angular-translate-to-an-angularjs-app/)
 - [Examples and demos](https://github.com/PascalPrecht/angular-translate/wiki/Demos) - Currently on plnkr.co
 - [Tutorial on angularjs.de](http://angularjs.de/artikel/angularjs-i18n-ng-translate) - German article
 - [angular-translate on GitHub](http://github.com/PascalPrecht/angular-translate) - The GitHub repository

--- a/docs/content/guide/en/index.ngdoc
+++ b/docs/content/guide/en/index.ngdoc
@@ -83,7 +83,6 @@ so make sure to check this list.
 - [angular-translate and partial loading](http://technpol.wordpress.com/2013/11/02/adding-translation-using-angular-translate-to-an-angularjs-app/#comment-773)
 - [Examples and demos](https://github.com/PascalPrecht/angular-translate/wiki/Demos) - Currently on plnkr.co
 - [Tutorial on angularjs.de](http://angularjs.de/artikel/angularjs-i18n-ng-translate) - German article
-- [Tutorial on neoskop.de](http://www.neoskop.de/blog/angular-translate) - German article
 - [angular-translate on GitHub](http://github.com/PascalPrecht/angular-translate) - The GitHub repository
 - [angular-translate on ngmodules.org](http://ngmodules.org/modules/angular-translate)
 - [angular-translate mailinglist](https://groups.google.com/forum/#!forum/angular-translate) - Discuss, ask et al!


### PR DESCRIPTION
- remove anchor to specific comment on technpol.wordpress.com link
- remove neoskop article as it still uses `$translate.uses()`