### PR TITLE
Apply notFoundIndicators only when all configured language checked and translation isn't found in $translate.instant method

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1969,8 +1969,6 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
           if ($translationTable[possibleLangKey]) {
             if (typeof $translationTable[possibleLangKey][translationId] !== 'undefined') {
               result = determineTranslationInstant(translationId, interpolateParams, interpolationId);
-            } else if ($notFoundIndicatorLeft || $notFoundIndicatorRight) {
-              result = applyNotFoundIndicators(translationId);
             }
           }
           if (typeof result !== 'undefined') {
@@ -1979,10 +1977,14 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
         }
 
         if (!result && result !== '') {
-          // Return translation of default interpolator if not found anything.
-          result = defaultInterpolator.interpolate(translationId, interpolateParams);
-          if ($missingTranslationHandlerFactory && !pendingLoader) {
-            result = translateByHandler(translationId, interpolateParams);
+          if ($notFoundIndicatorLeft || $notFoundIndicatorRight) {
+            result = applyNotFoundIndicators(translationId);
+          } else {
+            // Return translation of default interpolator if not found anything.
+            result = defaultInterpolator.interpolate(translationId, interpolateParams);
+            if ($missingTranslationHandlerFactory && !pendingLoader) {
+              result = translateByHandler(translationId, interpolateParams);
+            }
           }
         }
 

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -2175,6 +2175,50 @@ describe('pascalprecht.translate', function () {
     });
   });
 
+  describe('$translate.instant (with fallback and not found indicators)', function () {
+
+    beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide) {
+      $translateProvider
+        .useLoader('customLoader')
+        .translations('en', {
+          'FOO': 'bar'
+        })
+        .translations('de', {
+          'FOO2': 'bar2'
+        })
+        .preferredLanguage('de')
+        .fallbackLanguage('en')
+        .translationNotFoundIndicator('-+-+');
+
+      $provide.factory('customLoader', function ($q, $timeout) {
+        return function (options) {
+          var deferred = $q.defer();
+
+          $timeout(function () {
+            deferred.resolve({});
+          }, 1000);
+
+          return deferred.promise;
+        };
+      });
+    }));
+
+    var $translate;
+
+    beforeEach(inject(function (_$translate_) {
+      $translate = _$translate_;
+    }));
+
+    it('should return translation if translation id exist', function () {
+      expect($translate.instant('FOO')).toEqual('bar');
+      expect($translate.instant('FOO2')).toEqual('bar2');
+    });
+
+    it('should return translation id wrapped into not found indicators if translation id does not exist', function () {
+      expect($translate.instant('FOO3')).toEqual('-+-+ FOO3 -+-+');
+    });
+  });
+
   describe('$translate#determineTranslation with fallback for shortcuts', function () {
 
     var missingTranslations = {};


### PR DESCRIPTION
fix($translate): apply notFoundIndicators only when all configured language checked in $translate.instant method

Fixes #1314