### PR TITLE
passing the result of getLocale to the function

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -832,7 +832,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
    */
   this.determinePreferredLanguage = function (fn) {
 
-    var locale = (fn && angular.isFunction(fn)) ? fn() : getLocale();
+    var locale = (fn && angular.isFunction(fn)) ? fn(getLocale()) : getLocale();
 
     if (!$availableLanguageKeys.length) {
       $preferredLanguage = locale;

--- a/test/unit/service/translate.determineLocale.spec.js
+++ b/test/unit/service/translate.determineLocale.spec.js
@@ -341,13 +341,13 @@ describe('pascalprecht.translate', function () {
         describe('should pass the locale to the custom func', function () {
           beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide, pascalprechtTranslateOverrider) {
             pascalprechtTranslateOverrider.getLocale = function () { return 'en-us'; };
-          }));
-          it('test', inject(function ($window, $translate) {
             $translateProvider.determinePreferredLanguage(function(locale) {
               if (locale === 'en-us') {
                 return 'en_US';
               }
             });
+          }));
+          it('test', inject(function ($window, $translate) {
             expect($translate.use()).toEqual('en_US');
           }));
         });

--- a/test/unit/service/translate.determineLocale.spec.js
+++ b/test/unit/service/translate.determineLocale.spec.js
@@ -7,6 +7,20 @@ describe('pascalprecht.translate', function () {
   describe('$translateProvider', function () {
 
     describe('#determinePreferredLanguage()', function () {
+      
+      describe('should pass the locale to the custom func', function () {
+        beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide, pascalprechtTranslateOverrider) {
+          pascalprechtTranslateOverrider.getLocale = function () { return 'en-us'; };
+          $translateProvider.determinePreferredLanguage(function(locale) {
+            if (locale === 'en-us') {
+              return 'en_US';
+            }
+          });
+        }));
+        it('test', inject(function ($window, $translate) {
+           expect($translate.use()).toEqual('en_US');
+        }));
+      });
 
       describe('without locale negotiation', function () {
 
@@ -335,20 +349,6 @@ describe('pascalprecht.translate', function () {
           }));
           it('test', inject(function ($window, $translate) {
             expect($translate.use()).toEqual('en');
-          }));
-        });
-        
-        describe('should pass the locale to the custom func', function () {
-          beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide, pascalprechtTranslateOverrider) {
-            pascalprechtTranslateOverrider.getLocale = function () { return 'en-us'; };
-            $translateProvider.determinePreferredLanguage(function(locale) {
-              if (locale === 'en-us') {
-                return 'en_US';
-              }
-            });
-          }));
-          it('test', inject(function ($window, $translate) {
-            expect($translate.use()).toEqual('en_US');
           }));
         });
       });

--- a/test/unit/service/translate.determineLocale.spec.js
+++ b/test/unit/service/translate.determineLocale.spec.js
@@ -337,6 +337,20 @@ describe('pascalprecht.translate', function () {
             expect($translate.use()).toEqual('en');
           }));
         });
+        
+        describe('should pass the locale to the custom func', function () {
+          beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide, pascalprechtTranslateOverrider) {
+            pascalprechtTranslateOverrider.getLocale = function () { return 'en-us'; };
+          }));
+          it('test', inject(function ($window, $translate) {
+            $translateProvider.determinePreferredLanguage(function(locale) {
+              if (local === 'en-us') {
+                return 'en_US'
+              }
+            });
+            expect($translate.use()).toEqual('en_US');
+          }));
+        });
       });
 
     });

--- a/test/unit/service/translate.determineLocale.spec.js
+++ b/test/unit/service/translate.determineLocale.spec.js
@@ -344,7 +344,7 @@ describe('pascalprecht.translate', function () {
           }));
           it('test', inject(function ($window, $translate) {
             $translateProvider.determinePreferredLanguage(function(locale) {
-              if (local === 'en-us') {
+              if (locale === 'en-us') {
                 return 'en_US';
               }
             });

--- a/test/unit/service/translate.determineLocale.spec.js
+++ b/test/unit/service/translate.determineLocale.spec.js
@@ -345,7 +345,7 @@ describe('pascalprecht.translate', function () {
           it('test', inject(function ($window, $translate) {
             $translateProvider.determinePreferredLanguage(function(locale) {
               if (local === 'en-us') {
-                return 'en_US'
+                return 'en_US';
               }
             });
             expect($translate.use()).toEqual('en_US');


### PR DESCRIPTION
Since the 'optional function' can be used to customize how the preferred language is determined, it would be great to somehow have access to the preferred language as would be 'normally' determined by `determinePreferredLanguage`, so you have a chance to inspect it and decide whether you need to override it or not. Also it's just a good way to not do any work that has already be done by your excellent library! :smile: 

I just had a use case where I just wanted to allow for a limited number of languages to be automatically determined as preferred, and I had to check the `navigator.languages` myself in the custom function, something that you already do. Just passing around the result of `getLocale` would have saved me the effort. 