### PR TITLE
chore(): add support of default translation in missingTranslationHandler

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1342,14 +1342,16 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
        * Translate by missing translation handler.
        *
        * @param translationId
+       * @param interpolateParams
+       * @param defaultTranslationText
        * @returns translation created by $missingTranslationHandler or translationId is $missingTranslationHandler is
        * absent
        */
-      var translateByHandler = function (translationId, interpolateParams) {
+      var translateByHandler = function (translationId, interpolateParams, defaultTranslationText) {
         // If we have a handler factory - we might also call it here to determine if it provides
         // a default text for a translationid that can't be found anywhere in our tables
         if ($missingTranslationHandlerFactory) {
-          var resultString = $injector.get($missingTranslationHandlerFactory)(translationId, $uses, interpolateParams);
+          var resultString = $injector.get($missingTranslationHandlerFactory)(translationId, $uses, interpolateParams, defaultTranslationText);
           if (resultString !== undefined) {
             return resultString;
           } else {
@@ -1394,7 +1396,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
           } else {
             // if no default translation is set and an error handler is defined, send it to the handler
             // and then return the result
-            deferred.resolve(translateByHandler(translationId, interpolateParams));
+            deferred.resolve(translateByHandler(translationId, interpolateParams, defaultTranslationText));
           }
         }
         return deferred.promise;
@@ -1475,7 +1477,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
           var missingTranslationHandlerTranslation;
           // for logging purposes only (as in $translateMissingTranslationHandlerLog), value is not returned to promise
           if ($missingTranslationHandlerFactory && !pendingLoader) {
-            missingTranslationHandlerTranslation = translateByHandler(translationId, interpolateParams);
+            missingTranslationHandlerTranslation = translateByHandler(translationId, interpolateParams, defaultTranslationText);
           }
 
           // since we couldn't translate the inital requested translation id,

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -1950,8 +1950,8 @@ describe('pascalprecht.translate', function () {
         .useMissingTranslationHandler('customHandler');
 
       $provide.factory('customHandler', function () {
-        return function (translationId, language, params) {
-          missingTranslations[translationId] = { lang: language, params: params };
+        return function (translationId, language, params, defaultTranslation) {
+          missingTranslations[translationId] = { lang: language, params: params, defaultTranslation: defaultTranslation };
         };
       });
 
@@ -1973,7 +1973,8 @@ describe('pascalprecht.translate', function () {
       expect(missingTranslations).toEqual({
         'NOT_EXISTING_TRANSLATION_ID': {
           lang: 'en',
-          params: {}
+          params: {},
+          defaultTranslation: undefined
         }
       });
     });
@@ -1985,7 +1986,21 @@ describe('pascalprecht.translate', function () {
           lang: 'en',
           params: {
             name: 'name'
-          }
+          },
+          defaultTranslation: undefined
+        }
+      });
+    });
+
+    it('should pass on defaultTranslationText to missingTranslationHandler', function () {
+      $translate('NOT_EXISTING_TRANSLATION_ID', {name: 'name'}, '', 'DEFAULT');
+      expect(missingTranslations).toEqual({
+        'NOT_EXISTING_TRANSLATION_ID': {
+          lang: 'en',
+          params: {
+            name: 'name'
+          },
+          defaultTranslation: 'DEFAULT'
         }
       });
     });


### PR DESCRIPTION
We can both define a default translation and a missing translation handler. In my case, I need to treat the default translation in the missing handler. This PR add the `defaultTranslationText` parameter to the handler.
