### PR TITLE
feat(directive): Add translation IDs to the scope

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -126,7 +126,7 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
         scope.preText = '';
         scope.postText = '';
         scope.translateNamespace = getTranslateNamespace(scope);
-        var translationIds = {};
+        scope.translationIds = {};
 
         var initInterpolationParams = function (interpolateParams, iAttr, tAttr) {
           // initial setup
@@ -164,26 +164,26 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
             if (angular.isArray(interpolateMatches)) {
               scope.preText = interpolateMatches[1];
               scope.postText = interpolateMatches[3];
-              translationIds.translate = $interpolate(interpolateMatches[2])(scope.$parent);
+              scope.translationIds.translate = $interpolate(interpolateMatches[2])(scope.$parent);
               var watcherMatches = iElementText.match(watcherRegExp);
               if (angular.isArray(watcherMatches) && watcherMatches[2] && watcherMatches[2].length) {
                 observeElementTranslation._unwatchOld = scope.$watch(watcherMatches[2], function (newValue) {
-                  translationIds.translate = newValue;
+                  scope.translationIds.translate = newValue;
                   updateTranslations();
                 });
               }
             } else {
-              translationIds.translate = iElementText;
+              scope.translationIds.translate = iElementText;
             }
           } else {
-            translationIds.translate = translationId;
+            scope.translationIds.translate = translationId;
           }
           updateTranslations();
         };
 
         var observeAttributeTranslation = function (translateAttr) {
           iAttr.$observe(translateAttr, function (translationId) {
-            translationIds[translateAttr] = translationId;
+            scope.translationIds[translateAttr] = translationId;
             updateTranslations();
           });
         };
@@ -199,7 +199,7 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
           } else {
             // case of regular attribute
             if (translationId !== '' || !firstAttributeChangedEvent) {
-              translationIds.translate = translationId;
+              scope.translationIds.translate = translationId;
               updateTranslations();
             }
           }
@@ -242,10 +242,10 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
 
         // Master update function
         var updateTranslations = function () {
-          for (var key in translationIds) {
+          for (var key in scope.translationIds) {
 
-            if (translationIds.hasOwnProperty(key) && translationIds[key] !== undefined) {
-              updateTranslation(key, translationIds[key], scope, scope.interpolateParams, scope.defaultText, scope.translateNamespace);
+            if (scope.translationIds.hasOwnProperty(key) && scope.translationIds[key] !== undefined) {
+              updateTranslation(key, scope.translationIds[key], scope, scope.interpolateParams, scope.defaultText, scope.translateNamespace);
             }
           }
         };

--- a/test/unit/directive/translate.spec.js
+++ b/test/unit/directive/translate.spec.js
@@ -42,13 +42,6 @@ describe('pascalprecht.translate', function () {
       expect(element.text()).toBe('TEXT');
     });
 
-    it('should return translation id if translation doesn\'t exist and if its passed as interpolation', function () {
-      $rootScope.translationIds = 'TEXT';
-      element = $compile('<div translate="{{translationIds}}"></div>')($rootScope);
-      $rootScope.$digest();
-      expect(element.text()).toBe('TEXT');
-    });
-
     it('should return default text if translation doesn\'t exist', function () {
       element = $compile('<div translate="TEXT" translate-default="Not translated"></div>')($rootScope);
       $rootScope.$digest();


### PR DESCRIPTION
This change allows to use translation IDs extracted by `translate`
directive in other directives.

For example, if you are developing a translation editor, you can create
a directive, let’s call it `angular-translate-edit`, with `restrict:
‘A’`, that would get translation IDs defined for the angular-translate.

This gives you the possibility to avoid some complex code duplication
with all different options to define translation IDs, including
interpolation, what is already done in the `translate` directive.

As a part of this change one duplicated test is removed that uses
`$rootScope.translationIds` due to the name conflict in the
prototypically inherited directive scope. The same test already exists
and it just uses `$rootScope.translationId` instead.