### PR TITLE
Added installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Since angular-translate has some dependencies when developing it, you can just i
 
 `
 $ npm install
+`
+
+`
 $ bower install
 `
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@
 
 ###Installing via Bower
 You can install the angular-translate package very easily using Bower. After installing Bower on your machine, simply run:
+
 `
 $ bower install angular-translate
 `
+
 This will install a package in your configured components folder. You can watch the bower package repository here. As you can see, it's pretty much broken down to things that matter. The raw source. For development as well as production use.
 
 ###Installing with Git
@@ -32,12 +34,14 @@ Another way to get the source of angular-translate, is to clone the whole reposi
 `
 $ git clone git://github.com/PascalPrecht/angular-translate.git
 `
+
 You now have a full clone of the repository including the history and everything else that ever happened during the development of angular-translate. Do with the code what ever the fuck you want.
 
 Since angular-translate has some dependencies when developing it, you can just install all of them at once. To install all needed dependencies, simply run the following commands in the cloned angular-translate repository.
 
 `
 $ npm install
+
 $ bower install
 `
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Since angular-translate has some dependencies when developing it, you can just i
 
 `
 $ npm install
-
 $ bower install
 `
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,30 @@
 ### Presentation (Kod.io 2014)
 [![angular-translate Talk](presentation2.png)](https://www.youtube.com/watch?v=C7xqaExvaQ4)
 
+### Getting started
+
+###Installing via Bower
+You can install the angular-translate package very easily using Bower. After installing Bower on your machine, simply run:
+`
+$ bower install angular-translate
+`
+This will install a package in your configured components folder. You can watch the bower package repository here. As you can see, it's pretty much broken down to things that matter. The raw source. For development as well as production use.
+
+###Installing with Git
+Another way to get the source of angular-translate, is to clone the whole repository from GitHub.
+
+`
+$ git clone git://github.com/PascalPrecht/angular-translate.git
+`
+You now have a full clone of the repository including the history and everything else that ever happened during the development of angular-translate. Do with the code what ever the fuck you want.
+
+Since angular-translate has some dependencies when developing it, you can just install all of them at once. To install all needed dependencies, simply run the following commands in the cloned angular-translate repository.
+
+`
+$ npm install
+$ bower install
+`
+
 ### Links
 * Website [angular-translate.github.io](https://angular-translate.github.io/)
 * API Reference [angular-translate.github.io/docs/#/api](https://angular-translate.github.io/docs/#/api)


### PR DESCRIPTION
Once I found the repo, I had to go to the website and click "Getting started" to get installation instructions. Adding them to the README would save some clicks.