### PR TITLE
Fix for changing `translation-default` attr value

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -214,6 +214,7 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
 
         iAttr.$observe('translateDefault', function (value) {
           scope.defaultText = value;
+          updateTranslations();
         });
 
         if (translateValuesExist) {


### PR DESCRIPTION
If we have something like this:
```
<span translate="{{not_existing_translation_key}}" translate-default="{{something.isChanging}}"></span>
```

And if the value of `something.isChanging` changes over time, the value does not update accordingly