### PR TITLE
1092 spanish examples

### DIFF
--- a/docs/content/guide/en/10_storages.ngdoc
+++ b/docs/content/guide/en/10_storages.ngdoc
@@ -102,7 +102,7 @@ update our app to use localStorage as well!
         PASSED_AS_TEXT: 'Hey! Ich wurde als text übergeben!',
         PASSED_AS_ATTRIBUTE: 'Ich wurde als Attribut übergeben, cool oder?',
         PASSED_AS_INTERPOLATION: 'Anfänger! Ich bin interpoliert!',
-        VARIABLE_REPLACEMENT: 'Hi {{name}}',
+        VARIABLE_REPLACEMENT: 'Hallo {{name}}',
         BUTTON_LANG_DE: 'Deutsch',
         BUTTON_LANG_EN: 'Englisch'
       };

--- a/docs/content/guide/es/02_getting-started.ngdoc
+++ b/docs/content/guide/es/02_getting-started.ngdoc
@@ -53,9 +53,9 @@ O, tal vez, la configuración del servicio `$route`:
 
 <pre>
 app.config(function ($routeProvider) {
-  $routeProvider.when('/something', {
-    templateUrl: 'url/to/template',
-    controller: 'SomeFancyCtrl'
+  $routeProvider.when('/algoPasa', {
+    templateUrl: 'url/al/template',
+    controller: 'UnControladorCualquiera'
   });
 });
 </pre>
@@ -90,7 +90,7 @@ o, si se los carga remotamente, como objetos JSON. Así es como se vería una ta
 
 ```json
 {
-  "TRANSLATION_ID": "This is a concrete translation for a specific language."
+  "TRANSLATION_ID": "Una traducción en concreto, para un lenguaje en particular."
 }
 ```
 
@@ -104,7 +104,7 @@ crear objetos JSON anidados:
 {
   "NAMESPACE": {
     "SUB_NAMESPACE": {
-       "TRANSLATION_ID1": "This is a namespaced translation."
+       "TRANSLATION_ID1": "Esta es una traducción con namespace."
     }
   }
 }
@@ -119,7 +119,7 @@ Una funcionalidad muy útil, disponible desde `1.1.1`, es el uso de Atajos y Ví
 {
   "bar": {
     "foo": {
-      "foo": "This is my text."
+      "foo": "Acá está mi texto"
     }
   }
 }
@@ -136,10 +136,10 @@ siguiente tabla:
 
 ```json
 {
-  "SOME_NAMESPACE": {
+  "UN_NAMESPACE": {
     "OK_TEXT": "OK"
   },
-  "ANOTHER_NAMESPACE": {
+  "OTRO_NAMESPACE": {
     "OK_TEXT": "OK"
   }
 }
@@ -154,11 +154,11 @@ una arroba y dos puntos `@:`, seguidos por la clave de traducción con la que se
 
 ```json
 {
-  "SOME_NAMESPACE": {
+  "UN_NAMESPACE": {
     "OK_TEXT": "OK"
   },
-  "ANOTHER_NAMESPACE": {
-    "OK_TEXT": "@:SOME_NAMESPACE.OK_TEXT"
+  "OTRO_NAMESPACE": {
+    "OK_TEXT": "@:UN_NAMESPACE.OK_TEXT"
   }
 }
 ```
@@ -170,10 +170,10 @@ Supongamos que tenemos una tabla de traducción como esta:
 
 <pre>
 var translations = {
-  HEADLINE: 'What an awesome module!',
-  PARAGRAPH: 'Srsly!',
+  ENCABEZADO: '¡Qué módulo asombroso!',
+  PARRAFO: '¡En serio!',
   NAMESPACE: {
-    PARAGRAPH: 'And it comes with awesome features!'
+    PARRAFO: '¡Y viene con funcionalidades extraordinarias!'
   }
 };
 </pre>
@@ -182,10 +182,10 @@ Podemos agregarla con  `$translateProvider.translations()`:
 
 <pre>
 app.config(['$translateProvider', function ($translateProvider) {
-  // add translation table
+  // agregar la tabla de traducción
   $translateProvider
-    .translations('en', translations)
-    .preferredLanguage('en');
+    .translations('es', translations)
+    .preferredLanguage('es');
 }]);
 </pre>
 
@@ -197,25 +197,25 @@ ha sido instanciado y usado. Este es el código en funcionamiento:
   <doc:source>
     <script>
       var translations = {
-        HEADLINE: 'What an awesome module!',
-        PARAGRAPH: 'Srsly!',
+        ENCABEZADO: '¡Qué módulo asombroso!',
+        PARRAFO: '¡En serio!',
         NAMESPACE: {
-          PARAGRAPH: 'And it comes with awesome features!'
+          PARRAFO: '¡Y viene con funcionalidades extraordinarias!'
         }
       };
 
       var app = angular.module('myApp', ['pascalprecht.translate']);
 
       app.config(['$translateProvider', function ($translateProvider) {
-        // add translation table
-        $translateProvider
-          .translations('en', translations)
-          .preferredLanguage('en');
+      // agregar la tabla de traducción
+      $translateProvider
+        .translations('es', translations)
+        .preferredLanguage('es');
       }]);
     </script>
     <div>
-      <h1>Nothing to see here yet!</h1>
-      <p>But we'll change it now</p>
+      <h1>Todavía no se ve nada</h1>
+      <p>Pero enseguida lo vamos a arreglar ...</p>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/02_getting-started.ngdoc
+++ b/docs/content/guide/es/02_getting-started.ngdoc
@@ -90,7 +90,7 @@ o, si se los carga remotamente, como objetos JSON. Así es como se vería una ta
 
 ```json
 {
-  "TRANSLATION_ID": "Una traducción en concreto, para un lenguaje en particular."
+  "CLAVE_DE_TRADUCCION": "Una traducción en concreto, para un lenguaje en particular."
 }
 ```
 
@@ -104,7 +104,7 @@ crear objetos JSON anidados:
 {
   "NAMESPACE": {
     "SUB_NAMESPACE": {
-       "TRANSLATION_ID1": "Esta es una traducción con namespace."
+       "OTRA_CLAVE_DE_TRADUCCION": "Esta es una traducción con namespace."
     }
   }
 }
@@ -170,10 +170,10 @@ Supongamos que tenemos una tabla de traducción como esta:
 
 <pre>
 var translations = {
-  ENCABEZADO: '¡Qué módulo asombroso!',
-  PARRAFO: '¡En serio!',
+  HEADLINE: '¡Qué módulo asombroso!',
+  PARAGRAPH: '¡En serio!',
   NAMESPACE: {
-    PARRAFO: '¡Y viene con funcionalidades extraordinarias!'
+    PARAGRAPH: '¡Y viene con funcionalidades extraordinarias!'
   }
 };
 </pre>
@@ -197,10 +197,10 @@ ha sido instanciado y usado. Este es el código en funcionamiento:
   <doc:source>
     <script>
       var translations = {
-        ENCABEZADO: '¡Qué módulo asombroso!',
-        PARRAFO: '¡En serio!',
+        HEADLINE: '¡Qué módulo asombroso!',
+        PARAGRAPH: '¡En serio!',
         NAMESPACE: {
-          PARRAFO: '¡Y viene con funcionalidades extraordinarias!'
+          PARAGRAPH: '¡Y viene con funcionalidades extraordinarias!'
         }
       };
 

--- a/docs/content/guide/es/02_getting-started.ngdoc
+++ b/docs/content/guide/es/02_getting-started.ngdoc
@@ -90,7 +90,7 @@ o, si se los carga remotamente, como objetos JSON. Así es como se vería una ta
 
 ```json
 {
-  "CLAVE_DE_TRADUCCION": "Una traducción en concreto, para un lenguaje en particular."
+  "TRANSLATION_ID": "Una traducción en concreto, para un lenguaje en particular."
 }
 ```
 
@@ -104,7 +104,7 @@ crear objetos JSON anidados:
 {
   "NAMESPACE": {
     "SUB_NAMESPACE": {
-       "OTRA_CLAVE_DE_TRADUCCION": "Esta es una traducción con namespace."
+       "OTRA_TRANSLATION_ID": "Esta es una traducción con namespace."
     }
   }
 }

--- a/docs/content/guide/es/03_using-translate-service.ngdoc
+++ b/docs/content/guide/es/03_using-translate-service.ngdoc
@@ -36,19 +36,19 @@ Entonces, el uso básico de `$translate` en la capa de servicios o de controlado
 
 <pre>
 app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
-  $translate('HEADLINE').then(function (headline) {
+  $translate('ENCABEZADO').then(function (headline) {
     $scope.headline = headline;
   });
-  $translate('PARAGRAPH').then(function (paragraph) {
+  $translate('PARRAFO').then(function (paragraph) {
     $scope.paragraph = paragraph;
   });
-  $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
+  $translate('NAMESPACE.PARRAFO').then(function (anotherOne) {
     $scope.namespaced_paragraph = anotherOne;
   });
 }]);
 </pre>
 
-**Nota:** a las traducciones con "namespace" se accede como si fueran propiedades JSON, por ejemplo, 'NAMESPACE.PARAGRAPH'`.
+**Nota:** a las traducciones con "namespace" se accede como si fueran propiedades JSON, por ejemplo, 'NAMESPACE.PARRAFO'`.
 
 Y eso es todo. Ahora, cuando piense en traducir los contenidos de un `<title>`, lo puede hacer dentro del código
 de su controlador.
@@ -59,10 +59,10 @@ El servicio de traducción acepta requests con varias claves a la vez.
 
 <pre>
 app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
-  $translate(['HEADLINE', 'PARAGRAPH', 'NAMESPACE.PARAGRAPH']).then(function (translations) {
-    $scope.headline = translations.HEADLINE;
-    $scope.paragraph = translations.PARAGRAPH;
-    $scope.namespaced_paragraph = translations['NAMESPACE.PARAGRAPH'];
+  $translate(['ENCABEZADO', 'PARRAFO', 'NAMESPACE.PARRAFO']).then(function (translations) {
+    $scope.headline = translations.ENCABEZADO;
+    $scope.paragraph = translations.PARRAFO;
+    $scope.namespaced_paragraph = translations['NAMESPACE.PARRAFO'];
   });
 }]);
 </pre>
@@ -79,7 +79,7 @@ Simplemente invóquela así:
 
 <pre>
   $translate.versionInfo();
-  // returns e.g. "2.1.0"
+  // devuelve, por ejemplo "2.1.0"
 </pre>
 
 ## Cosas a tener en cuenta
@@ -103,7 +103,7 @@ Eso se vería así:
 <pre>
 app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, $translate, $rootScope) {
   $rootScope.$on('$translateChangeSuccess', function () {
-    $translate('HEADLINE').then(function (translation) {
+    $translate('ENCABEZADO').then(function (translation) {
       $scope.headline = translation;
     });
   });
@@ -120,10 +120,10 @@ Este es un ejemplo que anda:
   <doc:source>
     <script>
       var translations = {
-        HEADLINE: 'What an awesome module!',
-        PARAGRAPH: 'Srsly!',
+        ENCABEZADO: '¡Qué módulo asombroso!',
+        PARRAFO: '¡En serio!',
         NAMESPACE: {
-          PARAGRAPH: 'And it comes with awesome features!'
+          PARRAFO: '¡Y viene con funcionalidades extraordinarias!'
         }
       };
 
@@ -132,27 +132,27 @@ Este es un ejemplo que anda:
       app.config(['$translateProvider', function ($translateProvider) {
         // add translation table
         $translateProvider
-          .translations('en', translations)
-          .preferredLanguage('en');
+          .translations('es', translations)
+          .preferredLanguage('es');
       }]);
 
       app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
         // expose translation via `$translate` service
-        $translate('HEADLINE').then(function (headline) {
-          $scope.headline = headline;
+        $translate('ENCABEZADO').then(function (headline) {
+          $scope.encabezado = headline;
         });
-        $translate('PARAGRAPH').then(function (paragraph) {
-          $scope.paragraph = paragraph;
+        $translate('PARRAFO').then(function (paragraph) {
+          $scope.parrafo = paragraph;
         });
-        $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
-          $scope.namespaced_paragraph = anotherOne;
+        $translate('NAMESPACE.PARRAFO').then(function (anotherOne) {
+          $scope.parrafoConNamespace = anotherOne;
         });
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <h1>{{headline}}</h1>
-      <p>{{paragraph}}</p>
-      <p>{{namespaced_paragraph}}</p>
+      <h1>{{encabezado}}</h1>
+      <p>{{parrafo}}</p>
+      <p>{{parrafoConNamespace}}</p>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/03_using-translate-service.ngdoc
+++ b/docs/content/guide/es/03_using-translate-service.ngdoc
@@ -36,19 +36,19 @@ Entonces, el uso básico de `$translate` en la capa de servicios o de controlado
 
 <pre>
 app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
-  $translate('ENCABEZADO').then(function (headline) {
+  $translate('HEADLINE').then(function (headline) {
     $scope.headline = headline;
   });
-  $translate('PARRAFO').then(function (paragraph) {
+  $translate('PARAGRAPH').then(function (paragraph) {
     $scope.paragraph = paragraph;
   });
-  $translate('NAMESPACE.PARRAFO').then(function (anotherOne) {
+  $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
     $scope.namespaced_paragraph = anotherOne;
   });
 }]);
 </pre>
 
-**Nota:** a las traducciones con "namespace" se accede como si fueran propiedades JSON, por ejemplo, 'NAMESPACE.PARRAFO'`.
+**Nota:** a las traducciones con "namespace" se accede como si fueran propiedades JSON, por ejemplo, 'NAMESPACE.PARAGRAPH'`.
 
 Y eso es todo. Ahora, cuando piense en traducir los contenidos de un `<title>`, lo puede hacer dentro del código
 de su controlador.
@@ -59,10 +59,10 @@ El servicio de traducción acepta requests con varias claves a la vez.
 
 <pre>
 app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
-  $translate(['ENCABEZADO', 'PARRAFO', 'NAMESPACE.PARRAFO']).then(function (translations) {
-    $scope.headline = translations.ENCABEZADO;
-    $scope.paragraph = translations.PARRAFO;
-    $scope.namespaced_paragraph = translations['NAMESPACE.PARRAFO'];
+  $translate(['HEADLINE', 'PARAGRAPH', 'NAMESPACE.PARAGRAPH']).then(function (translations) {
+    $scope.headline = translations.HEADLINE;
+    $scope.paragraph = translations.PARAGRAPH;
+    $scope.namespaced_paragraph = translations['NAMESPACE.PARAGRAPH'];
   });
 }]);
 </pre>
@@ -103,7 +103,7 @@ Eso se vería así:
 <pre>
 app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, $translate, $rootScope) {
   $rootScope.$on('$translateChangeSuccess', function () {
-    $translate('ENCABEZADO').then(function (translation) {
+    $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;
     });
   });
@@ -120,10 +120,10 @@ Este es un ejemplo que anda:
   <doc:source>
     <script>
       var translations = {
-        ENCABEZADO: '¡Qué módulo asombroso!',
-        PARRAFO: '¡En serio!',
+        HEADLINE: '¡Qué módulo asombroso!',
+        PARAGRAPH: '¡En serio!',
         NAMESPACE: {
-          PARRAFO: '¡Y viene con funcionalidades extraordinarias!'
+          PARAGRAPH: '¡Y viene con funcionalidades extraordinarias!'
         }
       };
 
@@ -137,14 +137,14 @@ Este es un ejemplo que anda:
       }]);
 
       app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
-        // expose translation via `$translate` service
-        $translate('ENCABEZADO').then(function (headline) {
+        // exponer la traducción vía el servicio `$translate` 
+        $translate('HEADLINE').then(function (headline) {
           $scope.encabezado = headline;
         });
-        $translate('PARRAFO').then(function (paragraph) {
+        $translate('PARAGRAPH').then(function (paragraph) {
           $scope.parrafo = paragraph;
         });
-        $translate('NAMESPACE.PARRAFO').then(function (anotherOne) {
+        $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
           $scope.parrafoConNamespace = anotherOne;
         });
       }]);

--- a/docs/content/guide/es/04_using-translate-filter.ngdoc
+++ b/docs/content/guide/es/04_using-translate-filter.ngdoc
@@ -25,7 +25,7 @@ simplemente transfiriendo la lógica desde el controlador hacia nuestro filtro `
 El filtro funcionaría así:
 
 ```
-<ANY>{{ TRANSLATION_ID | translate }}</ANY>
+<ANY>{{ CLAVE_DE_TRADUCCION | translate }}</ANY>
 ```
 
 Así que, para actualizar nuestro ejemplo, quitamos el uso del servicio `$translate` de nuestro
@@ -33,8 +33,8 @@ controlador, y agregamos la lógica en nuestra capa de vista, utilizando el filt
 de esta manera:
 
 <pre>
-<h1>{{'HEADLINE' | translate}}</h1>
-<p>{{'PARAGRAPH' | translate}}</p>
+<h1>{{'ENCABEZADO' | translate}}</h1>
+<p>{{'PARRAFO' | translate}}</p>
 </pre>
 
 Fácil ¿no? Por supuesto, se puede ver una muestra andando aquí:
@@ -43,16 +43,16 @@ Fácil ¿no? Por supuesto, se puede ver una muestra andando aquí:
   <doc:source>
     <script>
       var translations = {
-        HEADLINE: 'What an awesome module!',
-        PARAGRAPH: 'Srsly!'
+        ENCABEZADO: '¡Qué módulo asombroso!',
+        PARRAFO: '¡En serio!'
       };
 
       var app = angular.module('myApp', ['pascalprecht.translate']);
 
       app.config(['$translateProvider', function ($translateProvider) {
         // add translation table
-        $translateProvider.translations('en', translations);
-        $translateProvider.preferredLanguage('en');
+        $translateProvider.translations('es', translations);
+        $translateProvider.preferredLanguage('es');
       }]);
 
       app.controller('Ctrl', ['$scope', function ($scope) {
@@ -60,8 +60,8 @@ Fácil ¿no? Por supuesto, se puede ver una muestra andando aquí:
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'HEADLINE' | translate }}</p>
-      <p>{{ 'PARAGRAPH' | translate }}</p>
+      <p>{{ 'ENCABEZADO' | translate }}</p>
+      <p>{{ 'PARRAFO' | translate }}</p>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/04_using-translate-filter.ngdoc
+++ b/docs/content/guide/es/04_using-translate-filter.ngdoc
@@ -33,8 +33,8 @@ controlador, y agregamos la lógica en nuestra capa de vista, utilizando el filt
 de esta manera:
 
 <pre>
-<h1>{{'ENCABEZADO' | translate}}</h1>
-<p>{{'PARRAFO' | translate}}</p>
+<h1>{{'HEADLINE' | translate}}</h1>
+<p>{{'PARAGRAPH' | translate}}</p>
 </pre>
 
 Fácil ¿no? Por supuesto, se puede ver una muestra andando aquí:
@@ -43,14 +43,14 @@ Fácil ¿no? Por supuesto, se puede ver una muestra andando aquí:
   <doc:source>
     <script>
       var translations = {
-        ENCABEZADO: '¡Qué módulo asombroso!',
-        PARRAFO: '¡En serio!'
+        HEADLINE: '¡Qué módulo asombroso!',
+        PARAGRAPH: '¡En serio!'
       };
 
       var app = angular.module('myApp', ['pascalprecht.translate']);
 
       app.config(['$translateProvider', function ($translateProvider) {
-        // add translation table
+        // agregar tabla de traducción
         $translateProvider.translations('es', translations);
         $translateProvider.preferredLanguage('es');
       }]);
@@ -60,8 +60,8 @@ Fácil ¿no? Por supuesto, se puede ver una muestra andando aquí:
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'ENCABEZADO' | translate }}</p>
-      <p>{{ 'PARRAFO' | translate }}</p>
+      <p>{{ 'HEADLINE' | translate }}</p>
+      <p>{{ 'PARAGRAPH' | translate }}</p>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/04_using-translate-filter.ngdoc
+++ b/docs/content/guide/es/04_using-translate-filter.ngdoc
@@ -25,7 +25,7 @@ simplemente transfiriendo la lógica desde el controlador hacia nuestro filtro `
 El filtro funcionaría así:
 
 ```
-<ANY>{{ CLAVE_DE_TRADUCCION | translate }}</ANY>
+<ANY>{{ TRANSLATION_ID | translate }}</ANY>
 ```
 
 Así que, para actualizar nuestro ejemplo, quitamos el uso del servicio `$translate` de nuestro

--- a/docs/content/guide/es/05_using-translate-directive.ngdoc
+++ b/docs/content/guide/es/05_using-translate-directive.ngdoc
@@ -14,14 +14,14 @@ una directiva para traducir conenidos en la vista.
 La directiva `translate` puede utilizarse de muchas maneras distintas. Un
  uso general sería:
 ```
-<CUALQUIERTAG translate>CLAVE_DE_TRADUCCION<CUALQUIERTAG>
+<CUALQUIERTAG translate>TRANSLATION_ID<CUALQUIERTAG>
 ```
 
 También se puede pasar la clave de traducción como parámetro de una directiva `translate` que esté
  funcionando como atributo, de esta manera:
 
 ```
-<CUALQUIERTAG translate="CLAVE_DE_TRADUCCION"></CUALQUIERTAG>
+<CUALQUIERTAG translate="TRANSLATION_ID"></CUALQUIERTAG>
 ```
 
 Incluso si éstas son ya maneras muy flexibles de usar una directiva, angular-translate ofrece
@@ -52,7 +52,7 @@ la traducción en sí, no funcionará como debería.
 Este comportamiento puede ser habilitado con directivas:
 
 ```
-<CUALQUIERTAG translate="CLAVE_DE_TRADUCCION" translate-compile></CUALQUIERTAG>
+<CUALQUIERTAG translate="TRANSLATION_ID" translate-compile></CUALQUIERTAG>
 ```
 
 Además, se puede habilitar esta funcionalidad de manera global, utilizando:
@@ -64,7 +64,7 @@ $translateProvider.usePostCompiling(true);
 ... y entonces, aún se puede inhabilitar la funcionalidad directiva-por-directiva según haga falta:
 
 ```
-<CUALQUIERTAG translate="CLAVE_DE_TRADUCCION" translate-compile="false"></CUALQUIERTAG>
+<CUALQUIERTAG translate="TRANSLATION_ID" translate-compile="false"></CUALQUIERTAG>
 ```
 
 ## Ejemplo

--- a/docs/content/guide/es/05_using-translate-directive.ngdoc
+++ b/docs/content/guide/es/05_using-translate-directive.ngdoc
@@ -14,14 +14,14 @@ una directiva para traducir conenidos en la vista.
 La directiva `translate` puede utilizarse de muchas maneras distintas. Un
  uso general sería:
 ```
-<CUALQUIERTAG translate>TRANSLATION_ID<CUALQUIERTAG>
+<ANY translate>TRANSLATION_ID<ANY>
 ```
 
 También se puede pasar la clave de traducción como parámetro de una directiva `translate` que esté
  funcionando como atributo, de esta manera:
 
 ```
-<CUALQUIERTAG translate="TRANSLATION_ID"></CUALQUIERTAG>
+<ANY translate="TRANSLATION_ID"></ANY>
 ```
 
 Incluso si éstas son ya maneras muy flexibles de usar una directiva, angular-translate ofrece
@@ -33,13 +33,13 @@ Incluso si éstas son ya maneras muy flexibles de usar una directiva, angular-tr
 
 
 ```
-<CUALQUIERTAG translate="{{claveAInterpolar}}"></CUALQUIERTAG>
+<ANY translate="{{claveAInterpolar}}"></ANY>
 ```
 
 ¿No está bueno? Ah, y angular-translate no sería angular-translate si no pudiera también
 manipular de la misma forma nuestro primer ejemplo. Esto también funcionaría:
 ```
-<CUALQUIERTAG translate>{{claveAInterpolar}}</CUALQUIERTAG>
+<ANY translate>{{claveAInterpolar}}</ANY>
 ```
 
 ¡Elija la forma que más le convenga!
@@ -52,7 +52,7 @@ la traducción en sí, no funcionará como debería.
 Este comportamiento puede ser habilitado con directivas:
 
 ```
-<CUALQUIERTAG translate="TRANSLATION_ID" translate-compile></CUALQUIERTAG>
+<ANY translate="TRANSLATION_ID" translate-compile></ANY>
 ```
 
 Además, se puede habilitar esta funcionalidad de manera global, utilizando:
@@ -64,7 +64,7 @@ $translateProvider.usePostCompiling(true);
 ... y entonces, aún se puede inhabilitar la funcionalidad directiva-por-directiva según haga falta:
 
 ```
-<CUALQUIERTAG translate="TRANSLATION_ID" translate-compile="false"></CUALQUIERTAG>
+<ANY translate="TRANSLATION_ID" translate-compile="false"></ANY>
 ```
 
 ## Ejemplo

--- a/docs/content/guide/es/05_using-translate-directive.ngdoc
+++ b/docs/content/guide/es/05_using-translate-directive.ngdoc
@@ -14,14 +14,14 @@ una directiva para traducir conenidos en la vista.
 La directiva `translate` puede utilizarse de muchas maneras distintas. Un
  uso general sería:
 ```
-<ANY translate>TRANSLATION_ID</ANY>
+<CUALQUIERTAG translate>CLAVE_DE_TRADUCCION<CUALQUIERTAG>
 ```
 
 También se puede pasar la clave de traducción como parámetro de una directiva `translate` que esté
  funcionando como atributo, de esta manera:
 
 ```
-<ANY translate="TRANSLATION_ID"></ANY>
+<CUALQUIERTAG translate="CLAVE_DE_TRADUCCION"></CUALQUIERTAG>
 ```
 
 Incluso si éstas son ya maneras muy flexibles de usar una directiva, angular-translate ofrece
@@ -33,13 +33,13 @@ Incluso si éstas son ya maneras muy flexibles de usar una directiva, angular-tr
 
 
 ```
-<ANY translate="{{toBeInterpolated}}"></ANY>
+<CUALQUIERTAG translate="{{claveAInterpolar}}"></CUALQUIERTAG>
 ```
 
 ¿No está bueno? Ah, y angular-translate no sería angular-translate si no pudiera también
 manipular de la misma forma nuestro primer ejemplo. Esto también funcionaría:
 ```
-<ANY translate>{{toBeInterpolated}}</ANY>
+<CUALQUIERTAG translate>{{claveAInterpolar}}</CUALQUIERTAG>
 ```
 
 ¡Elija la forma que más le convenga!
@@ -52,7 +52,7 @@ la traducción en sí, no funcionará como debería.
 Este comportamiento puede ser habilitado con directivas:
 
 ```
-<ANY translate="TRANSLATION_ID" translate-compile></ANY>
+<CUALQUIERTAG translate="CLAVE_DE_TRADUCCION" translate-compile></CUALQUIERTAG>
 ```
 
 Además, se puede habilitar esta funcionalidad de manera global, utilizando:
@@ -64,7 +64,7 @@ $translateProvider.usePostCompiling(true);
 ... y entonces, aún se puede inhabilitar la funcionalidad directiva-por-directiva según haga falta:
 
 ```
-<ANY translate="TRANSLATION_ID" translate-compile="false"></ANY>
+<CUALQUIERTAG translate="CLAVE_DE_TRADUCCION" translate-compile="false"></CUALQUIERTAG>
 ```
 
 ## Ejemplo
@@ -75,24 +75,24 @@ podría verse así:
 
 <pre>
 var translations = {
-  HEADLINE: 'What an awesome module!',
-  PARAGRAPH: 'Srsly!',
-  PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
-  PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
-  PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!'
+  ENCABEZADO: '¡Qué módulo asombroso!',
+  PARRAFO: '¡En serio!'
+  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
+  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
+  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
 };
 </pre>
 
 Luego de lo cual, actualizamos nuesta vista con las nuevas claves de traducción:
 
 <pre>
-<p>{{ 'HEADLINE' | translate }}</p>
-<p>{{ 'PARAGRAPH' | translate }}</p>
+<p>{{ 'ENCABEZADO' | translate }}</p>
+<p>{{ 'PARRAFO' | translate }}</p>
 
-<p translate>PASSED_AS_TEXT</p>
-<p translate="PASSED_AS_ATTRIBUTE"></p>
-<p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
-<p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
+<p translate>PASADO_COMO_TEXTO</p>
+<p translate="PASADO_COMO_ATRIBUTO"></p>
+<p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
+<p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
 </pre>
 
 Nuestra aplicación actualizada ahora luce así:
@@ -101,11 +101,11 @@ Nuestra aplicación actualizada ahora luce así:
   <doc:source>
     <script>
       var translations = {
-        HEADLINE: 'What an awesome module!',
-        PARAGRAPH: 'Srsly!',
-        PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
-        PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
-        PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!'
+        ENCABEZADO: '¡Qué módulo asombroso!',
+        PARRAFO: '¡En serio!'
+        PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
+        PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
+        PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
       };
 
       var app = angular.module('myApp', ['pascalprecht.translate']);
@@ -113,8 +113,8 @@ Nuestra aplicación actualizada ahora luce así:
       app.config(['$translateProvider', function ($translateProvider) {
         // add translation table
         $translateProvider
-          .translations('en', translations)
-          .preferredLanguage('en');
+          .translations('es', translations)
+          .preferredLanguage('es');
       }]);
 
       app.controller('Ctrl', ['$scope', function ($scope) {
@@ -122,13 +122,13 @@ Nuestra aplicación actualizada ahora luce así:
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'HEADLINE' | translate }}</p>
-      <p>{{ 'PARAGRAPH' | translate }}</p>
+      <p>{{ 'ENCABEZADO' | translate }}</p>
+      <p>{{ 'PARRAFO' | translate }}</p>
 
-      <p translate>PASSED_AS_TEXT</p>
-      <p translate="PASSED_AS_ATTRIBUTE"></p>
-      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
-      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
+      <p translate>PASADO_COMO_TEXTO</p>
+      <p translate="PASADO_COMO_ATRIBUTO"></p>
+      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
+      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/05_using-translate-directive.ngdoc
+++ b/docs/content/guide/es/05_using-translate-directive.ngdoc
@@ -75,24 +75,24 @@ podría verse así:
 
 <pre>
 var translations = {
-  ENCABEZADO: '¡Qué módulo asombroso!',
-  PARRAFO: '¡En serio!'
-  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
-  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
-  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
+  HEADLINE: '¡Qué módulo asombroso!',
+  PARAGRAPH: '¡En serio!'
+  PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
+  PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
+  PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...'
 };
 </pre>
 
 Luego de lo cual, actualizamos nuesta vista con las nuevas claves de traducción:
 
 <pre>
-<p>{{ 'ENCABEZADO' | translate }}</p>
-<p>{{ 'PARRAFO' | translate }}</p>
+<p>{{ 'HEADLINE' | translate }}</p>
+<p>{{ 'PARAGRAPH' | translate }}</p>
 
-<p translate>PASADO_COMO_TEXTO</p>
-<p translate="PASADO_COMO_ATRIBUTO"></p>
-<p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
-<p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
+<p translate>PASSED_AS_TEXT</p>
+<p translate="PASSED_AS_ATTRIBUTE"></p>
+<p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
+<p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
 </pre>
 
 Nuestra aplicación actualizada ahora luce así:
@@ -101,11 +101,11 @@ Nuestra aplicación actualizada ahora luce así:
   <doc:source>
     <script>
       var translations = {
-        ENCABEZADO: '¡Qué módulo asombroso!',
-        PARRAFO: '¡En serio!'
-        PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
-        PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
-        PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
+        HEADLINE: '¡Qué módulo asombroso!',
+        PARAGRAPH: '¡En serio!',
+        PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
+        PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
+        PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...'
       };
 
       var app = angular.module('myApp', ['pascalprecht.translate']);
@@ -122,13 +122,13 @@ Nuestra aplicación actualizada ahora luce así:
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'ENCABEZADO' | translate }}</p>
-      <p>{{ 'PARRAFO' | translate }}</p>
+      <p>{{ 'HEADLINE' | translate }}</p>
+      <p>{{ 'PARAGRAPH' | translate }}</p>
 
-      <p translate>PASADO_COMO_TEXTO</p>
-      <p translate="PASADO_COMO_ATRIBUTO"></p>
-      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
-      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
+      <p translate>PASSED_AS_TEXT</p>
+      <p translate="PASSED_AS_ATTRIBUTE"></p>
+      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
+      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/06_variable-replacement.ngdoc
+++ b/docs/content/guide/es/06_variable-replacement.ngdoc
@@ -164,19 +164,19 @@ Si esta no es una funcionalidad "cool", entonces ninguna lo es.
 
 <pre>
 var translations = {
-  ENCABEZADO: '¡Qué módulo asombroso!',
-  PARRAFO: '¡En serio!',
-  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
-  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
-  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
-  REEMPLAZO_DE_VARIABLE: 'Hola, {{nombre}}'
+  HEADLINE: '¡Qué módulo asombroso!',
+  PARAGRAPH: '¡En serio!',
+  PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
+  PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
+  PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...'
+  VARIABLE_REPLACEMENT: 'Hola, {{nombre}}'
 };
 </pre>
 
 Seguidamente, pasemos un nombre mediante la directiva `translate`:
 
 <pre>
-<p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht' }"></p>
+<p translate="VARIABLE_REPLACEMENT" translate-values="{ nombre: 'PascalPrecht' }"></p>
 </pre>
 
 Y nuestro código en funcionamiento, ahora se ve así:
@@ -185,12 +185,12 @@ Y nuestro código en funcionamiento, ahora se ve así:
   <doc:source>
     <script>
       var translations = {
-        ENCABEZADO: '¡Qué módulo asombroso!',
-        PARRAFO: '¡En serio!'
-        PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
-        PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
-        PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
-        REEMPLAZO_DE_VARIABLE: 'Hola, {{nombre}}'
+        HEADLINE: '¡Qué módulo asombroso!',
+        PARAGRAPH: '¡En serio!',
+        PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
+        PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
+        PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...',
+        VARIABLE_REPLACEMENT: 'Hola, {{nombre}}'
       };
 
       var app = angular.module('myApp', ['pascalprecht.translate']);
@@ -207,15 +207,15 @@ Y nuestro código en funcionamiento, ahora se ve así:
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'ENCABEZADO' | translate }}</p>
-      <p>{{ 'PARRAFO' | translate }}</p>
+      <p>{{ 'HEADLINE' | translate }}</p>
+      <p>{{ 'PARAGRAPH' | translate }}</p>
 
-      <p translate>PASADO_COMO_TEXTO</p>
-      <p translate="PASADO_COMO_ATRIBUTO"></p>
-      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
-      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
-      <p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht'}"></p>
-      <p translate="REEMPLAZO_DE_VARIABLE" translate-value-nombre="PascalPrecht"></p>
+      <p translate>PASSED_AS_TEXT</p>
+      <p translate="PASSED_AS_ATTRIBUTE"></p>
+      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
+      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
+      <p translate="VARIABLE_REPLACEMENT" translate-values="{ nombre: 'PascalPrecht'}"></p>
+      <p translate="VARIABLE_REPLACEMENT" translate-value-nombre="PascalPrecht"></p>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/06_variable-replacement.ngdoc
+++ b/docs/content/guide/es/06_variable-replacement.ngdoc
@@ -29,7 +29,7 @@ Cuando se usa el servicio de interpolación por defacto de `angular-translate`, 
 
 ```
 {
-  "CLAVE_DE_TRADUCCION": "{{nombreUsuario}} se conectó."
+  "TRANSLATION_ID": "{{nombreUsuario}} se conectó."
 }
 ```
 
@@ -44,14 +44,14 @@ Como segundo parámetro, el servicio  `$translate` espera un objeto hash de Java
 se interpola la traducción. De modo que, si tenemos una traducción como la descrita arriba, para pasarle valores de
 `username` tendríamos que hacer lo siguiente:
 <pre>
-$translate('CLAVE_DE_TRADUCCION', { nombreUsuario: 'PascalPrecht' });
+$translate('TRANSLATION_ID', { nombreUsuario: 'PascalPrecht' });
 </pre>
 
 Si hay una clave de traducción que requiera más de un valor, simplemente extienda el objeto hash que se
 pasa, con los pares clave-valor correspondientes.
 
 <pre>
-$translate('CLAVE_DE_TRADUCCION, {
+$translate('TRANSLATION_ID, {
   nombreUsuario: 'PascalPrecht',
   ultimaConexion: '2013-07-21 6:50PM'
 });
@@ -69,7 +69,7 @@ como un objeto hash. Para lograr esto se requiere una sintaxis especial, porque 
  `$translate`.
 
 <pre>
-{{ 'CLAVE_DE_TRADUCCION' | translate:'{ nombreUsuario: "PascalPrecht" }' }}
+{{ 'TRANSLATION_ID' | translate:'{ nombreUsuario: "PascalPrecht" }' }}
 </pre>
 
 No es muy difícil ¿verdad? Pero ese `username` ¿no debería tener un valor constante, y a su vez ser interpolado
@@ -89,7 +89,7 @@ angular.module('myApp').controller('Ctrl', ['$scope', function ($scope) {
 y recién después pasarlos como expresión a través del filtro:
 
 <pre>
-{{ 'CLAVE_DE_TRADUCCION' | translate: datosDeLaTraduccion }}
+{{ 'TRANSLATION_ID' | translate: datosDeLaTraduccion }}
 </pre>
 
 ## Reemplazo de variables en la directiva translate
@@ -104,21 +104,21 @@ sale es un viejo y querido objeto Javascript, el cual a su vez le es pasado al s
 
 
 <pre>
-<CUALQUIERTAG translate="CLAVE_DE_TRADUCCION"
+<CUALQUIERTAG translate="TRANSLATION_ID"
      translate-values='{ nombreUsuario: "PascalPrect"}'></CUALQUIERTAG>
 </pre>
 
 o bien
 
 <pre>
-<CUALQUIERTAG translate="CLAVE_DE_TRADUCCION"
+<CUALQUIERTAG translate="TRANSLATION_ID"
      translate-values="{ nombreUsuario: someScopeObject.nombreUsuario }"></CUALQUIERTAG>
 </pre>
 
 o bien
 
 <pre>
-<CUALQUIERTAG translate="CLAVE_DE_TRADUCCION"
+<CUALQUIERTAG translate="TRANSLATION_ID"
      translate-values="{{datosDeLaTradducion}}"></CUALQUIERTAG>
 </pre>
 

--- a/docs/content/guide/es/06_variable-replacement.ngdoc
+++ b/docs/content/guide/es/06_variable-replacement.ngdoc
@@ -29,7 +29,7 @@ Cuando se usa el servicio de interpolación por defacto de `angular-translate`, 
 
 ```
 {
-  "TRANSLATION_ID": "{{nombreUsuario}} se conectó."
+  "TRANSLATION_ID": "{{userName}} se conectó."
 }
 ```
 
@@ -44,7 +44,7 @@ Como segundo parámetro, el servicio  `$translate` espera un objeto hash de Java
 se interpola la traducción. De modo que, si tenemos una traducción como la descrita arriba, para pasarle valores de
 `username` tendríamos que hacer lo siguiente:
 <pre>
-$translate('TRANSLATION_ID', { nombreUsuario: 'PascalPrecht' });
+$translate('TRANSLATION_ID', { userNameUsuario: 'PascalPrecht' });
 </pre>
 
 Si hay una clave de traducción que requiera más de un valor, simplemente extienda el objeto hash que se
@@ -52,7 +52,7 @@ pasa, con los pares clave-valor correspondientes.
 
 <pre>
 $translate('TRANSLATION_ID, {
-  nombreUsuario: 'PascalPrecht',
+  userName: 'PascalPrecht',
   ultimaConexion: '2013-07-21 6:50PM'
 });
 </pre>
@@ -69,7 +69,7 @@ como un objeto hash. Para lograr esto se requiere una sintaxis especial, porque 
  `$translate`.
 
 <pre>
-{{ 'TRANSLATION_ID' | translate:'{ nombreUsuario: "PascalPrecht" }' }}
+{{ 'TRANSLATION_ID' | translate:'{ userName: "PascalPrecht" }' }}
 </pre>
 
 No es muy difícil ¿verdad? Pero ese `username` ¿no debería tener un valor constante, y a su vez ser interpolado
@@ -81,7 +81,7 @@ No es muy difícil ¿verdad? Pero ese `username` ¿no debería tener un valor co
 angular.module('myApp').controller('Ctrl', ['$scope', function ($scope) {
 
   $scope.translationData = {
-    nombreUsuario: 'PascalPrecht'
+    userName: 'PascalPrecht'
   };
 }]);
 </pre>
@@ -89,7 +89,7 @@ angular.module('myApp').controller('Ctrl', ['$scope', function ($scope) {
 y recién después pasarlos como expresión a través del filtro:
 
 <pre>
-{{ 'TRANSLATION_ID' | translate: datosDeLaTraduccion }}
+{{ 'TRANSLATION_ID' | translate: translationData }}
 </pre>
 
 ## Reemplazo de variables en la directiva translate
@@ -105,21 +105,21 @@ sale es un viejo y querido objeto Javascript, el cual a su vez le es pasado al s
 
 <pre>
 <ANY translate="TRANSLATION_ID"
-     translate-values='{ nombreUsuario: "PascalPrect"}'></ANY>
+     translate-values='{ userName: "PascalPrect"}'></ANY>
 </pre>
 
 o bien
 
 <pre>
 <ANY translate="TRANSLATION_ID"
-     translate-values="{ nombreUsuario: someScopeObject.nombreUsuario }"></ANY>
+     translate-values="{ userName: someScopeObject.userName }"></ANY>
 </pre>
 
 o bien
 
 <pre>
 <ANY translate="TRANSLATION_ID"
-     translate-values="{{datosDeLaTradducion}}"></ANY>
+     translate-values="{{translationData}}"></ANY>
 </pre>
 
 ## Atributos personalizados (custom) para valores de traducción
@@ -138,7 +138,7 @@ Supongamos que tenemos la siguiente clave de traducción:
 
 <pre>
 {
-  "SALUDO": "Hola, me llamo {{nombre}}"
+  "SALUDO": "Hola, me llamo {{name}}"
 }
 </pre>
 
@@ -146,7 +146,7 @@ Y queremos traducirla mediante la impresionante directiva `translate`. Podemos h
  esta vez usaremos un atributo personalizado `translate-value-*` para pasar el valor. Así que haríamos lo siguiente:
 
 <pre>
-<p translate="SALUDO" translate-value-nombre="Pascal"></p>
+<p translate="SALUDO" translate-value-name="Pascal"></p>
 </pre>
 
 Todo lo que hay que hacer, es usar el prefijo `translate-value-` y agregar el nombre del identificador de la
@@ -155,7 +155,7 @@ Todo lo que hay que hacer, es usar el prefijo `translate-value-` y agregar el no
 Ah, por supuesto, también se puede usar con valores interpolados:
 
 <pre>
-<p translate="SALUDO" translate-value-nombre="{{nombre}}"></p>
+<p translate="SALUDO" translate-value-name="{{name}}"></p>
 </pre>
 
 Si esta no es una funcionalidad "cool", entonces ninguna lo es.
@@ -169,14 +169,14 @@ var translations = {
   PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
   PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
   PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...'
-  VARIABLE_REPLACEMENT: 'Hola, {{nombre}}'
+  VARIABLE_REPLACEMENT: 'Hola, {{name}}'
 };
 </pre>
 
 Seguidamente, pasemos un nombre mediante la directiva `translate`:
 
 <pre>
-<p translate="VARIABLE_REPLACEMENT" translate-values="{ nombre: 'PascalPrecht' }"></p>
+<p translate="VARIABLE_REPLACEMENT" translate-values="{ name: 'PascalPrecht' }"></p>
 </pre>
 
 Y nuestro código en funcionamiento, ahora se ve así:
@@ -190,7 +190,7 @@ Y nuestro código en funcionamiento, ahora se ve así:
         PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
         PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
         PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...',
-        VARIABLE_REPLACEMENT: 'Hola, {{nombre}}'
+        VARIABLE_REPLACEMENT: 'Hola, {{name}}'
       };
 
       var app = angular.module('myApp', ['pascalprecht.translate']);
@@ -214,8 +214,8 @@ Y nuestro código en funcionamiento, ahora se ve así:
       <p translate="PASSED_AS_ATTRIBUTE"></p>
       <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
       <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
-      <p translate="VARIABLE_REPLACEMENT" translate-values="{ nombre: 'PascalPrecht'}"></p>
-      <p translate="VARIABLE_REPLACEMENT" translate-value-nombre="PascalPrecht"></p>
+      <p translate="VARIABLE_REPLACEMENT" translate-values="{ name: 'PascalPrecht'}"></p>
+      <p translate="VARIABLE_REPLACEMENT" translate-value-name="PascalPrecht"></p>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/06_variable-replacement.ngdoc
+++ b/docs/content/guide/es/06_variable-replacement.ngdoc
@@ -104,22 +104,22 @@ sale es un viejo y querido objeto Javascript, el cual a su vez le es pasado al s
 
 
 <pre>
-<CUALQUIERTAG translate="TRANSLATION_ID"
-     translate-values='{ nombreUsuario: "PascalPrect"}'></CUALQUIERTAG>
+<ANY translate="TRANSLATION_ID"
+     translate-values='{ nombreUsuario: "PascalPrect"}'></ANY>
 </pre>
 
 o bien
 
 <pre>
-<CUALQUIERTAG translate="TRANSLATION_ID"
-     translate-values="{ nombreUsuario: someScopeObject.nombreUsuario }"></CUALQUIERTAG>
+<ANY translate="TRANSLATION_ID"
+     translate-values="{ nombreUsuario: someScopeObject.nombreUsuario }"></ANY>
 </pre>
 
 o bien
 
 <pre>
-<CUALQUIERTAG translate="TRANSLATION_ID"
-     translate-values="{{datosDeLaTradducion}}"></CUALQUIERTAG>
+<ANY translate="TRANSLATION_ID"
+     translate-values="{{datosDeLaTradducion}}"></ANY>
 </pre>
 
 ## Atributos personalizados (custom) para valores de traducción

--- a/docs/content/guide/es/06_variable-replacement.ngdoc
+++ b/docs/content/guide/es/06_variable-replacement.ngdoc
@@ -29,7 +29,7 @@ Cuando se usa el servicio de interpolación por defacto de `angular-translate`, 
 
 ```
 {
-  "TRANSLATION_ID": "{{username}} is logged in."
+  "CLAVE_DE_TRADUCCION": "{{nombreUsuario}} se conectó."
 }
 ```
 
@@ -44,16 +44,16 @@ Como segundo parámetro, el servicio  `$translate` espera un objeto hash de Java
 se interpola la traducción. De modo que, si tenemos una traducción como la descrita arriba, para pasarle valores de
 `username` tendríamos que hacer lo siguiente:
 <pre>
-$translate('TRANSLATION_ID', { username: 'PascalPrecht' });
+$translate('CLAVE_DE_TRADUCCION', { nombreUsuario: 'PascalPrecht' });
 </pre>
 
 Si hay una clave de traducción que requiera más de un valor, simplemente extienda el objeto hash que se
 pasa, con los pares clave-valor correspondientes.
 
 <pre>
-$translate('TRANSLATION_ID', {
-  username: 'PascalPrecht',
-  lastLogin: '2013-07-21 6:50PM'
+$translate('CLAVE_DE_TRADUCCION, {
+  nombreUsuario: 'PascalPrecht',
+  ultimaConexion: '2013-07-21 6:50PM'
 });
 </pre>
 
@@ -69,7 +69,7 @@ como un objeto hash. Para lograr esto se requiere una sintaxis especial, porque 
  `$translate`.
 
 <pre>
-{{ 'TRANSLATION_ID' | translate:'{ username: "PascalPrecht" }' }}
+{{ 'CLAVE_DE_TRADUCCION' | translate:'{ nombreUsuario: "PascalPrecht" }' }}
 </pre>
 
 No es muy difícil ¿verdad? Pero ese `username` ¿no debería tener un valor constante, y a su vez ser interpolado
@@ -81,7 +81,7 @@ No es muy difícil ¿verdad? Pero ese `username` ¿no debería tener un valor co
 angular.module('myApp').controller('Ctrl', ['$scope', function ($scope) {
 
   $scope.translationData = {
-    username: 'PascalPrecht'
+    nombreUsuario: 'PascalPrecht'
   };
 }]);
 </pre>
@@ -89,7 +89,7 @@ angular.module('myApp').controller('Ctrl', ['$scope', function ($scope) {
 y recién después pasarlos como expresión a través del filtro:
 
 <pre>
-{{ 'TRANSLATION_ID' | translate:translationData }}
+{{ 'CLAVE_DE_TRADUCCION' | translate: datosDeLaTraduccion }}
 </pre>
 
 ## Reemplazo de variables en la directiva translate
@@ -104,22 +104,22 @@ sale es un viejo y querido objeto Javascript, el cual a su vez le es pasado al s
 
 
 <pre>
-<ANY translate="TRANSLATION_ID"
-     translate-values='{ username: "PascalPrect"}'></ANY>
+<CUALQUIERTAG translate="CLAVE_DE_TRADUCCION"
+     translate-values='{ nombreUsuario: "PascalPrect"}'></CUALQUIERTAG>
 </pre>
 
 o bien
 
 <pre>
-<ANY translate="TRANSLATION_ID"
-     translate-values="{ username: someScopeObject.username }"></ANY>
+<CUALQUIERTAG translate="CLAVE_DE_TRADUCCION"
+     translate-values="{ nombreUsuario: someScopeObject.nombreUsuario }"></CUALQUIERTAG>
 </pre>
 
 o bien
 
 <pre>
-<ANY translate="TRANSLATION_ID"
-     translate-values="{{translationData}}"></ANY>
+<CUALQUIERTAG translate="CLAVE_DE_TRADUCCION"
+     translate-values="{{datosDeLaTradducion}}"></CUALQUIERTAG>
 </pre>
 
 ## Atributos personalizados (custom) para valores de traducción
@@ -138,7 +138,7 @@ Supongamos que tenemos la siguiente clave de traducción:
 
 <pre>
 {
-  "GREETING": "Hi, my name is {{name}}"
+  "SALUDO": "Hola, me llamo {{nombre}}"
 }
 </pre>
 
@@ -146,7 +146,7 @@ Y queremos traducirla mediante la impresionante directiva `translate`. Podemos h
  esta vez usaremos un atributo personalizado `translate-value-*` para pasar el valor. Así que haríamos lo siguiente:
 
 <pre>
-<p translate="GREETING" translate-value-name="Pascal"></p>
+<p translate="SALUDO" translate-value-nombre="Pascal"></p>
 </pre>
 
 Todo lo que hay que hacer, es usar el prefijo `translate-value-` y agregar el nombre del identificador de la
@@ -155,7 +155,7 @@ Todo lo que hay que hacer, es usar el prefijo `translate-value-` y agregar el no
 Ah, por supuesto, también se puede usar con valores interpolados:
 
 <pre>
-<p translate="GREETING" translate-value-name="{{name}}"></p>
+<p translate="SALUDO" translate-value-nombre="{{nombre}}"></p>
 </pre>
 
 Si esta no es una funcionalidad "cool", entonces ninguna lo es.
@@ -164,19 +164,19 @@ Si esta no es una funcionalidad "cool", entonces ninguna lo es.
 
 <pre>
 var translations = {
-  HEADLINE: 'What an awesome module!',
-  PARAGRAPH: 'Srsly!',
-  PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
-  PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
-  PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
-  VARIABLE_REPLACEMENT: 'Hi, {{name}}'
+  ENCABEZADO: '¡Qué módulo asombroso!',
+  PARRAFO: '¡En serio!',
+  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
+  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
+  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
+  REEMPLAZO_DE_VARIABLE: 'Hola, {{nombre}}'
 };
 </pre>
 
 Seguidamente, pasemos un nombre mediante la directiva `translate`:
 
 <pre>
-<p translate="VARIABLE_REPLACEMENT" translate-values="{ name: 'PascalPrecht' }"></p>
+<p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht' }"></p>
 </pre>
 
 Y nuestro código en funcionamiento, ahora se ve así:
@@ -185,21 +185,21 @@ Y nuestro código en funcionamiento, ahora se ve así:
   <doc:source>
     <script>
       var translations = {
-        HEADLINE: 'What an awesome module!',
-        PARAGRAPH: 'Srsly!',
-        PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
-        PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
-        PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
-        VARIABLE_REPLACEMENT: 'Hi, {{name}}'
+        ENCABEZADO: '¡Qué módulo asombroso!',
+        PARRAFO: '¡En serio!'
+        PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
+        PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
+        PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
+        REEMPLAZO_DE_VARIABLE: 'Hola, {{nombre}}'
       };
 
       var app = angular.module('myApp', ['pascalprecht.translate']);
 
       app.config(['$translateProvider', function ($translateProvider) {
-        // add translation table
+        // agregar la tabla de traducción
         $translateProvider
-          .translations('en', translations)
-          .preferredLanguage('en');
+          .translations('es', translations)
+          .preferredLanguage('es');
       }]);
 
       app.controller('Ctrl', ['$scope', function ($scope) {
@@ -207,15 +207,15 @@ Y nuestro código en funcionamiento, ahora se ve así:
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'HEADLINE' | translate }}</p>
-      <p>{{ 'PARAGRAPH' | translate }}</p>
+      <p>{{ 'ENCABEZADO' | translate }}</p>
+      <p>{{ 'PARRAFO' | translate }}</p>
 
-      <p translate>PASSED_AS_TEXT</p>
-      <p translate="PASSED_AS_ATTRIBUTE"></p>
-      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
-      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
-      <p translate="VARIABLE_REPLACEMENT" translate-values="{ name: 'PascalPrecht'}"></p>
-      <p translate="VARIABLE_REPLACEMENT" translate-value-name="PascalPrecht"></p>
+      <p translate>PASADO_COMO_TEXTO</p>
+      <p translate="PASADO_COMO_ATRIBUTO"></p>
+      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
+      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
+      <p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht'}"></p>
+      <p translate="REEMPLAZO_DE_VARIABLE" translate-value-nombre="PascalPrecht"></p>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/07_multi-language.ngdoc
+++ b/docs/content/guide/es/07_multi-language.ngdoc
@@ -9,9 +9,9 @@ En [Sustitución de variables](#/guide/06_variable-replacement) usted aprendió 
  toda la funcionalidad básica que proveen dichos servicios (usando en servicio de interpolación por defecto),
  ahora estamos listos para el siguiente nivel: **Soporte Multilenguaje**
 
-Por supuesto, está muy bueno saber cómo usar los componentes que provee angular-translate, pero
+Por supuesto, está muy bien saber cómo usar los componentes que provee angular-translate, pero
 las cosas se ponen realmente interesantes cuando se trata de enseñarle a su aplicación más de un
-lenguaje (lo cual es la razón para usar este módulo, en realidad).
+lenguaje (lo cual es la razón de ser de este módulo, en realidad).
 ¡Así que empecemos aprendiendo cómo agregar varias tablas de traducción a la vez!
 
 ## Enseñarle varios lenguajes a su aplicación
@@ -27,19 +27,19 @@ argumento a `$translations()`, le podemos pasar la clave de lenguaje como primer
 Así que agregar una tabla con clave se haría así:
 
 <pre>
-// registers translation table with language key 'en'
+// registra una clave de traducción para 'en' (inglés)
 $translateProvider.translations('en', {
-  GREETING: 'Hello world!'
+  SALUDO: 'Hello world!'
 });
 </pre>
 
-Ahora, para agregar una segunda tabla para otro lenguaje, digamos, alemán, simplemente haga lo mismo
+Ahora, para agregar una segunda tabla para otro lenguaje, digamos, castellano, simplemente haga lo mismo
 con una clave de lenguaje diferente:
 
 <pre>
-// registers translation table with language key 'de'
-$translateProvider.translations('de', {
-  GREETING: 'Hallo Welt!'
+// registra una clave de traducción para 'es' (español)
+$translateProvider.translations('es', {
+  SALUDO: '¡Hola, mundo!'
 });
 </pre>
 
@@ -56,8 +56,8 @@ lenguaje, la cual apunta a una tabla de traducción determinada. Así que, para 
 use alemán en lugar de inglés, extienda el código de esta manera:
 
 <pre>
-// tells angular-translate to use the German language
-$translateProvider.preferredLanguage('de');
+// le dice a angular-translate que use español
+$translateProvider.preferredLanguage('es');
 </pre>
 
 **Nota:** También se puede usar `$translateProvider.use()` para esto,
@@ -83,7 +83,7 @@ Entonces, en lugar de invocar `$translateProvider.preferredLanguage(langKey)`, u
  como esto:
 
 <pre>
-// try to find out preferred language by yourself
+// que intente encontrar el lenguaje preferido por sí mismo
 $translateProvider.determinePreferredLanguage();
 </pre>
 
@@ -95,7 +95,7 @@ Con esto se puede decidir en qué "tags" (etiquetas) de lenguaje se deberían tr
 
 <pre>
 $translateProvider
-  .uniformLanguageTag('bcp47') // enable BCP-47, must be before determinePreferredLanguage!
+  .uniformLanguageTag('bcp47') // habilitar BCP-47, lo cual debe hacerse antes que determinePreferredLanguage!
   .determinePreferredLanguage();
 </pre>
 
@@ -106,7 +106,7 @@ clave de lenguaje:
 <pre>
 $translateProvider.determinePreferredLanguage(function () {
   var preferredLangKey = '';
-  // some custom logic's going on in here
+  // acá iría código personalizado 
   return preferredLangKey;
 });
 </pre>
@@ -139,25 +139,25 @@ traducción para los botones que agregaremos más adelante:
 
 <pre>
 var translationsEN = {
-  HEADLINE: 'What an awesome module!',
-  PARAGRAPH: 'Srsly!',
-  PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
-  PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
-  PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
-  VARIABLE_REPLACEMENT: 'Hi {{name}}',
-  BUTTON_LANG_DE: 'German',
-  BUTTON_LANG_EN: 'English'
+  ENCABEZADO: 'What an awesome module!',
+  PARRAFO: 'Srsly!',
+  PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
+  PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
+  PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
+  REEMPLAZO_DE_VARIABLE: 'Hi {{name}}',
+  BOTON_LENGUAGJE_ES: 'Spanish',
+  BOTON_LENGUAGJE_EN: 'English'
 };
 
-var translationsDE= {
-  HEADLINE: 'Was für ein großartiges Modul!',
-  PARAGRAPH: 'Ernsthaft!',
-  PASSED_AS_TEXT: 'Hey! Ich wurde als text übergeben!',
-  PASSED_AS_ATTRIBUTE: 'Ich wurde als Attribut übergeben, cool oder?',
-  PASSED_AS_INTERPOLATION: 'Anfänger! Ich bin interpoliert!',
-  VARIABLE_REPLACEMENT: 'Hi {{name}}',
-  BUTTON_LANG_DE: 'Deutsch',
-  BUTTON_LANG_EN: 'Englisch'
+var translationsES= {
+  ENCABEZADO: '¡Qué módulo asombroso!',
+  PARRAFO: '¡En serio!',
+  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
+  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
+  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
+  REEMPLAZO_DE_VARIABLE: 'Hola {{nombre}}',
+  BOTON_LENGUAGJE_ES: 'Español',
+  BOTON_LENGUAGJE_EN: 'Inglés'
 };
 </pre>
 
@@ -166,7 +166,7 @@ y le decimos a angular-translate que use inglés como lenguaje por defecto.
 
 <pre>
 $translateProvider.translations('en', translationsEN);
-$translateProvider.translations('de', translationsDE);
+$translateProvider.translations('es', translationsES);
 $translateProvider.preferredLanguage('en');
 </pre>
 
@@ -175,7 +175,7 @@ agregamos un botón para cada lenguaje. También configuramos una directiva `ng-
 función que cambie el lenguaje:
 
 <pre>
-<button ng-click="changeLanguage('de')" translate="BUTTON_LANG_DE"></button>
+<button ng-click="changeLanguage('es')" translate="BUTTON_LANG_ES"></button>
 <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>
 </pre>
 
@@ -197,39 +197,37 @@ Et voilà! ¡Ahora tenemos una aplicación con soporte multilenguaje!
 <doc:example module="myApp">
   <doc:source>
     <script>
-      var translationsEN = {
-        HEADLINE: 'What an awesome module!',
-        PARAGRAPH: 'Srsly!',
-        PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
-        PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
-        PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
-        VARIABLE_REPLACEMENT: 'Hi {{name}}',
-        MISSING_TRANSLATION: 'Oops! I have not been translated into German...',
-        BUTTON_LANG_DE: 'German',
-        BUTTON_LANG_EN: 'English'
-      };
+		var translationsEN = {
+		  ENCABEZADO: 'What an awesome module!',
+		  PARRAFO: 'Srsly!',
+		  PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
+		  PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
+		  PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
+		  REEMPLAZO_DE_VARIABLE: 'Hi {{name}}',
+		  BOTON_LENGUAGJE_ES: 'Spanish',
+		  BOTON_LENGUAGJE_EN: 'English'
+		};
 
-      var translationsDE= {
-        HEADLINE: 'Was für ein großartiges Modul!',
-        PARAGRAPH: 'Ernsthaft!',
-        PASSED_AS_TEXT: 'Hey! Ich wurde als text übergeben!',
-        PASSED_AS_ATTRIBUTE: 'Ich wurde als Attribut übergeben, cool oder?',
-        PASSED_AS_INTERPOLATION: 'Anfänger! Ich bin interpoliert!',
-        VARIABLE_REPLACEMENT: 'Hi {{name}}',
-        // MISSING_TRANSLATION is ... missing :)
-        BUTTON_LANG_DE: 'Deutsch',
-        BUTTON_LANG_EN: 'Englisch'
-      };
+		var translationsES= {
+		  ENCABEZADO: '¡Qué módulo asombroso!',
+		  PARRAFO: '¡En serio!',
+		  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
+		  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
+		  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
+		  REEMPLAZO_DE_VARIABLE: 'Hola {{nombre}}',
+		  BOTON_LENGUAGJE_ES: 'Español',
+		  BOTON_LENGUAGJE_EN: 'Inglés'
+		};
 
-      var app = angular.module('myApp', ['pascalprecht.translate']);
+		var app = angular.module('myApp', ['pascalprecht.translate']);
 
-      app.config(['$translateProvider', function ($translateProvider) {
-        // add translation tables
-        $translateProvider.translations('en', translationsEN);
-        $translateProvider.translations('de', translationsDE);
-        $translateProvider.preferredLanguage('en');
-        $translateProvider.fallbackLanguage('en');
-      }]);
+		app.config(['$translateProvider', function ($translateProvider) {
+		// agregar las tablas de traducción
+		$translateProvider.translations('en', translationsEN);
+		$translateProvider.translations('es', translationsES);
+		$translateProvider.preferredLanguage('es');
+		$translateProvider.fallbackLanguage('en');
+		}]);
 
       app.controller('Ctrl', ['$translate', '$scope', function ($translate, $scope) {
 
@@ -239,18 +237,20 @@ Et voilà! ¡Ahora tenemos una aplicación con soporte multilenguaje!
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'HEADLINE' | translate }}</p>
-      <p>{{ 'PARAGRAPH' | translate }}</p>
+      <p>{{ 'ENCABEZADO' | translate }}</p>
+      <p>{{ 'PARRRAFO' | translate }}</p>
+      
+      <p translate>PASADO_COMO_TEXTO</p>
+      <p translate="PASADO_COMO_ATRIBUTO"></p>
+      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
+      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
+      <p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht'}"></p>
+      <p translate="REEMPLAZO_DE_VARIABLE" translate-value-nombre="PascalPrecht"></p>
 
-      <p translate>PASSED_AS_TEXT</p>
-      <p translate="PASSED_AS_ATTRIBUTE"></p>
-      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
-      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
-      <p translate="VARIABLE_REPLACEMENT" translate-values="{ name: 'PascalPrecht' }"></p>
-      <p translate>MISSING_TRANSLATION</p>
+      <p translate>TRADUCCION_NO_DISPONIBLE</p>
 
-      <button ng-click="changeLanguage('de')" translate="BUTTON_LANG_DE"></button>
-      <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>
+      <button ng-click="changeLanguage('es')" translate="BOTON_LENGUAGJE_ES"></button>
+      <button ng-click="changeLanguage('en')" translate="BOTON_LENGUAGJE_EN"></button>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/07_multi-language.ngdoc
+++ b/docs/content/guide/es/07_multi-language.ngdoc
@@ -197,27 +197,27 @@ Et voilà! ¡Ahora tenemos una aplicación con soporte multilenguaje!
 <doc:example module="myApp">
   <doc:source>
     <script>
-		var translationsEN = {
-		  HEADLINE: 'What an awesome module!',
-		  PARAGRAPH: 'Srsly!',
-		  PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
-		  PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
-		  PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
-		  VARIABLE_REPLACEMENT: 'Hi {{nombre}}',
-		  BUTTON_LANG_ES: 'Spanish',
-		  BUTTON_LANG_EN: 'English'
-		};
-
-		var translationsES= {
-		  HEADLINE: '¡Qué módulo asombroso!',
-		  PARAGRAPH: '¡En serio!',
-		  PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
-		  PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
-		  PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...',
-		  VARIABLE_REPLACEMENT: 'Hola {{nombre}}',
-		  BUTTON_LANG_ES: 'Español',
-		  BUTTON_LANG_EN: 'Inglés'
-		};
+        var translationsEN = {
+          HEADLINE: 'What an awesome module!',
+          PARAGRAPH: 'Srsly!',
+          PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
+          PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
+          PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
+          VARIABLE_REPLACEMENT: 'Hi {{nombre}}',
+          BUTTON_LANG_ES: 'Spanish',
+          BUTTON_LANG_EN: 'English'
+        };
+        
+        var translationsES= {
+          HEADLINE: '¡Qué módulo asombroso!',
+          PARAGRAPH: '¡En serio!',
+          PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
+          PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
+          PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...',
+          VARIABLE_REPLACEMENT: 'Hola {{nombre}}',
+          BUTTON_LANG_ES: 'Español',
+          BUTTON_LANG_EN: 'Inglés'
+        };
 
 		var app = angular.module('myApp', ['pascalprecht.translate']);
 

--- a/docs/content/guide/es/07_multi-language.ngdoc
+++ b/docs/content/guide/es/07_multi-language.ngdoc
@@ -139,25 +139,25 @@ traducción para los botones que agregaremos más adelante:
 
 <pre>
 var translationsEN = {
-  ENCABEZADO: 'What an awesome module!',
-  PARRAFO: 'Srsly!',
-  PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
-  PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
-  PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
-  REEMPLAZO_DE_VARIABLE: 'Hi {{name}}',
-  BOTON_LENGUAGJE_ES: 'Spanish',
-  BOTON_LENGUAGJE_EN: 'English'
+  HEADLINE: 'What an awesome module!',
+  PARAGRAPH: 'Srsly!',
+  PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
+  PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
+  PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
+  VARIABLE_REPLACEMENT: 'Hi {{name}}',
+  BUTTON_LANG_ES: 'Spanish',
+  BUTTON_LANG_EN: 'English'
 };
 
 var translationsES= {
-  ENCABEZADO: '¡Qué módulo asombroso!',
-  PARRAFO: '¡En serio!',
-  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
-  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
-  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
-  REEMPLAZO_DE_VARIABLE: 'Hola {{nombre}}',
-  BOTON_LENGUAGJE_ES: 'Español',
-  BOTON_LENGUAGJE_EN: 'Inglés'
+  HEADLINE: '¡Qué módulo asombroso!',
+  PARAGRAPH: '¡En serio!',
+  PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
+  PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
+  PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...'
+  VARIABLE_REPLACEMENT: 'Hola {{nombre}}',
+  BUTTON_LANG_ES: 'Español',
+  BUTTON_LANG_EN: 'Inglés'
 };
 </pre>
 
@@ -198,25 +198,25 @@ Et voilà! ¡Ahora tenemos una aplicación con soporte multilenguaje!
   <doc:source>
     <script>
 		var translationsEN = {
-		  ENCABEZADO: 'What an awesome module!',
-		  PARRAFO: 'Srsly!',
-		  PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
-		  PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
-		  PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
-		  REEMPLAZO_DE_VARIABLE: 'Hi {{name}}',
-		  BOTON_LENGUAGJE_ES: 'Spanish',
-		  BOTON_LENGUAGJE_EN: 'English'
+		  HEADLINE: 'What an awesome module!',
+		  PARAGRAPH: 'Srsly!',
+		  PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
+		  PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
+		  PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
+		  VARIABLE_REPLACEMENT: 'Hi {{nombre}}',
+		  BUTTON_LANG_ES: 'Spanish',
+		  BUTTON_LANG_EN: 'English'
 		};
 
 		var translationsES= {
-		  ENCABEZADO: '¡Qué módulo asombroso!',
-		  PARRAFO: '¡En serio!',
-		  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
-		  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
-		  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
-		  REEMPLAZO_DE_VARIABLE: 'Hola {{nombre}}',
-		  BOTON_LENGUAGJE_ES: 'Español',
-		  BOTON_LENGUAGJE_EN: 'Inglés'
+		  HEADLINE: '¡Qué módulo asombroso!',
+		  PARAGRAPH: '¡En serio!',
+		  PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
+		  PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
+		  PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...',
+		  VARIABLE_REPLACEMENT: 'Hola {{nombre}}',
+		  BUTTON_LANG_ES: 'Español',
+		  BUTTON_LANG_EN: 'Inglés'
 		};
 
 		var app = angular.module('myApp', ['pascalprecht.translate']);
@@ -237,20 +237,20 @@ Et voilà! ¡Ahora tenemos una aplicación con soporte multilenguaje!
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'ENCABEZADO' | translate }}</p>
-      <p>{{ 'PARRRAFO' | translate }}</p>
+      <p>{{ 'HEADLINE' | translate }}</p>
+      <p>{{ 'PARAGRAPH' | translate }}</p>
       
-      <p translate>PASADO_COMO_TEXTO</p>
-      <p translate="PASADO_COMO_ATRIBUTO"></p>
-      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
-      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
-      <p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht'}"></p>
-      <p translate="REEMPLAZO_DE_VARIABLE" translate-value-nombre="PascalPrecht"></p>
+      <p translate>PASSED_AS_TEXT</p>
+      <p translate="PASSED_AS_ATTRIBUTE"></p>
+      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
+      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
+      <p translate="VARIABLE_REPLACEMENT" translate-values="{ nombre: 'PascalPrecht'}"></p>
+      <p translate="VARIABLE_REPLACEMENT" translate-value-nombre="PascalPrecht"></p>
 
       <p translate>TRADUCCION_NO_DISPONIBLE</p>
 
-      <button ng-click="changeLanguage('es')" translate="BOTON_LENGUAGJE_ES"></button>
-      <button ng-click="changeLanguage('en')" translate="BOTON_LENGUAGJE_EN"></button>
+      <button ng-click="changeLanguage('es')" translate="BUTTON_LANG_ES"></button>
+      <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/08_fallback-languages.ngdoc
+++ b/docs/content/guide/es/08_fallback-languages.ngdoc
@@ -8,20 +8,20 @@ Ahora que ha leído que puede configurar un lenguaje preferido, y a la vez regis
 
 ## Registrar  un lenguaje de respaldo
 
-Enseñarle a su aplicación un lenguaje de respaldo es fácil: simplemente hay que invocar un método en `$translateProvider`. Sí, tan fácil como suena. Digamos que tenemos una aplicación y hemos registrado una tabla de traducción para el idioma alemán.
+Enseñarle a su aplicación un lenguaje de respaldo es fácil: simplemente hay que invocar un método en `$translateProvider`. Sí, tan fácil como suena. Digamos que tenemos una aplicación y hemos registrado una tabla de traducción para el idioma castellano.
 
 <pre>
 $translateProvider
-  .translations('de', { /* ... */ });
+  .translations('es', { /* ... */ });
 </pre>
 
-Ahora, digamos que existen algunas claves de traducción que **están** disponibles en inglés, pero no en  la tabla alemana. angular-translate normalmente devolvería sólo la clave si no puede encontrar una traducción. Pero si usted registra un lenguaje de respaldo que contenga la clave de traducción en su tabla, angular-translate devolverá esa traducción en lugar de la otra.
+Ahora, digamos que existen algunas claves de traducción que **están** disponibles en inglés, pero no en  la tabla española. angular-translate normalmente devolvería sólo la clave si no puede encontrar una traducción. Pero si usted registra un lenguaje de respaldo que contenga la clave de traducción en su tabla, angular-translate devolverá esa traducción en lugar de la otra.
 
-Así que, registremos inglés como el lenguaje de respaldo. Primero tenemos que registrar el lenguaje mismo, desde ya.
+Así que, registremos inglés como el lenguaje de respaldo. Primero tenemos que registrar el lenguaje mismo, desde luego.
 
 <pre>
 $translateProvider
-  .translations('de', { /* ... */ })
+  .translations('es', { /* ... */ })
   .translations('en', { /* ... */ });
 </pre>
 
@@ -29,12 +29,12 @@ Ahora le decimos a angular-translate que use inglés como lenguaje de respaldo:
 
 <pre>
 $translateProvider
-  .translations('de', { /* ... */ })
+  .translations('es', { /* ... */ })
   .translations('en', { /* ... */ })
   .fallbackLanguage('en');
 </pre>
 
-Y listo. Si no existe determinada clave en la tabla alemana, angular-translate buscará la misma clave en la tabla inglesa. Fácil, ¿no?
+Y listo. Si no existe determinada clave en la tabla castellana, angular-translate buscará la misma clave en la tabla inglesa. Fácil, ¿no?
 
 ## Registrar una pila de respaldo
 
@@ -43,7 +43,7 @@ Todo lo que hay que hacer, es registrar los lenguajes de respaldo como un array:
 
 <pre>
 $translateProvider
-  .translations('de', { /* ... */ })
+  .translations('es', { /* ... */ })
   .translations('en', { /* ... */ })
   .translations('fr', { /* ... */ })
   .fallbackLanguage(['en', 'fr']);
@@ -70,7 +70,7 @@ $scope.changeLanguage = function (langKey) {
 };
 </pre>
 
-Si usted hace cambios en la conjunto de lenguajes de respaldo en tiempo de ejecución, angular-translate se guiará por el orden en que las claves de lenguaje hayan sido especificadas para saber cómo iterar. Por ejemplo, si usted configuró `en, fr, de` como lenguajes de respaldo, y cambia el lenguaje de respaldo a `fr`, en este caso el lenguaje de respaldo de `fr` será `de`.
+Si usted hace cambios en la conjunto de lenguajes de respaldo en tiempo de ejecución, angular-translate se guiará por el orden en que las claves de lenguaje hayan sido especificadas para saber cómo iterar. Por ejemplo, si usted configuró `en, fr, es` como lenguajes de respaldo, y cambia el lenguaje de respaldo a `fr`, en este caso el lenguaje de respaldo de `fr` será `es`.
 
 ## Cambiar la pila entera de lenguajes de respaldo en tiempo de ejecución
 
@@ -78,7 +78,7 @@ Igual que antes, hay que hacer esto:
 
 <pre>
 $scope.changeLanguage = function (langKey) {
-  $translate.fallbackLanguage(['de', 'en', 'fr']);
+  $translate.fallbackLanguage(['es', 'en', 'fr']);
   $translate.use(langKey);
 };
 </pre>
@@ -88,12 +88,12 @@ Cuando se cambia la pila entera de lenguajes de respaldo, se está cambiando el 
 ## Limitar los lenguajes de respaldo a través de los que se itera
 
 Si seleccionamos una clave de lenguaje que no esté al principio de la pila, estaremos efectivamente limitando los lenguajes por los que se itere.
-Por ejemplo, si en el código siguiente configuramos 'en' como lenguaje de respaldo con `useFallbackLanguage()`, entonces 'de' será ignorado, nuestra pila comenzará a ser iterada a partir de 'en'.
+Por ejemplo, si en el código siguiente configuramos 'en' como lenguaje de respaldo con `useFallbackLanguage()`, entonces 'es' será ignorado, nuestra pila comenzará a ser iterada a partir de 'en'.
 
 <pre>
   // langKey is 'en'
   $scope.changeLanguage = function (langKey) {
-  $translate.fallbackLanguage(['de', 'en', 'fr']);
+  $translate.fallbackLanguage(['es', 'en', 'fr']);
   $translate.useFallbackLanguage(langKey);
 };
 </pre>

--- a/docs/content/guide/es/08_fallback-languages.ngdoc
+++ b/docs/content/guide/es/08_fallback-languages.ngdoc
@@ -91,7 +91,7 @@ Si seleccionamos una clave de lenguaje que no esté al principio de la pila, est
 Por ejemplo, si en el código siguiente configuramos 'en' como lenguaje de respaldo con `useFallbackLanguage()`, entonces 'es' será ignorado, nuestra pila comenzará a ser iterada a partir de 'en'.
 
 <pre>
-  // langKey is 'en'
+  // la clave de lenguaje (langKey) es 'en'
   $scope.changeLanguage = function (langKey) {
   $translate.fallbackLanguage(['es', 'en', 'fr']);
   $translate.useFallbackLanguage(langKey);

--- a/docs/content/guide/es/09_language-negotiation.ngdoc
+++ b/docs/content/guide/es/09_language-negotiation.ngdoc
@@ -4,14 +4,14 @@
 
 # Negociación de lenguajes
 
-angular-translate soporta una funcionalidad llamada "Negociación de lenguajes" (Language Negotiation), con la cual se puede declarar relaciones entre claves de lenguaje similares (por ejemplo, 'en_US' en lugar de 'en').
+angular-translate soporta una funcionalidad llamada "Negociación de lenguajes" (Language Negotiation), con la cual se puede declarar relaciones entre claves de lenguaje similares (por ejemplo, 'en_US', inglés de Estados Unidos, en lugar de 'en').
 
-¿Qué significa esto? Supongamos que usted tiene tablas de traducción con las claves de lenguaaje `en` y `de`.
+¿Qué significa esto? Supongamos que usted tiene tablas de traducción con las claves de lenguaaje `en` y `es`.
 
 <pre>
 $translateProvider
   .translations('en', { /* ... */ })
-  .translations('de', { /* ... */ });
+  .translations('es', { /* ... */ });
 </pre>
 
 .. y que también le dice a angular-translate que debería tratar de determinar el lenguaje preferido de su aplicación por sí solo, usando el método `.determinePreferredLanguage()`.
@@ -19,7 +19,7 @@ $translateProvider
 <pre>
 $translateProvider
   .translations('en', { /* ... */ })
-  .translations('de', { /* ... */ })
+  .translations('es', { /* ... */ })
   .determinePreferredLanguage();
 </pre>
 
@@ -38,11 +38,11 @@ Para el caso de uso que discutíamos anteriormente, el código quedaría así:
 $translateProvider
   .translations('en', { /* ... */ })
   .translations('de', { /* ... */ })
-  .registerAvailableLanguageKeys(['en', 'de'], {
+  .registerAvailableLanguageKeys(['en', 'es'], {
     'en_US': 'en',
     'en_UK': 'en',
-    'de_DE': 'de',
-    'de_CH': 'de'
+    'es_ES': 'es',
+    'es_AR': 'es'
   })
   .determinePreferredLanguage();
 </pre>

--- a/docs/content/guide/es/10_storages.ngdoc
+++ b/docs/content/guide/es/10_storages.ngdoc
@@ -65,25 +65,25 @@ Y listo. Su aplicación ahora usará localStorage para recordar el lenguaje del 
   <doc:source>
     <script>
 		var translationsEN = {
-		  ENCABEZADO: 'What an awesome module!',
-		  PARRAFO: 'Srsly!',
-		  PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
-		  PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
-		  PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
-		  REEMPLAZO_DE_VARIABLE: 'Hi {{name}}',
-		  BOTON_LENGUAGJE_ES: 'Spanish',
-		  BOTON_LENGUAGJE_EN: 'English'
+		  HEADLINE: 'What an awesome module!',
+		  PARAGRAPH: 'Srsly!',
+		  PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
+		  PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
+		  PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
+		  VARIABLE_REPLACEMENT: 'Hi {{nombre}}',
+		  BUTTON_LANG_ES: 'Spanish',
+		  BUTTON_LANG_EN: 'English'
 		};
 
 		var translationsES= {
-		  ENCABEZADO: '¡Qué módulo asombroso!',
-		  PARRAFO: '¡En serio!',
-		  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
-		  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
-		  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
-		  REEMPLAZO_DE_VARIABLE: 'Hola {{nombre}}',
-		  BOTON_LENGUAGJE_ES: 'Español',
-		  BOTON_LENGUAGJE_EN: 'Inglés'
+		  HEADLINE: '¡Qué módulo asombroso!',
+		  PARAGRAPH: '¡En serio!',
+		  PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
+		  PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
+		  PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...',
+		  VARIABLE_REPLACEMENT: 'Hola {{nombre}}',
+		  BUTTON_LANG_ES: 'Español',
+		  BUTTON_LANG_EN: 'Inglés'
 		};
 
 		var app = angular.module('myApp', ['ngCookies', 'pascalprecht.translate']);
@@ -105,18 +105,18 @@ Y listo. Su aplicación ahora usará localStorage para recordar el lenguaje del 
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'ENCABEZADO' | translate }}</p>
-      <p>{{ 'PARRRAFO' | translate }}</p>
+      <p>{{ 'HEADLINE' | translate }}</p>
+      <p>{{ 'PARAGRAPH' | translate }}</p>
       
-      <p translate>PASADO_COMO_TEXTO</p>
-      <p translate="PASADO_COMO_ATRIBUTO"></p>
-      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
-      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
-      <p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht'}"></p>
-      <p translate="REEMPLAZO_DE_VARIABLE" translate-value-nombre="PascalPrecht"></p>
+      <p translate>PASSED_AS_TEXT</p>
+      <p translate="PASSED_AS_ATTRIBUTE"></p>
+      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
+      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
+      <p translate="VARIABLE_REPLACEMENT" translate-values="{ nombre: 'PascalPrecht'}"></p>
+      <p translate="VARIABLE_REPLACEMENT" translate-value-nombre="PascalPrecht"></p>
       
-      <button ng-click="changeLanguage('es')" translate="BOTON_LENGUAJE_ES"></button>
-      <button ng-click="changeLanguage('en')" translate="BOTON_LENGUAJE_EN"></button>      
+      <button ng-click="changeLanguage('es')" translate="BUTTON_LANG_ES"></button>
+      <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>      
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/10_storages.ngdoc
+++ b/docs/content/guide/es/10_storages.ngdoc
@@ -70,7 +70,7 @@ Y listo. Su aplicación ahora usará localStorage para recordar el lenguaje del 
 		  PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
 		  PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
 		  PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
-		  VARIABLE_REPLACEMENT: 'Hi {{nombre}}',
+		  VARIABLE_REPLACEMENT: 'Hi {{name}}',
 		  BUTTON_LANG_ES: 'Spanish',
 		  BUTTON_LANG_EN: 'English'
 		};
@@ -81,7 +81,7 @@ Y listo. Su aplicación ahora usará localStorage para recordar el lenguaje del 
 		  PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
 		  PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
 		  PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...',
-		  VARIABLE_REPLACEMENT: 'Hola {{nombre}}',
+		  VARIABLE_REPLACEMENT: 'Hola {{name}}',
 		  BUTTON_LANG_ES: 'Español',
 		  BUTTON_LANG_EN: 'Inglés'
 		};
@@ -112,8 +112,7 @@ Y listo. Su aplicación ahora usará localStorage para recordar el lenguaje del 
       <p translate="PASSED_AS_ATTRIBUTE"></p>
       <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
       <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
-      <p translate="VARIABLE_REPLACEMENT" translate-values="{ nombre: 'PascalPrecht'}"></p>
-      <p translate="VARIABLE_REPLACEMENT" translate-value-nombre="PascalPrecht"></p>
+      <p translate="VARIABLE_REPLACEMENT" translate-values="{ name: 'PascalPrecht'}"></p>
       
       <button ng-click="changeLanguage('es')" translate="BUTTON_LANG_ES"></button>
       <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>      

--- a/docs/content/guide/es/10_storages.ngdoc
+++ b/docs/content/guide/es/10_storages.ngdoc
@@ -64,38 +64,38 @@ Y listo. Su aplicación ahora usará localStorage para recordar el lenguaje del 
 <doc:example module="myApp">
   <doc:source>
     <script>
-      var translationsEN = {
-        HEADLINE: 'What an awesome module!',
-        PARAGRAPH: 'Srsly!',
-        PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
-        PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
-        PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
-        VARIABLE_REPLACEMENT: 'Hi {{name}}',
-        BUTTON_LANG_DE: 'German',
-        BUTTON_LANG_EN: 'English'
-      };
+		var translationsEN = {
+		  ENCABEZADO: 'What an awesome module!',
+		  PARRAFO: 'Srsly!',
+		  PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
+		  PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
+		  PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
+		  REEMPLAZO_DE_VARIABLE: 'Hi {{name}}',
+		  BOTON_LENGUAGJE_ES: 'Spanish',
+		  BOTON_LENGUAGJE_EN: 'English'
+		};
 
-      var translationsDE= {
-        HEADLINE: 'Was für ein großartiges Modul!',
-        PARAGRAPH: 'Ernsthaft!',
-        PASSED_AS_TEXT: 'Hey! Ich wurde als text übergeben!',
-        PASSED_AS_ATTRIBUTE: 'Ich wurde als Attribut übergeben, cool oder?',
-        PASSED_AS_INTERPOLATION: 'Anfänger! Ich bin interpoliert!',
-        VARIABLE_REPLACEMENT: 'Hi {{name}}',
-        BUTTON_LANG_DE: 'Deutsch',
-        BUTTON_LANG_EN: 'Englisch'
-      };
+		var translationsES= {
+		  ENCABEZADO: '¡Qué módulo asombroso!',
+		  PARRAFO: '¡En serio!',
+		  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
+		  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
+		  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
+		  REEMPLAZO_DE_VARIABLE: 'Hola {{nombre}}',
+		  BOTON_LENGUAGJE_ES: 'Español',
+		  BOTON_LENGUAGJE_EN: 'Inglés'
+		};
 
-      var app = angular.module('myApp', ['ngCookies', 'pascalprecht.translate']);
+		var app = angular.module('myApp', ['ngCookies', 'pascalprecht.translate']);
 
-      app.config(['$translateProvider', function ($translateProvider) {
-        // add translation tables
-        $translateProvider.translations('en', translationsEN);
-        $translateProvider.translations('de', translationsDE);
-        $translateProvider.preferredLanguage('en');
-        // remember language
-        $translateProvider.useLocalStorage();
-      }]);
+		app.config(['$translateProvider', function ($translateProvider) {
+		  // agregar las tablas de traducción
+		  $translateProvider.translations('en', translationsEN);
+		  $translateProvider.translations('es', translationsES);
+		  $translateProvider.preferredLanguage('en');
+		  // recordar el idioma
+		  $translateProvider.useLocalStorage();
+		}]);
 
       app.controller('Ctrl', ['$translate', '$scope', function ($translate, $scope) {
 
@@ -105,17 +105,18 @@ Y listo. Su aplicación ahora usará localStorage para recordar el lenguaje del 
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'HEADLINE' | translate }}</p>
-      <p>{{ 'PARAGRAPH' | translate }}</p>
-
-      <p translate>PASSED_AS_TEXT</p>
-      <p translate="PASSED_AS_ATTRIBUTE"></p>
-      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
-      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
-      <p translate="VARIABLE_REPLACEMENT" translate-values="{ name: 'PascalPrecht' }"></p>
-
-      <button ng-click="changeLanguage('de')" translate="BUTTON_LANG_DE"></button>
-      <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>
+      <p>{{ 'ENCABEZADO' | translate }}</p>
+      <p>{{ 'PARRRAFO' | translate }}</p>
+      
+      <p translate>PASADO_COMO_TEXTO</p>
+      <p translate="PASADO_COMO_ATRIBUTO"></p>
+      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
+      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
+      <p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht'}"></p>
+      <p translate="REEMPLAZO_DE_VARIABLE" translate-value-nombre="PascalPrecht"></p>
+      
+      <button ng-click="changeLanguage('es')" translate="BOTON_LENGUAJE_ES"></button>
+      <button ng-click="changeLanguage('en')" translate="BOTON_LENGUAJE_EN"></button>      
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/11_custom-storages.ngdoc
+++ b/docs/content/guide/es/11_custom-storages.ngdoc
@@ -14,7 +14,7 @@ Si usted quiere usar un servicio de almacenamiento personalizado en su aplicaci�
 Digamos que usted quiere usar un servicio de almacenamiento personalizado en nuestra aplicación de ejemplo. Podemos fácilmente extenderla con un nuevo servicio. Sólo tenemos que asegurarnos de devolver un objeto con los métodos `get()` y `put()` method. Dicho servicio personalizado puede ser algo así:
 
 <pre>
-app.factory('almacenamientoPersinalizado', function () {
+app.factory('almacenamientoPersonalizado', function () {
   return {
     put: function (nombre, valor) {
       // almacenar `valor` bajo  `nombre` de alguna manera
@@ -35,7 +35,7 @@ Una vez que haya construido su servicio personalizado de almacenamiento, tiene q
 `useStorage()` internamente. También este último método puede usarse para informarle a angular-translate acerca de nuestro almacenamiento personalizado:
 
 <pre>
-$translateProvider.useStorage('customStorage');
+$translateProvider.useStorage('almacenamientoPersonalizado');
 </pre>
 
 angular-translate usará `$injector` para obtener una isntancia de la "factory" por su nombre, el cual en nuestro caso es `almacenamientoPersonalizado`, y luego será capaz de acceder a los métodos de ésta en tiempo de ejecución, para almacenar el último idioma elegido.
@@ -45,25 +45,25 @@ angular-translate usará `$injector` para obtener una isntancia de la "factory" 
   <doc:source>
     <script>
 		var translationsEN = {
-		  ENCABEZADO: 'What an awesome module!',
-		  PARRAFO: 'Srsly!',
-		  PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
-		  PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
-		  PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
-		  REEMPLAZO_DE_VARIABLE: 'Hi {{nombre}}',
-		  BOTON_LENGUAJE_ES: 'Spanish',
-		  BOTON_LENGUAJE_EN: 'English'
+		  HEADLINE: 'What an awesome module!',
+		  PARAGRAPH: 'Srsly!',
+		  PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
+		  PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
+		  PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
+		  VARIABLE_REPLACEMENT: 'Hi {{nombre}}',
+		  BUTTON_LANG_ES: 'Spanish',
+		  BUTTON_LANG_EN: 'English'
 		};
 
 		var translationsES= {
-		  ENCABEZADO: '¡Qué módulo asombroso!',
-		  PARRAFO: '¡En serio!',
-		  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
-		  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
-		  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
-		  REEMPLAZO_DE_VARIABLE: 'Hola {{nombre}}',
-		  BOTON_LENGUAJE_ES: 'Español',
-		  BOTON_LENGUAJE_EN: 'Inglés'
+		  HEADLINE: '¡Qué módulo asombroso!',
+		  PARAGRAPH: '¡En serio!',
+		  PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
+		  PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
+		  PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...',
+		  VARIABLE_REPLACEMENT: 'Hola {{nombre}}',
+		  BUTTON_LANG_ES: 'Español',
+		  BUTTON_LANG_EN: 'Inglés'
 		};
 
 		var app = angular.module('myApp', ['ngCookies', 'pascalprecht.translate']);
@@ -96,17 +96,17 @@ angular-translate usará `$injector` para obtener una isntancia de la "factory" 
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'ENCABEZADO' | translate }}</p>
-      <p>{{ 'PARRRAFO' | translate }}</p>
+      <p>{{ 'HEADLINE' | translate }}</p>
+      <p>{{ 'PARAGRAPH' | translate }}</p>
       
-      <p translate>PASADO_COMO_TEXTO</p>
-      <p translate="PASADO_COMO_ATRIBUTO"></p>
-      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
-      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
-      <p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht'}"></p>
+      <p translate>PASSED_AS_TEXT</p>
+      <p translate="PASSED_AS_ATTRIBUTE"></p>
+      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
+      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
+      <p translate="VARIABLE_REPLACEMENT" translate-values="{ nombre: 'PascalPrecht'}"></p>
 
-      <button ng-click="changeLanguage('es')" translate="BOTON_LENGUAJE_ES"></button>
-      <button ng-click="changeLanguage('en')" translate="BOTON_LENGUAJE_EN"></button>
+      <button ng-click="changeLanguage('es')" translate="BUTTON_LANG_ES"></button>
+      <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/11_custom-storages.ngdoc
+++ b/docs/content/guide/es/11_custom-storages.ngdoc
@@ -16,11 +16,11 @@ Digamos que usted quiere usar un servicio de almacenamiento personalizado en nue
 <pre>
 app.factory('almacenamientoPersonalizado', function () {
   return {
-    put: function (nombre, valor) {
-      // almacenar `valor` bajo  `nombre` de alguna manera
+    put: function (name, value) {
+      // almacenar `value` bajo  `name` de alguna manera
     },
     get: function (name) {
-      // pedir el valor de `nombre` de alguna manera
+      // pedir el valor de `name` de alguna manera
     }
   };
 });
@@ -50,7 +50,7 @@ angular-translate usará `$injector` para obtener una isntancia de la "factory" 
 		  PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
 		  PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
 		  PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
-		  VARIABLE_REPLACEMENT: 'Hi {{nombre}}',
+		  VARIABLE_REPLACEMENT: 'Hi {{name}}',
 		  BUTTON_LANG_ES: 'Spanish',
 		  BUTTON_LANG_EN: 'English'
 		};
@@ -61,7 +61,7 @@ angular-translate usará `$injector` para obtener una isntancia de la "factory" 
 		  PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
 		  PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
 		  PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...',
-		  VARIABLE_REPLACEMENT: 'Hola {{nombre}}',
+		  VARIABLE_REPLACEMENT: 'Hola {{name}}',
 		  BUTTON_LANG_ES: 'Español',
 		  BUTTON_LANG_EN: 'Inglés'
 		};
@@ -80,10 +80,10 @@ angular-translate usará `$injector` para obtener una isntancia de la "factory" 
 		app.factory('almacenamientoPersonalizado', function () {
 		  return {
 			  put: function (name, value) {
-				// almacenar `valor` bajo  `nombre` de alguna manera
+				// almacenar `value` bajo  `name` de alguna manera
 			  },
 			  get: function (name) {
-				// pedir el valor de `nombre` de alguna manera
+				// pedir el valor de `name` de alguna manera
 			  }
 		  };
 		});
@@ -103,7 +103,7 @@ angular-translate usará `$injector` para obtener una isntancia de la "factory" 
       <p translate="PASSED_AS_ATTRIBUTE"></p>
       <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
       <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
-      <p translate="VARIABLE_REPLACEMENT" translate-values="{ nombre: 'PascalPrecht'}"></p>
+      <p translate="VARIABLE_REPLACEMENT" translate-values="{ name: 'PascalPrecht'}"></p>
 
       <button ng-click="changeLanguage('es')" translate="BUTTON_LANG_ES"></button>
       <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>

--- a/docs/content/guide/es/11_custom-storages.ngdoc
+++ b/docs/content/guide/es/11_custom-storages.ngdoc
@@ -14,13 +14,13 @@ Si usted quiere usar un servicio de almacenamiento personalizado en su aplicaci�
 Digamos que usted quiere usar un servicio de almacenamiento personalizado en nuestra aplicación de ejemplo. Podemos fácilmente extenderla con un nuevo servicio. Sólo tenemos que asegurarnos de devolver un objeto con los métodos `get()` y `put()` method. Dicho servicio personalizado puede ser algo así:
 
 <pre>
-app.factory('customStorage', function () {
+app.factory('almacenamientoPersinalizado', function () {
   return {
-    put: function (name, value) {
-      // store `value` under `name` somehow
+    put: function (nombre, valor) {
+      // almacenar `valor` bajo  `nombre` de alguna manera
     },
     get: function (name) {
-      // request value of `name` somehow
+      // pedir el valor de `nombre` de alguna manera
     }
   };
 });
@@ -38,55 +38,55 @@ Una vez que haya construido su servicio personalizado de almacenamiento, tiene q
 $translateProvider.useStorage('customStorage');
 </pre>
 
-angular-translate usará `$injector` para obtener una isntancia de la "factory" por su nombre, el cual en nuestro caso es `customStorage`, y luego será capaz de acceder a los métodos de ésta en tiempo de ejecución, para almacenar el último idioma elegido.
+angular-translate usará `$injector` para obtener una isntancia de la "factory" por su nombre, el cual en nuestro caso es `almacenamientoPersonalizado`, y luego será capaz de acceder a los métodos de ésta en tiempo de ejecución, para almacenar el último idioma elegido.
 
 
 <doc:example module="myApp">
   <doc:source>
     <script>
-      var translationsEN = {
-        HEADLINE: 'What an awesome module!',
-        PARAGRAPH: 'Srsly!',
-        PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
-        PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
-        PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
-        VARIABLE_REPLACEMENT: 'Hi {{name}}',
-        BUTTON_LANG_DE: 'German',
-        BUTTON_LANG_EN: 'English'
-      };
+		var translationsEN = {
+		  ENCABEZADO: 'What an awesome module!',
+		  PARRAFO: 'Srsly!',
+		  PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
+		  PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
+		  PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
+		  REEMPLAZO_DE_VARIABLE: 'Hi {{nombre}}',
+		  BOTON_LENGUAJE_ES: 'Spanish',
+		  BOTON_LENGUAJE_EN: 'English'
+		};
 
-      var translationsDE= {
-        HEADLINE: 'Was für ein großartiges Modul!',
-        PARAGRAPH: 'Ernsthaft!',
-        PASSED_AS_TEXT: 'Hey! Ich wurde als text übergeben!',
-        PASSED_AS_ATTRIBUTE: 'Ich wurde als Attribut übergeben, cool oder?',
-        PASSED_AS_INTERPOLATION: 'Anfänger! Ich bin interpoliert!',
-        VARIABLE_REPLACEMENT: 'Hi {{name}}',
-        BUTTON_LANG_DE: 'Deutsch',
-        BUTTON_LANG_EN: 'Englisch'
-      };
+		var translationsES= {
+		  ENCABEZADO: '¡Qué módulo asombroso!',
+		  PARRAFO: '¡En serio!',
+		  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
+		  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
+		  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
+		  REEMPLAZO_DE_VARIABLE: 'Hola {{nombre}}',
+		  BOTON_LENGUAJE_ES: 'Español',
+		  BOTON_LENGUAJE_EN: 'Inglés'
+		};
 
-      var app = angular.module('myApp', ['ngCookies', 'pascalprecht.translate']);
+		var app = angular.module('myApp', ['ngCookies', 'pascalprecht.translate']);
 
-      app.config(['$translateProvider', function ($translateProvider) {
-        // add translation tables
-        $translateProvider.translations('en', translationsEN);
-        $translateProvider.translations('de', translationsDE);
-        $translateProvider.preferredLanguage('en');
-        // remember language
-        $translateProvider.useStorage('customStorage');
-      }]);
+		app.config(['$translateProvider', function ($translateProvider) {
+		  // agregar las tablas de traducción
+		  $translateProvider.translations('en', translationsEN);
+		  $translateProvider.translations('es', translationsES);
+		  $translateProvider.preferredLanguage('en');
+		  // recordar el idioma
+		  $translateProvider.useLocalStorage();
+		}]);
 
-      app.factory('customStorage', function () {
-        return {
-          put: function (name, value) {
-            // store `value` under `name` somehow
-          },
-          get: function (name) {
-            // request value of `name` somehow
-          }
-        };
-      });
+		app.factory('almacenamientoPersonalizado', function () {
+		  return {
+			  put: function (name, value) {
+				// almacenar `valor` bajo  `nombre` de alguna manera
+			  },
+			  get: function (name) {
+				// pedir el valor de `nombre` de alguna manera
+			  }
+		  };
+		});
 
       app.controller('Ctrl', ['$translate', '$scope', function ($translate, $scope) {
 
@@ -96,17 +96,17 @@ angular-translate usará `$injector` para obtener una isntancia de la "factory" 
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'HEADLINE' | translate }}</p>
-      <p>{{ 'PARAGRAPH' | translate }}</p>
+      <p>{{ 'ENCABEZADO' | translate }}</p>
+      <p>{{ 'PARRRAFO' | translate }}</p>
+      
+      <p translate>PASADO_COMO_TEXTO</p>
+      <p translate="PASADO_COMO_ATRIBUTO"></p>
+      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
+      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
+      <p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht'}"></p>
 
-      <p translate>PASSED_AS_TEXT</p>
-      <p translate="PASSED_AS_ATTRIBUTE"></p>
-      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
-      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
-      <p translate="VARIABLE_REPLACEMENT" translate-values="{ name: 'PascalPrecht' }"></p>
-
-      <button ng-click="changeLanguage('de')" translate="BUTTON_LANG_DE"></button>
-      <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>
+      <button ng-click="changeLanguage('es')" translate="BOTON_LENGUAJE_ES"></button>
+      <button ng-click="changeLanguage('en')" translate="BOTON_LENGUAJE_EN"></button>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/es/12_asynchronous-loading.ngdoc
@@ -88,7 +88,7 @@ $translateProvider.preferredLanguage('en');
 angular-translate concatenará la información dada con
 `{{prefix}}{{langKey}}{{suffix}}`. De manera que eso producirá `locale-en.json`. Y, de nuevo, como no hay ningún dato de traducción disponible todavía, se cargará automáticamente tan pronto sea posible.
 
-##Uso del partialLoader (cargador parcial)
+## Uso del partialLoader (cargador parcial)
 
 Cuando se tiene una aplicación grande y compleja, normalmente se la subdivide en varios submódulos. Por ejemplo, usted podría tener un módulo `appPrincipal`, el cual dependa de submódulos como `inicio` y `contactos`. Estos son sólo 2 submódulos, pero imagínese una aplicación realmente grande, que dependiere de 10 o 20 submódulos.
 
@@ -315,28 +315,28 @@ Vamos a usar staticFilesLoader. Primero, tenemos que extraer las tablas de tradu
 <pre>
 // locale-en.json
 {
-	ENCABEZADO: 'What an awesome module!',
-	PARRAFO: 'Srsly!',
-	PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
-	PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
-	PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
-	REEMPLAZO_DE_VARIABLE: 'Hi {{nombre}}',
-	BOTON_LENGUAJE_ES: 'Spanish',
-	BOTON_LENGUAJE_EN: 'English'
+	HEADLINE: 'What an awesome module!',
+	PARAGRAPH: 'Srsly!',
+	PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
+	PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
+	PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
+	VARIABLE_REPLACEMENT: 'Hi {{nombre}}',
+	BUTTON_LANG_ES: 'Spanish',
+	BUTTON_LANG_EN: 'English'
 }
 </pre>
 
 <pre>
 // locale-de.json
 {
-	ENCABEZADO: '¡Qué módulo asombroso!',
-	PARRAFO: '¡En serio!',
-	PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
-	PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
-	PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
-	REEMPLAZO_DE_VARIABLE: 'Hola {{nombre}}',
-	BOTON_LENGUAJE_ES: 'Español',
-	BOTON_LENGUAJE_EN: 'Inglés'
+	HEADLINE: '¡Qué módulo asombroso!',
+	PARAGRAPH: '¡En serio!',
+	PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
+	PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
+	PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...',
+	VARIABLE_REPLACEMENT: 'Hola {{nombre}}',
+	BUTTON_LANG_ES: 'Español',
+	BUTTON_LANG_EN: 'Inglés'
 }
 </pre>
 
@@ -387,14 +387,14 @@ Como no tenemos que hacer ningún cambio en nuestros controladores ni en nuestro
 
       app.config(['$translateProvider', function ($translateProvider) {
         $translateProvider.translations('en', {
-			ENCABEZADO: 'What an awesome module!',
-			PARRAFO: 'Srsly!',
-			PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
-			PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
-			PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
-			REEMPLAZO_DE_VARIABLE: 'Hi {{nombre}}',
-			BOTON_LENGUAJE_ES: 'Spanish',
-			BOTON_LENGUAJE_EN: 'English'
+			HEADLINE: 'What an awesome module!',
+			PARAGRAPH: 'Srsly!',
+			PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
+			PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
+			PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
+			VARIABLE_REPLACEMENT: 'Hi {{nombre}}',
+			BUTTON_LANG_ES: 'Spanish',
+			BUTTON_LANG_EN: 'English'
 		});
         // configures staticFilesLoader
         $translateProvider.useStaticFilesLoader({
@@ -412,17 +412,17 @@ Como no tenemos que hacer ningún cambio en nuestros controladores ni en nuestro
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'ENCABEZADO' | translate }}</p>
-      <p>{{ 'PARRRAFO' | translate }}</p>
+      <p>{{ 'HEADLINE' | translate }}</p>
+      <p>{{ 'PARAGRAPH' | translate }}</p>
       
-      <p translate>PASADO_COMO_TEXTO</p>
-      <p translate="PASADO_COMO_ATRIBUTO"></p>
-      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
-      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
-      <p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht'}"></p>
+      <p translate>PASSED_AS_TEXT</p>
+      <p translate="PASSED_AS_ATTRIBUTE"></p>
+      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
+      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
+      <p translate="VARIABLE_REPLACEMENT" translate-values="{ nombre: 'PascalPrecht'}"></p>
 
-      <button ng-click="changeLanguage('es')" translate="BOTON_LENGUAJE_ES"></button>
-      <button ng-click="changeLanguage('en')" translate="BOTON_LENGUAJE_EN"></button>
+      <button ng-click="changeLanguage('es')" translate="BUTTON_LANG_ES"></button>
+      <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/es/12_asynchronous-loading.ngdoc
@@ -26,14 +26,14 @@ Muy bien, una vez que el cargador está disponible, le tenemos que decir a angul
 Además, cuando usemos cargadores asincrónicos, tenemos que usar `$translateProvider.preferredLanguage()`, para indicarle a angular-translate para qué lenguaje tiene que cargar los datos de traducción.
 
 <pre>
-$translateProvider.useUrlLoader('foo/bar.json');
+$translateProvider.useUrlLoader('cualquier/cosa.json');
 $translateProvider.preferredLanguage('en');
 </pre>
 
 
 ¿Qué está pasando aquú? angular-translate usa la extensión para transforma la cadena dada en un verdadero cargador, capaz de ser invocado más adelante, en tiempo de ejecución, una vez que el servicio `$translate` sea instanciado. Además, al decirle a angular-translate que use la clave de lenguaje 'en', se agrega dicha clave como parámetro de la request que dicha cadena del cargador generará.
 
-Así que el ejemplo de recién generará una request `foo/bar.json?lang=en`.
+Así que el ejemplo de recién generará una request `cualquier/cosa.json?lang=en`.
 
 `angular-translate` también se da cuenta de cuándo no hay datos de traducción disponible al comienzo de la aplicación, e invocará automáticamente el cargador, tan pronto como se pueda.
 
@@ -75,10 +75,10 @@ $translateProvider.useStaticFilesLoader({
         prefix: 'locale-',
         suffix: '.json'
     }, {
-        prefix: '/absolute/path/to/locale-',
+        prefix: '/path/absoluto/a/locale-',
         suffix: '.json'
     }, {
-        prefix: 'another/path/to/locales/',
+        prefix: 'otro/path/absoluto/a/locales/',
         suffix: ''
     }]
 });
@@ -90,7 +90,7 @@ angular-translate concatenará la información dada con
 
 ##Uso del partialLoader (cargador parcial)
 
-Cuando se tiene una aplicación grande y compleja, normalmente se la subdivide en varios submódulos. Por ejemplo, usted podría tener un módulo `mainApp`, el cual dependa de submódulos como `home` y `contact`. Estos son sólo 2 submódulos, pero imagínese una aplicación realmente grande, que dependiere de 10 o 20 submódulos.
+Cuando se tiene una aplicación grande y compleja, normalmente se la subdivide en varios submódulos. Por ejemplo, usted podría tener un módulo `appPrincipal`, el cual dependa de submódulos como `inicio` y `contactos`. Estos son sólo 2 submódulos, pero imagínese una aplicación realmente grande, que dependiere de 10 o 20 submódulos.
 
 En una aplicación así, probablemente 13 de los 20 submódulos no se ejecuten casi nunca. En esos casos, ¿para qué cargar una gran cantidad de datos de traducción que nunca serán utilizados?
 
@@ -108,15 +108,15 @@ $ bower install angular-translate-loader-partial
 
 Cuando se use `partialLoader`, hay que prever qué patrón tendría que utilizar
 `angular-translate` para cargar los datos de su aplicación. Es similar a lo que pasa con
-`staticFilesLoader`, pero un poco más específico. Hay que especificar una `part` (que es una "parte" específica de su aplicación, por ejemplo 'home') y un `lang` (que es la clave de lenguaje).
+`staticFilesLoader`, pero un poco más específico. Hay que especificar una `part` (que es una "parte" específica de su aplicación, por ejemplo 'inicio') y un `lang` (que es la clave de lenguaje).
 
 Suponga que usted ya tiene sus archivos de traducción estructurados de esta manera:
 
 ```
-/i18n/home/en.json
-/i18n/home/de.json
-/i18n/contact/en.json
-/i18n/contact/de.json
+/i18n/inicio/en.json
+/i18n/inicio/de.json
+/i18n/contactos/en.json
+/i18n/contactos/de.json
 ```
 
 Prolijito, ¿no? Ahora que sabemos cómo están estructurados nuestros datos, podemos configurar un `$translateProvider` que use carga parcial de la siguiente manera:
@@ -147,7 +147,7 @@ angular.module('main')
 Ahora, para decirle a `angular-translate` qué parte debe cargar, usamos el método `addPart()` de `$translatePartialLoaderProvider`:
 
 <pre>
-$translatePartialLoaderProvider.addPart('home');
+$translatePartialLoaderProvider.addPart('incio');
 $translateProvider.useLoader('$translatePartialLoader', {
   urlTemplate: '/i18n/{part}/{lang}.json'
 });
@@ -164,9 +164,9 @@ Así como se puede agregar una "parte" de traducción vía el provider, también
 Supongamos que usted tiene un `ContactCtrl` dentro del módulo  `contact`, lo cual se vería así:
 
 <pre>
-angular.module('contact')
+angular.module('contactos')
 .controller('ContactCtrl', function ($scope, $translatePartialLoader) {
-  $translatePartialLoader.addPart('contact');
+  $translatePartialLoader.addPart('contactos');
 });
 </pre>
 
@@ -178,9 +178,9 @@ Lo que está pasando aquí, es que estamos manipuando el estado de nuestros carg
 Así que lo único que tenemos que hacer es agregar lo siguiente:
 
 <pre>
-angular.module('contact')
+angular.module('contactos')
 .controller('ContactCtrl', function ($scope, $translatePartialLoader, $translate) {
-  $translatePartialLoader.addPart('contact');
+  $translatePartialLoader.addPart('contactos');
   $translate.refresh();
 });
 </pre>
@@ -217,7 +217,7 @@ He aquí un simple ejemplo de manipulador de errores (error handler):
 angular.module('translation')
 .factory('MyErrorHandler', function ($q, $log) {
   return function (part, lang) {
-    $log.error('The "' + part + '/' + lang + '" part was not loaded.');
+    $log.error('La sección "' + part + '/' + lang + '" no fue cargada.');
     return $q.when({});
   };
 });
@@ -248,7 +248,7 @@ Cada cargador puede tener `opciones` de configuración dedicadas, tanto para el 
 
 <pre>
 $translateProvider.useLoader('customLoader', {
-  settingA: 'foobar'
+  settingA: 'cualquierCosa'
 });
 $translateProvider.useStaticFilesLoader({
   $http: {
@@ -279,10 +279,10 @@ $translateProvider.useLoaderCache(yourSpecialCacheService);
 Angular-Translate también soporta vinculación diferida (lazy binding) para las instancias, de manera que esto también funcionaría:
 
 <pre>
-$translateProvider.useLoaderCache('yourSpecialCacheService');
+$translateProvider.useLoaderCache('suServicioEspecialDeCache');
 </pre>
 
-La instancia nombrada con el ID `yourspecialCacheService` será buscada "on demand".
+La instancia nombrada con el ID `suServicioEspecialDeCache` se buscará "a pedido".
 
 ## Destello del contenido no traducido  (o FOUC - "Flash of untranslated content", por sus siglas en inglés)
 
@@ -315,40 +315,40 @@ Vamos a usar staticFilesLoader. Primero, tenemos que extraer las tablas de tradu
 <pre>
 // locale-en.json
 {
-  "HEADLINE": "What an awesome module!",
-  "PARAGRAPH": "Srsly!",
-  "PASSED_AS_TEXT": "Hey there! I'm passed as text value!",
-  "PASSED_AS_ATTRIBUTE": "I'm passed as attribute value, cool ha?",
-  "PASSED_AS_INTERPOLATION": "Beginners! I'm interpolated!",
-  "VARIABLE_REPLACEMENT": "Hi {{name}}",
-  "BUTTON_LANG_DE": "German",
-  "BUTTON_LANG_EN": "English"
+	ENCABEZADO: 'What an awesome module!',
+	PARRAFO: 'Srsly!',
+	PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
+	PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
+	PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
+	REEMPLAZO_DE_VARIABLE: 'Hi {{nombre}}',
+	BOTON_LENGUAJE_ES: 'Spanish',
+	BOTON_LENGUAJE_EN: 'English'
 }
 </pre>
 
 <pre>
 // locale-de.json
 {
-  "HEADLINE": "Was für ein großartiges Modul!",
-  "PARAGRAPH": "Ernsthaft!",
-  "PASSED_AS_TEXT": "Hey! Ich wurde als text übergeben!",
-  "PASSED_AS_ATTRIBUTE": "Ich wurde als Attribut übergeben, cool oder?",
-  "PASSED_AS_INTERPOLATION": "Anfänger! Ich bin interpoliert!",
-  "VARIABLE_REPLACEMENT": "Hi {{name}}",
-  "BUTTON_LANG_DE": "deutsch",
-  "BUTTON_LANG_EN": "englisch"
+	ENCABEZADO: '¡Qué módulo asombroso!',
+	PARRAFO: '¡En serio!',
+	PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
+	PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
+	PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
+	REEMPLAZO_DE_VARIABLE: 'Hola {{nombre}}',
+	BOTON_LENGUAJE_ES: 'Español',
+	BOTON_LENGUAJE_EN: 'Inglés'
 }
 </pre>
 
 Luego configuramos el servicio `$translate` usando `$translateProvider`:
 
 <pre>
-// configures staticFilesLoader
+// configurar staticFilesLoader
 $translateProvider.useStaticFilesLoader({
   prefix: 'data/locale-',
   suffix: '.json'
 });
-// load 'en' table on startup
+// carga la tabla 'en' al comenzar
 $translateProvider.preferredLanguage('en');
 </pre>
 
@@ -362,7 +362,7 @@ de esta manera:
 
 <pre>
 $translateProvider.translations('en', {
-    'HELLO_TEXT': 'Hello World!'
+    'TEXTO_HOLA': 'Hello World!'
 });
 $translateProvider.useStaticFilesLoader({
     'prefix': 'locale-',
@@ -387,15 +387,15 @@ Como no tenemos que hacer ningún cambio en nuestros controladores ni en nuestro
 
       app.config(['$translateProvider', function ($translateProvider) {
         $translateProvider.translations('en', {
-          "HEADLINE": "What an awesome module!",
-          "PARAGRAPH": "Srsly!",
-          "PASSED_AS_TEXT": "Hey there! I'm passed as text value!",
-          "PASSED_AS_ATTRIBUTE": "I'm passed as attribute value, cool ha?",
-          "PASSED_AS_INTERPOLATION": "Beginners! I'm interpolated!",
-          "VARIABLE_REPLACEMENT": "Hi {{name}}",
-          "BUTTON_LANG_DE": "German",
-          "BUTTON_LANG_EN": "English"
-        });
+			ENCABEZADO: 'What an awesome module!',
+			PARRAFO: 'Srsly!',
+			PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
+			PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
+			PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
+			REEMPLAZO_DE_VARIABLE: 'Hi {{nombre}}',
+			BOTON_LENGUAJE_ES: 'Spanish',
+			BOTON_LENGUAJE_EN: 'English'
+		});
         // configures staticFilesLoader
         $translateProvider.useStaticFilesLoader({
           prefix: 'data/locale-',
@@ -406,31 +406,30 @@ Como no tenemos que hacer ningún cambio en nuestros controladores ni en nuestro
       }]);
 
       app.controller('Ctrl', ['$translate', '$scope', function ($translate, $scope) {
-
         $scope.changeLanguage = function (langKey) {
           $translate.use(langKey);
         };
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'HEADLINE' | translate }}</p>
-      <p>{{ 'PARAGRAPH' | translate }}</p>
+      <p>{{ 'ENCABEZADO' | translate }}</p>
+      <p>{{ 'PARRRAFO' | translate }}</p>
+      
+      <p translate>PASADO_COMO_TEXTO</p>
+      <p translate="PASADO_COMO_ATRIBUTO"></p>
+      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
+      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
+      <p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht'}"></p>
 
-      <p translate>PASSED_AS_TEXT</p>
-      <p translate="PASSED_AS_ATTRIBUTE"></p>
-      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
-      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
-      <p translate="VARIABLE_REPLACEMENT" translate-values="{ name: 'PascalPrecht' }"></p>
-
-      <button ng-click="changeLanguage('de')" translate="BUTTON_LANG_DE"></button>
-      <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>
+      <button ng-click="changeLanguage('es')" translate="BOTON_LENGUAJE_ES"></button>
+      <button ng-click="changeLanguage('en')" translate="BOTON_LENGUAJE_EN"></button>
     </div>
   </doc:source>
 </doc:example>
 
-Open up your browser's devtools and take a look at the network activities when changing
-the language. Our app now loads translation data asynchronously! In the next
-chapter you'll learn how to build **your own custom loaders**.
+Abra las "devtools" de su navegador y échele un vistazo a la actividad de red cuando se cambia el lenguaje.
+¡Ahora nuestra aplicación ahora carga datos asincrónicamente!
+En el próximo capítulo aprenderá cómo crear **sus propios cargadores**
 
 <br>
 <hr>

--- a/docs/content/guide/es/13_custom-loaders.ngdoc
+++ b/docs/content/guide/es/13_custom-loaders.ngdoc
@@ -71,25 +71,25 @@ app.factory('cargadorAsincronico', function ($q, $timeout) {
 
     if (options.key === 'en') {
       translations = {
-        HEADLINE: 'What an awesome module!',
-        PARAGRAPH: 'Srsly!',
-        PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
-        PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
-        PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
-        VARIABLE_REPLACEMENT: 'Hi {{name}}',
-        BUTTON_LANG_DE: 'German',
-        BUTTON_LANG_EN: 'English'
+      	HEADLINE: 'What an awesome module!',
+      	PARAGRAPH: 'Srsly!',
+      	PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
+      	PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
+      	PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
+      	VARIABLE_REPLACEMENT: 'Hi {{nombre}}',
+      	BUTTON_LANG_ES: 'Spanish',
+      	BUTTON_LANG_EN: 'English'
       };
     } else {
       translations = {
-        HEADLINE: 'Was für ein großartiges Modul!',
-        PARAGRAPH: 'Ernsthaft!',
-        PASSED_AS_TEXT: 'Hey! Ich wurde als text übergeben!',
-        PASSED_AS_ATTRIBUTE: 'Ich wurde als Attribut übergeben, cool oder?',
-        PASSED_AS_INTERPOLATION: 'Anfänger! Ich bin interpoliert!',
-        VARIABLE_REPLACEMENT: 'Hi {{name}}',
-        BUTTON_LANG_DE: 'Deutsch',
-        BUTTON_LANG_EN: 'Englisch'
+      	HEADLINE: '¡Qué módulo asombroso!',
+      	PARAGRAPH: '¡En serio!',
+      	PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
+      	PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
+      	PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...',
+      	VARIABLE_REPLACEMENT: 'Hola {{nombre}}',
+      	BUTTON_LANG_ES: 'Español',
+      	BUTTON_LANG_EN: 'Inglés'
       };
     }
 
@@ -102,7 +102,7 @@ app.factory('cargadorAsincronico', function ($q, $timeout) {
 });
 </pre>
 
-¿Qué es lo que hace, esto? Utiliza el servicio `$timeout` para esperar 2 segundos, y luego resuelve la promesa con la tabla de traducción inglesa o la alemana, dependiendo de la clave de lenguaje.
+¿Qué es lo que hace, esto? Utiliza el servicio `$timeout` para esperar 2 segundos, y luego resuelve la promesa con la tabla de traducción inglesa o castellana, dependiendo de la clave de lenguaje.
 
 Ahora utulice `$translateProvider.useLoader()` para hacer uso de nuestro servicio:
 
@@ -130,25 +130,25 @@ $translateProvider.useLoader('asyncLoader');
 
           if (options.key === 'en') {
             translations = {
-			  ENCABEZADO: 'What an awesome module!',
-			  PARRAFO: 'Srsly!',
-			  PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
-			  PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
-			  PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
-			  REEMPLAZO_DE_VARIABLE: 'Hi {{nombre}}',
-			  BOTON_LENGUAJE_ES: 'Spanish',
-			  BOTON_LENGUAJE_EN: 'English'
+      			  HEADLINE: 'What an awesome module!',
+      			  PARAGRAPH: 'Srsly!',
+      			  PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
+      			  PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
+      			  PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
+      			  VARIABLE_REPLACEMENT: 'Hi {{nombre}}',
+      			  BUTTON_LANG_ES: 'Spanish',
+      			  BUTTON_LANG_EN: 'English'
             };
           } else {
             translations = {
-			  ENCABEZADO: '¡Qué módulo asombroso!',
-			  PARRAFO: '¡En serio!',
-			  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
-			  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
-			  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
-			  REEMPLAZO_DE_VARIABLE: 'Hola {{nombre}}',
-			  BOTON_LENGUAJE_ES: 'Español',
-			  BOTON_LENGUAJE_EN: 'Inglés'
+      			  HEADLINE: '¡Qué módulo asombroso!',
+      			  PARAGRAPH: '¡En serio!',
+      			  PASSED_AS_TEXT: 'Hola, me están pasando como un texto',
+      			  PASSED_AS_ATTRIBUTE: 'Me están pasando como atributo, ¡qué bueno!',
+      			  PASSED_AS_INTERPOLATION: '¡Aprendices! A mí me están interpolando ...'
+      			  VARIABLE_REPLACEMENT: 'Hola {{nombre}}',
+      			  BUTTON_LANG_ES: 'Español',
+      			  BUTTON_LANG_EN: 'Inglés'
             };
           }
 
@@ -168,17 +168,16 @@ $translateProvider.useLoader('asyncLoader');
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'ENCABEZADO' | translate }}</p>
-      <p>{{ 'PARRRAFO' | translate }}</p>
-      
-      <p translate>PASADO_COMO_TEXTO</p>
-      <p translate="PASADO_COMO_ATRIBUTO"></p>
-      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
-      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
-      <p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht'}"></p>
+      <p>{{ 'HEADLINE' | translate }}</p>
+      <p>{{ 'PARAGRAPH' | translate }}</p>
+      <p translate>PASSED_AS_TEXT</p>
+      <p translate="PASSED_AS_ATTRIBUTE"></p>
+      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
+      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
+      <p translate="VARIABLE_REPLACEMENT" translate-values="{ nombre: 'PascalPrecht'}"></p>
 
-      <button ng-click="changeLanguage('es')" translate="BOTON_LENGUAJE_ES"></button>
-      <button ng-click="changeLanguage('en')" translate="BOTON_LENGUAJE_EN"></button>
+      <button ng-click="changeLanguage('es')" translate="BUTTON_LANG_ES"></button>
+      <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>
     </div>
   </doc:source>
 </doc:example>

--- a/docs/content/guide/es/13_custom-loaders.ngdoc
+++ b/docs/content/guide/es/13_custom-loaders.ngdoc
@@ -17,19 +17,19 @@ Si ninguno de los cargadores porvistos se ajusta a sus necesidades, usted puede 
 Una factory de cargador personalizado podría verse así:
 
 <pre>
-app.factory('customLoader', function ($http, $q) {
+app.factory('cargadorPersonalizado', function ($http, $q) {
     // return loaderFn
     return function (options) {
         var deferred = $q.defer();
-        // do something with $http, $q and key to load localization files
+        // hacer algo con $http, $q y la clave, para cargar archivos de localización
 
         var data = {
-            'TEXT': 'Fooooo'
+            'TEXTO': 'Algo ...'
         };
 
-        // resolve with translation data
+        // resolver con datos de traducción
         return deferred.resolve(data);
-        // or reject with language key
+        // o rechazar, con la clave de traducción
         return deferred.reject(options.key);
     };
 });
@@ -43,18 +43,19 @@ Usted sabe que `$translateProvider` provee métodos como `useStaticFilesLoader()
 `useUrlLoader()`, y que ambos usan `useLoader()` internamente para registrar una "factory" de carga, la cual luego es invocada por el `$injector`. Puede usar el mismo mecanismo para su servicio personalizado; así que, para registrar su servicio personalizado, simplemente ponga:
 
 <pre>
-$translateProvider.useLoader('customLoader');
+$translateProvider.useLoader('cargadorPersonalizado');
 </pre>
 
 angular-translate accede a la factory de su cargador personalizado con el servicio `$injector`, y se encarga de todo el resto por usted.
+
 ## Agregado de opciones adicionales
 
 La propiedad `options.key` nos dice que `options` es simplemente un objeto, el cual se podría extender con propiedades adicionales según sus necesidades. Por ejemplo, si usted necesita una propiedad `foo` en el objeto `options`, todo lo que tiene que hacer es proveer dicha propiedad cuando registre su factory de carga personalizada.
 
-Así que, si nuestra propiedad `foo` necesita un valor `bar`, podemos pasarlo así:
+Así que, si nuestra propiedad `juan` necesita un valor `perico`, podemos pasarlo así:
 
 <pre>
-$translateProvider.useLoader('customLoader', { foo: 'bar'});
+$translateProvider.useLoader('cargadorPersonalizado', { juan: 'perico'});
 </pre>
 
 Entonces, en su factory de carga, se puede acceder a esta propiedad via `options.foo`. No se preocupe por `options.key`, dado que esta última es agregada internamente por angular-translate antes de invocar el cargador.
@@ -62,7 +63,7 @@ Entonces, en su factory de carga, se puede acceder a esta propiedad via `options
 Hagamos uso del cargador personalizado en nuestra aplicación de ejemplo, para demostrar cómo funcionan las cosas. Primero construimos nuestro cargador así:
 
 <pre>
-app.factory('asyncLoader', function ($q, $timeout) {
+app.factory('cargadorAsincronico', function ($q, $timeout) {
 
   return function (options) {
     var deferred = $q.defer(),
@@ -121,7 +122,7 @@ $translateProvider.useLoader('asyncLoader');
         $translateProvider.useLoader('asyncLoader');
       }]);
 
-      app.factory('asyncLoader', function ($q, $timeout) {
+      app.factory('cargadorAsincronico', function ($q, $timeout) {
 
         return function (options) {
           var deferred = $q.defer(),
@@ -129,25 +130,25 @@ $translateProvider.useLoader('asyncLoader');
 
           if (options.key === 'en') {
             translations = {
-              HEADLINE: 'What an awesome module!',
-              PARAGRAPH: 'Srsly!',
-              PASSED_AS_TEXT: 'Hey there! I\'m passed as text value!',
-              PASSED_AS_ATTRIBUTE: 'I\'m passed as attribute value, cool ha?',
-              PASSED_AS_INTERPOLATION: 'Beginners! I\'m interpolated!',
-              VARIABLE_REPLACEMENT: 'Hi {{name}}',
-              BUTTON_LANG_DE: 'German',
-              BUTTON_LANG_EN: 'English'
+			  ENCABEZADO: 'What an awesome module!',
+			  PARRAFO: 'Srsly!',
+			  PASADO_COMO_TEXTO: 'Hey there! I\'m passed as text value!',
+			  PASADO_COMO_ATRIBUTO: 'I\'m passed as attribute value, cool ha?',
+			  PASADO_COMO_INTERPOLACION: 'Beginners! I\'m interpolated!',
+			  REEMPLAZO_DE_VARIABLE: 'Hi {{nombre}}',
+			  BOTON_LENGUAJE_ES: 'Spanish',
+			  BOTON_LENGUAJE_EN: 'English'
             };
           } else {
             translations = {
-              HEADLINE: 'Was für ein großartiges Modul!',
-              PARAGRAPH: 'Ernsthaft!',
-              PASSED_AS_TEXT: 'Hey! Ich wurde als text übergeben!',
-              PASSED_AS_ATTRIBUTE: 'Ich wurde als Attribut übergeben, cool oder?',
-              PASSED_AS_INTERPOLATION: 'Anfänger! Ich bin interpoliert!',
-              VARIABLE_REPLACEMENT: 'Hi {{name}}',
-              BUTTON_LANG_DE: 'Deutsch',
-              BUTTON_LANG_EN: 'Englisch'
+			  ENCABEZADO: '¡Qué módulo asombroso!',
+			  PARRAFO: '¡En serio!',
+			  PASADO_COMO_TEXTO: 'Hola, me están pasando como un texto',
+			  PASADO_COMO_ATRIBUTO: 'Me están pasando como atributo, ¡qué bueno!',
+			  PASADO_COMO_INTERPOLACION: '¡Aprendices! A mí me están interpolando ...'
+			  REEMPLAZO_DE_VARIABLE: 'Hola {{nombre}}',
+			  BOTON_LENGUAJE_ES: 'Español',
+			  BOTON_LENGUAJE_EN: 'Inglés'
             };
           }
 
@@ -167,22 +168,22 @@ $translateProvider.useLoader('asyncLoader');
       }]);
     </script>
     <div ng-controller="Ctrl">
-      <p>{{ 'HEADLINE' | translate }}</p>
-      <p>{{ 'PARAGRAPH' | translate }}</p>
+      <p>{{ 'ENCABEZADO' | translate }}</p>
+      <p>{{ 'PARRRAFO' | translate }}</p>
+      
+      <p translate>PASADO_COMO_TEXTO</p>
+      <p translate="PASADO_COMO_ATRIBUTO"></p>
+      <p translate>{{ 'PASADO_COMO_INTERPOLACION' }}</p>
+      <p translate="{{ 'PASADO_COMO_INTERPOLACION' }}"></p>
+      <p translate="REEMPLAZO_DE_VARIABLE" translate-values="{ nombre: 'PascalPrecht'}"></p>
 
-      <p translate>PASSED_AS_TEXT</p>
-      <p translate="PASSED_AS_ATTRIBUTE"></p>
-      <p translate>{{ 'PASSED_AS_INTERPOLATION' }}</p>
-      <p translate="{{ 'PASSED_AS_INTERPOLATION' }}"></p>
-      <p translate="VARIABLE_REPLACEMENT" translate-values="{ name: 'PascalPrecht' }"></p>
-
-      <button ng-click="changeLanguage('de')" translate="BUTTON_LANG_DE"></button>
-      <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>
+      <button ng-click="changeLanguage('es')" translate="BOTON_LENGUAJE_ES"></button>
+      <button ng-click="changeLanguage('en')" translate="BOTON_LENGUAJE_EN"></button>
     </div>
   </doc:source>
 </doc:example>
 
-Cuando se cambia el lenguaje apretando en el botón `alemán`, se puede ver que la aplicación espera 2 segundos hasta que se resuelve con los nuevos datos de traducción. ¿No está genial?
+Cuando se cambia el lenguaje apretando en el botón `Español`, se puede ver que la aplicación espera 2 segundos hasta que se resuelve con los nuevos datos de traducción. ¿No está genial?
 
 <br>
 <hr>

--- a/docs/content/guide/es/14_pluralization.ngdoc
+++ b/docs/content/guide/es/14_pluralization.ngdoc
@@ -4,9 +4,9 @@
 
 # Pluralización
 
-¡Guau, que hemos llegado lejos! Hemos aprendido todo acerca de los componentes que angular-translate provee, y sabemos cómo introducir varias tablas de traducción a la vez. También hemos hecho uso de distintos tipos de almacenamiento para que nuestra aplicación recuerde el lenguaje a lo largo de varios llamados http, y, finalmente pero no en último lugar, hemos usado cargadores asincrónicos, para cargar nuestros datos de traducción asincrónicamente desde un servidor. ¡Guau!
+¡Guau, hemos llegado lejos! Hemos aprendido todo acerca de los componentes que angular-translate provee, y sabemos cómo introducir varias tablas de traducción a la vez. También hemos hecho uso de distintos tipos de almacenamiento para que nuestra aplicación recuerde el lenguaje a lo largo de varios llamados http, y, finalmente pero no en último lugar, hemos usado cargadores asincrónicos, para cargar nuestros datos de traducción asincrónicamente desde un servidor. ¡Guau!
 
-Pero hay algo de lo que no hemos hablado todavía: **pluralización**. 
+Pero hay algo de lo que no hemos hablado todavía: **pluralización**.
 La pluralización es un tema bastante difícil cuando se trata de localización (l10n) e internationalización (i18n).
 Diferentes culturas y lenguajes tienen intepretaciones distintas acerca de cómo un lenguaje de comporta en determinadas situaciones. Por fortuna, hay un
 [estándar](http://userguide.icu-project.org/formatparse/messages) que especifica todo este asunto. Lo cual no quita que es un desafío implementarlo.
@@ -121,37 +121,37 @@ El servicio `$translate` espera el tipo de interpolación como tercer parámetro
 
 <pre>
 $translate('TEXT', { val: 5 });
-// "I'm using default interpolation 10"
+// "Estoy usando la interpolación por defecto 10"
 
 $translate('PLURAL', { GENDER: 'male' }, 'messageformat');
-// "He liked this."
+// "A él le gusta esto."
 </pre>
 
 Se puede obtener el mismo resultado con el filtro `translate`. Como se explicó antes, el tercer argumento es un identificador del tipo de servicio de interpolación:
 
 <pre>
 {{ 'TEXT' | translate:"{ val: 5 }" }}
-// "I'm using default interpolation 10"
+// "Estoy usando la interpolación por defecto 10"
 {{ 'PLURAL' | translate:"{ GENDER: 'male' }":"messageformat" }}
-// "He liked this."
+// "A él le gusta esto."
 </pre>
 
 La directiva `translate` espera un nuevo atributo llamado `translate-interpolation`, el cual controla cuál servicio de interpolación se usa para una clave de traducción determinada:
 
 <pre>
-<ANY
+<CUALQUIERTAG
   translate="TEXT"
-  translate-values="{ val: 5 }"></ANY>
-// "I'm using default interpolation 10"
+  translate-values="{ val: 5 }"></CUALQUIERTAG>
+// "Estoy usando la interpolación por defecto 10"
 
-<ANY
+<CUALQUIERTAG
   translate="PLURAL"
   translate-values="{ GENDER: 'male' }"
-  translate-interpolation="messageformat"></ANY>
-// "He liked this."
+  translate-interpolation="messageformat"></CUALQUIERTAG>
+// "A él le gusta esto."
 </pre>
 
-Aquí hay un ejemplo en funcionamiento (por favor, note que también hay un archivo embebido para la localización 'de' en alemán):
+Aquí hay un ejemplo en funcionamiento (por favor, note que también hay un archivo embebido para la localización 'es' en castellano):
 
 <doc:example module="myApp">
   <doc:source>
@@ -164,18 +164,18 @@ Aquí hay un ejemplo en funcionamiento (por favor, note que también hay un arch
 
         $translateProvider.translations('en', {
           HEADLINE: 'I\'m a headline',
-          TEXT: 'I\'m using default interpolation {{ val + val }}',
+          TEXTO: 'I\'m using default interpolation {{ val + val }}',
           PLURAL: '{GENDER, select, male{He} female{She} other{They}} liked this.',
           BUTTON_LANG_EN: 'English',
-          BUTTON_LANG_DE: 'German'
+          BUTTON_LANG_ES: 'Spanish'
         });
 
-        $translateProvider.translations('de', {
-          HEADLINE: 'Ich bin eine Überschrift',
-          TEXT: 'Ich benutze default interpolation {{ val + val }}',
-          PLURAL: '{GENDER, select, male{Er fand} female{Sie fand} other{Sie fanden}} es gut.',
-          BUTTON_LANG_EN: 'Englisch',
-          BUTTON_LANG_DE: 'Deutsch'
+        $translateProvider.translations('es', {
+          HEADLINE: 'Soy un encabezado',
+          TEXTO: 'Estoy usando la interpolación por defecto {{ val + val }}',
+          PLURAL: '{GENDER, select, male{A él le} female{A ella le} other{A ellos les}} gusta esto.',
+          BUTTON_LANG_EN: 'Inglés',
+          BUTTON_LANG_ES: 'Español'
         });
       }]);
 
@@ -188,11 +188,11 @@ Aquí hay un ejemplo en funcionamiento (por favor, note que también hay un arch
     </script>
     <div ng-controller="Ctrl">
       <p translate="HEADLINE"></p>
-      <p translate="TEXT" translate-values="{ val: 5 }"></p>
+      <p translate="TEXTO" translate-values="{ val: 5 }"></p>
 
       <p translate="PLURAL" translate-values="{ GENDER: 'other' }" translate-interpolation="messageformat"></p>
 
-      <button ng-click="changeLanguage('de')" translate="BUTTON_LANG_DE"></button>
+      <button ng-click="changeLanguage('es')" translate="BUTTON_LANG_ES"></button>
       <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>
     </div>
   </doc:source>

--- a/docs/content/guide/es/14_pluralization.ngdoc
+++ b/docs/content/guide/es/14_pluralization.ngdoc
@@ -139,15 +139,15 @@ Se puede obtener el mismo resultado con el filtro `translate`. Como se explicó 
 La directiva `translate` espera un nuevo atributo llamado `translate-interpolation`, el cual controla cuál servicio de interpolación se usa para una clave de traducción determinada:
 
 <pre>
-<CUALQUIERTAG
+<ANY
   translate="TEXT"
-  translate-values="{ val: 5 }"></CUALQUIERTAG>
+  translate-values="{ val: 5 }"></ANY>
 // "Estoy usando la interpolación por defecto 10"
 
-<CUALQUIERTAG
+<ANY
   translate="PLURAL"
   translate-values="{ GENDER: 'male' }"
-  translate-interpolation="messageformat"></CUALQUIERTAG>
+  translate-interpolation="messageformat"></ANY>
 // "A él le gusta esto."
 </pre>
 

--- a/docs/content/guide/es/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/es/15_custom-interpolators.ngdoc
@@ -19,7 +19,7 @@ Cuando cree un serivcio de interpolación personalizado, hay muchas cosa que ya 
 Veamos cómo se vería si implementáramos un servicio de interpolación personalizado. Primero, simplemente implementemos la interfaz:
 
 <pre>
-app.factory('customInterpolation', function () {
+app.factory('interpolacionPersonalizada', function () {
 
   return {
 
@@ -38,10 +38,10 @@ app.factory('customInterpolation', function () {
 });
 </pre>
 
-Muy bien, esta es la estructura básica del servicio de interpolación. Ahora, agreguemos algo de lógica, de manera que angular-translate pueda hacer uso de ella una vez que incorporemos nuestro serrvicio de interpolación:
+Muy bien, esta es la estructura básica del servicio de interpolación. Ahora, agreguemos algo de lógica, de manera que angular-translate pueda hacer uso de ella una vez que incorporemos nuestro servicio de interpolación:
 
 <pre>
-app.factory('customInterpolation', function ($interpolate) {
+app.factory('interpolacionPersonalizada', function ($interpolate) {
 
   var $locale;
 
@@ -71,13 +71,13 @@ Así como hay métodos para almacenamientos (`useStorage()`) y  cargadores (`use
 en su aplicación.
 
 <pre>
-$translateProvider.useInterpolation('customInterpolation');
+$translateProvider.useInterpolation('interpolacionPersonalizada');
 </pre>
 
 Ahora su aplicación utiliza su interpolación personalizada por defecto. Sin embargo, como aprendió en capítulos anteriores, puede agregar su interpolación personalizada como opcional, para no perder las útiles funcionalidades de Angular:
 
 <pre>
-$translateProvider.addInterpolation('customInterpolation');
+$translateProvider.addInterpolation('interpolacionPersonalizada');
 </pre>
 
 Así es como se vería:
@@ -89,22 +89,22 @@ Así es como se vería:
 
       app.config(['$translateProvider', function ($translateProvider) {
         $translateProvider.preferredLanguage('en');
-        $translateProvider.useInterpolation('customInterpolation');
+        $translateProvider.useInterpolation('interpolacionPersonalizada');
 
         $translateProvider.translations('en', {
           HEADLINE: 'I\'m a headline',
           TEXT: 'I\'m using default interpolation {{ val + val }}',
           PLURAL: '{GENDER, select, male{He} female{She} other{They}} liked this.',
           BUTTON_LANG_EN: 'English',
-          BUTTON_LANG_DE: 'German'
+          BUTTON_LANG_ES: 'Spanish'
         });
 
-        $translateProvider.translations('de', {
-          HEADLINE: 'Ich bin eine Überschrift',
-          TEXT: 'Ich benutze default interpolation {{ val + val }}',
-          PLURAL: '{GENDER, select, male{Er fand} female{Sie fand} other{Sie fanden}} es gut.',
-          BUTTON_LANG_EN: 'Englisch',
-          BUTTON_LANG_DE: 'Deutsch'
+        $translateProvider.translations('es', {
+          HEADLINE: 'Soy un encabezado',
+          TEXT: 'Uso la interpolación por defecto {{ val + val }}',
+          PLURAL: '{GENDER, select, male{A él le} female{A ella le} other{A ellos les}} gusta esto.',
+          BUTTON_LANG_EN: 'Inglés',
+          BUTTON_LANG_ES: 'Español'
         });
       }]);
 
@@ -115,7 +115,7 @@ Así es como se vería:
         };
       }]);
 
-      app.factory('customInterpolation', function ($interpolate) {
+      app.factory('interpolacionPersonalizada', function ($interpolate) {
 
         var $locale;
 
@@ -140,7 +140,7 @@ Así es como se vería:
       <p translate="HEADLINE"></p>
       <p translate="TEXT" translate-values="{ val: 5 }"></p>
 
-      <button ng-click="changeLanguage('de')" translate="BUTTON_LANG_DE"></button>
+      <button ng-click="changeLanguage('es')" translate="BUTTON_LANG_ES"></button>
       <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>
     </div>
   </doc:source>

--- a/docs/content/guide/es/16_error-handling.ngdoc
+++ b/docs/content/guide/es/16_error-handling.ngdoc
@@ -36,15 +36,15 @@ Aquí hay un ejemplo en funcionamiento:
           TEXT: 'I\'m using default interpolation {{ val + val }}',
           PLURAL: '{GENDER, select, male{He} female{She} other{They}} liked this.',
           BUTTON_LANG_EN: 'English',
-          BUTTON_LANG_DE: 'German'
+          BUTTON_LANG_ES: 'Spanish'
         });
 
-        $translateProvider.translations('de', {
-          HEADLINE: 'Ich bin eine Überschrift',
-          TEXT: 'Ich benutze default interpolation {{ val + val }}',
-          PLURAL: '{GENDER, select, male{Er fand} female{Sie fand} other{Sie fanden}} es gut.',
-          BUTTON_LANG_EN: 'Englisch',
-          BUTTON_LANG_DE: 'Deutsch'
+        $translateProvider.translations('es', {
+          HEADLINE: 'Soy un encabezado',
+          TEXT: 'Estoy usando la interpolación por defecto {{ val + val }}',
+          PLURAL: '{GENDER, select, male{A él le} female{A ella le} other{A ellos les}} gusta esto.',
+          BUTTON_LANG_EN: 'Inglés',
+          BUTTON_LANG_ES: 'Español'
         });
       }]);
 
@@ -59,7 +59,7 @@ Aquí hay un ejemplo en funcionamiento:
       <p translate="NOT_EXISTING"></p>
       <p translate="ALSO_NOT_EXISTING"></p>
 
-      <button ng-click="changeLanguage('de')" translate="BUTTON_LANG_DE"></button>
+      <button ng-click="changeLanguage('es')" translate="BUTTON_LANG_ES"></button>
       <button ng-click="changeLanguage('en')" translate="BUTTON_LANG_EN"></button>
     </div>
   </doc:source>

--- a/docs/content/guide/es/17_custom-error-handler.ngdoc
+++ b/docs/content/guide/es/17_custom-error-handler.ngdoc
@@ -8,15 +8,15 @@ Por supuesto que usted querrá ser capaz de usar su propio manejo de errores per
 
 <pre>
 var app = angular.module('myApp', ['pascalprecht.translate'], function ($translateProvider) {
-  // tell angular-translate to use your custom handler
+  // decirle a angular-translate que use su propio manejo de errores
   $translateProvider.useMissingTranslationHandler('myCustomHandlerFactory');
 });
 
-// define custom handler
+// definir un manejo personalizado
 app.factory('myCustomHandlerFactory', function (dep1, dep2) {
-  // has to return a function which gets a tranlation ID
+  // tiene que utilizar una función que devuelva la una clave de traducción
   return function (translationID) {
-    // do something with dep1 and dep2
+    // hacer algo con dep1 y dep2
   };
 });
 
@@ -32,9 +32,9 @@ Simplemente devuélvale un valor al framework de angular-translate desde dentro 
 <pre>
 app.factory('customTranslationHandler', function () {
   return function (translationID, uses) {
-    // return the following text as a translation 'result' - this will be
-    // displayed instead of the language key.
-    return 'NO DEFAULT KEY';
+    // devolver el texto siguiente como "resultado" de la traducción - esto será
+    // mostrado en lugar de la clave de traducción
+    return 'NO HAY CLAVE POR DEFECTO';
   };
 });
 </pre>

--- a/docs/content/guide/es/19_security.ngdoc
+++ b/docs/content/guide/es/19_security.ngdoc
@@ -40,7 +40,7 @@ Recomendamos encarecidamente una estrategia segura. Por lo tanto, mostraremos un
 
 ## Demonstraciones
 
-### Neither escaped nor sanitized
+### Ni codificado (escaped) ni saneado (sanitized)
 
 <doc:example module="myApp_not_escaped">
   <doc:source>
@@ -69,7 +69,7 @@ Recomendamos encarecidamente una estrategia segura. Por lo tanto, mostraremos un
   </doc:source>
 </doc:example>
 
-### Escaped
+### Codificado (escaped)
 
 <doc:example module="myApp_escaped">
   <doc:source>
@@ -99,7 +99,7 @@ Recomendamos encarecidamente una estrategia segura. Por lo tanto, mostraremos un
   </doc:source>
 </doc:example>
 
-### Escaped (parameters only)
+### Sólo los parámetros codificados (escaped)
 
 <doc:example module="myApp_escape_params">
   <doc:source>
@@ -114,7 +114,7 @@ Recomendamos encarecidamente una estrategia segura. Por lo tanto, mostraremos un
       app.config(['$translateProvider', function ($translateProvider) {
         $translateProvider.translations('en', translations);
         $translateProvider.preferredLanguage('en');
-        // Enable escaping of HTML
+        // Permitir la codificación  del HTML
         $translateProvider.useSanitizeValueStrategy('escapeParameters');
       }]);
 
@@ -129,7 +129,7 @@ Recomendamos encarecidamente una estrategia segura. Por lo tanto, mostraremos un
   </doc:source>
 </doc:example>
 
-### Sanitized
+### Contenido saneado (sanitized)
 
 <doc:example module="myApp_sanitize">
   <doc:source>
@@ -144,7 +144,7 @@ Recomendamos encarecidamente una estrategia segura. Por lo tanto, mostraremos un
       app.config(['$translateProvider', function ($translateProvider) {
         $translateProvider.translations('en', translations);
         $translateProvider.preferredLanguage('en');
-        // Enable escaping of HTML
+        // Permitir la codificación del HTML
         $translateProvider.useSanitizeValueStrategy('sanitize');
       }]);
 

--- a/docs/content/guide/es/20_tools.ngdoc
+++ b/docs/content/guide/es/20_tools.ngdoc
@@ -42,10 +42,11 @@ grunt.initConfig({
     },
     your_target: {
                  files: {
-                     // This will generate a single json file with all the specified strings
+                     // Esto generará un único archivo json con todas las cadenas especificadas
                      'tmp/dest.json' : ['test/fixtures/*.po'],
 
-                     //this will create several json files, the names of them will be the same than in the .po files
+                     // esto generará varios archivos json, cuyos nombres serán los 
+                     // mismos que los de los archivos  .po 
                      'tmp/dest' : ['test/fixtures/*.po']
                   }
     },

--- a/docs/content/guide/es/21_migration-guide.ngdoc
+++ b/docs/content/guide/es/21_migration-guide.ngdoc
@@ -12,7 +12,7 @@ Por favor, asegúrese de que su aplicación no contenga código como este:
 ```js
 $translateProvider.translations({
   'greetings' : 'Hello',
-  // some other keys
+  // otras claves ...
 });
 ```
 
@@ -22,7 +22,7 @@ Para arreglarlo, simplemente agregue una clave de lenguaje como primer argumento
 ```js
 $translateProvider.translations('en', {
   'greetings' : 'Hello',
-  // some other keys
+  // otras claves ...
 });
 $translateProvider.use('en');
 ```
@@ -48,7 +48,7 @@ var stringFromService;
 $translate('translationId').then(function(translation) {
   stringFromService = translation;
 }, function(translationId){
-  // Unable to translate given translationId
+  // incapaz de traducir la clave dada
   stringFromService = translationId;
 });
 ```

--- a/docs/content/guide/es/22_unit-testing-with-angular-translate.ngdoc
+++ b/docs/content/guide/es/22_unit-testing-with-angular-translate.ngdoc
@@ -4,7 +4,7 @@
 
 # Tests unitarios con angular-translate
 
-AngularJS ha sido creado con la capacidad de ser testeado en mente.
+AngularJS ha sido concebido desde el vamos, teniendo en mente la capacidad de ser testeado.
 Y eso nos encanta. Es por eso que le hemos practicado tests unitarios a angular-translate desde su mismo comienzo. Sin embargo, cuando cree sus aplicaciones AngularJS con soporte i18n usando angular-translate, testear puede volverse un tanto complicado. Esta guía le muestra cómo evitar problemas comunes cuando escriba tests unitarios que usen angular-translate.
 
 ## ¿Cuál es el problema?
@@ -77,7 +77,7 @@ describe('myApp', function () {
     });
   }));
 
-  it('should do something', function () {
+  it('debería hacer algo', function () {
 
   });
 });
@@ -114,7 +114,7 @@ describe('myApp', function () {
   it('should do something', function () {
     $httpBackend.expectGET('locale-en.json');
 
-    // test code goes here
+    // el código para tests iría aquí
   });
 });
 </pre>
@@ -134,7 +134,7 @@ Utilizando el proveedor `$provider`, podemos construir una factory de cargadores
 beforeEach(module('myApp', function ($provide, $translateProvider) {
 
   $provide.factory('customLoader', function () {
-    // loader logic goes here
+    // la lógica del cargador iría acá
   });
 
   $translateProvider.useLoader('customLoader');

--- a/docs/content/guide/es/index.ngdoc
+++ b/docs/content/guide/es/index.ngdoc
@@ -7,7 +7,7 @@
 #### ¡Agregue i18n y l10n a sus aplicaciones Angular!
 
 <br>
-¿Quiere agregar **i18n** y **l10n** en sus aplicaciones Angular, pero no sane cómo? Con angular-translate, está todo resuelto.
+¿Quiere agregar **i18n** y **l10n** en sus aplicaciones Angular, pero no sabe cómo? Con angular-translate, está todo resuelto.
 
 Angular-translate viene con numerosas herramientas y extensiones muy útiles, y le ofrece una enorme flexibilidad a la hora de
 aplicar customizaciones.

--- a/docs/content/guide/es/index.ngdoc
+++ b/docs/content/guide/es/index.ngdoc
@@ -4,7 +4,7 @@
 
 # La manera más fácil de agregar internacionalización (i18n) en sus aplicaciones Angular
 
-####¡Agregue i18n y l10n a sus aplicaciones Angular!
+#### ¡Agregue i18n y l10n a sus aplicaciones Angular!
 
 <br>
 ¿Quiere agregar **i18n** y **l10n** en sus aplicaciones Angular, pero no sane cómo? Con angular-translate, está todo resuelto.
@@ -58,8 +58,8 @@ app.config(['$translateProvider', function ($translateProvider) {
   });
 
   $translateProvider.translations('de', {
-    'TITLE': 'Hallo',
-    'FOO': 'Dies ist ein Absatz'
+    'TITLE': 'Hola',
+    'FOO': 'Esto es un párrafo'
   });
 
   $translateProvider.preferredLanguage('en');
@@ -98,4 +98,4 @@ Traduzca su aplicación:
 
   <br>
   <hr>
-  <center>Hecho conunicorn &hearts; y cariño puesto por[PascalPrecht](http://github.com/PascalPrecht)</center>
+  <center>Hecho con &hearts; de unicornio y con amor por [PascalPrecht](http://github.com/PascalPrecht)</center>

--- a/docs/data/locale-de.json
+++ b/docs/data/locale-de.json
@@ -4,7 +4,7 @@
   "PASSED_AS_TEXT": "Hey! Ich wurde als text übergeben!",
   "PASSED_AS_ATTRIBUTE": "Ich wurde als Attribut übergeben, cool oder?",
   "PASSED_AS_INTERPOLATION": "Anfänger! Ich bin interpoliert!",
-  "VARIABLE_REPLACEMENT": "Hi {{name}}",
+  "VARIABLE_REPLACEMENT": "Hallo {{name}}",
   "BUTTON_LANG_DE": "deutsch",
   "BUTTON_LANG_EN": "englisch"
 }

--- a/docs/data/locale-es.json
+++ b/docs/data/locale-es.json
@@ -1,0 +1,10 @@
+{
+  "HEADLINE": "¡Qué módulo asombroso!",
+  "PARAGRAPH": "¡En serio!",
+  "PASSED_AS_TEXT": "¡Hola! Me están pasando como texto.",
+  "PASSED_AS_ATTRIBUTE": "Me están pasando como atributo. ¡Qué bueno! ¿no?",
+  "PASSED_AS_INTERPOLATION": "¡Aprendices! A mí me están interpolando",
+  "VARIABLE_REPLACEMENT": "Hola {{name}}",
+  "BUTTON_LANG_DE": "Español",
+  "BUTTON_LANG_EN": "Inglés"
+}


### PR DESCRIPTION
This pull request replaces German with Spanish, as second language in the translated guide.
Code comments and some variable names are also used in Spanish.
A new little .json. file was added with Spanish entries.

This closes issue #1092 

