### PR TITLE
feat(service): Add `negotiateLocale` method

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -140,6 +140,9 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
   };
 
   var negotiateLocale = function (preferred) {
+    if(!preferred) {
+      return;
+    }
 
     var avail = [],
         locale = angular.lowercase(preferred),
@@ -150,6 +153,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
       avail.push(angular.lowercase($availableLanguageKeys[i]));
     }
 
+    // Check for an exact match in our list of available keys
     if (indexOf(avail, locale) > -1) {
       return preferred;
     }
@@ -173,16 +177,15 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
       }
     }
 
-    if (preferred) {
-      var parts = preferred.split('_');
+    // Check for a language code without region
+    var parts = preferred.split('_');
 
-      if (parts.length > 1 && indexOf(avail, angular.lowercase(parts[0])) > -1) {
-        return parts[0];
-      }
+    if (parts.length > 1 && indexOf(avail, angular.lowercase(parts[0])) > -1) {
+      return parts[0];
     }
 
-    // If everything fails, just return the preferred, unchanged.
-    return preferred;
+    // If everything fails, return undefined.
+    return;
   };
 
   /**
@@ -837,7 +840,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
     if (!$availableLanguageKeys.length) {
       $preferredLanguage = locale;
     } else {
-      $preferredLanguage = negotiateLocale(locale);
+      $preferredLanguage = negotiateLocale(locale) || locale;
     }
 
     return this;
@@ -1688,6 +1691,22 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
       $translate.storage = function () {
         return Storage;
       };
+
+      /**
+       * @ngdoc function
+       * @name pascalprecht.translate.$translate#negotiateLocale
+       * @methodOf pascalprecht.translate.$translate
+       *
+       * @description
+       * Returns a language key based on available languages and language aliases. If a
+       * language key cannot be resolved, returns undefined.
+       *
+       * If no or a falsy key is given, returns undefined.
+       *
+       * @param {string} [key] Language key
+       * @return {string|undefined} Language key or undefined if no language key is found.
+       */
+      $translate.negotiateLocale = negotiateLocale;
 
       /**
        * @ngdoc function

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -92,6 +92,9 @@ describe('pascalprecht.translate', function () {
 
     beforeEach(module('pascalprecht.translate', function ($translateProvider) {
       $translateProvider
+        .registerAvailableLanguageKeys(['en', 'en_EN'], {
+          'en_US': 'en_EN'
+        })
         .translations('en', translationMock)
         .translations('en', {
           'FOO': 'bar',
@@ -139,6 +142,10 @@ describe('pascalprecht.translate', function () {
 
     it('should have a method instant()', function () {
       expect($translate.instant).toBeDefined();
+    });
+
+    it('should have a method negotiateLocale()', function () {
+      expect($translate.negotiateLocale).toBeDefined();
     });
 
     it('should have a method isForceAsyncReloadEnabled()', function () {
@@ -199,6 +206,29 @@ describe('pascalprecht.translate', function () {
 
       it('should return \'.\' if no delimiter is specified', function () {
         expect($translate.nestedObjectDelimeter()).toEqual('.');
+      });
+    });
+
+    describe('$translate#negotiateLocale()', function() {
+
+      it('should return undefined if no key is specified', function () {
+        expect($translate.negotiateLocale()).toEqual(undefined);
+      });
+
+      it('should return language key if registered', function () {
+        expect($translate.negotiateLocale('en')).toEqual('en');
+      });
+
+      it('should return resolved alias', function () {
+        expect($translate.negotiateLocale('en_US')).toEqual('en_EN');
+      });
+
+      it('should return matching registered language if lang_REGION doesn\'t match', function () {
+        expect($translate.negotiateLocale('en_GB')).toEqual('en');
+      });
+
+      it('should return undefined if key doesn\'t resolve to an alias or registered language', function () {
+        expect($translate.negotiateLocale('foo')).toEqual(undefined);
       });
     });
 


### PR DESCRIPTION
Add the `$translate#negotiateLocale` method.

Exposing `negotiateLocale` enables testing language keys without calling `$translate#use`.  This is particularly helpful in cases where languages and aliases are known and registered on load.

We have several sites which route based on language key, being able to test validity directly would be beneficial.