### PR TITLE
feat(service): force language used for translating

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,6 +58,7 @@ module.exports = function (grunt) {
         'src/directive/translate.js',
         'src/directive/translate-cloak.js',
         'src/directive/translate-namespace.js',
+        'src/directive/translate-language.js',
         'src/filter/translate.js',
         'src/service/translationCache.js'
       ],

--- a/src/directive/translate-language.js
+++ b/src/directive/translate-language.js
@@ -1,0 +1,66 @@
+angular.module('pascalprecht.translate')
+/**
+ * @ngdoc directive
+ * @name pascalprecht.translate.directive:translateLanguage
+ * @restrict A
+ *
+ * @description
+ * Forces the language to the directives in the underlying scope.
+ *
+ * @param {string=} translate language that will be negotiated.
+ *
+ * @example
+   <example module="ngView">
+    <file name="index.html">
+      <div>
+
+        <div>
+            <h1 translate>HELLO</h1>
+        </div>
+
+        <div translate-language="de">
+            <h1 translate>HELLO</h1>
+        </div>
+
+      </div>
+    </file>
+    <file name="script.js">
+      angular.module('ngView', ['pascalprecht.translate'])
+
+      .config(function ($translateProvider) {
+
+        $translateProvider
+          .translations('en',{
+            'HELLO': 'Hello world!'
+          })
+          .translations('de',{
+            'HELLO': 'Hallo Welt!'
+          })
+          .translations(.preferredLanguage('en');
+
+      });
+
+    </file>
+   </example>
+ */
+.directive('translateLanguage', translateLanguageDirective);
+
+function translateLanguageDirective() {
+
+  'use strict';
+
+  return {
+    restrict: 'A',
+    scope: true,
+    compile: function () {
+      return function linkFn(scope, iElement, iAttrs) {
+        iAttrs.$observe('translateLanguage', function (newTranslateLanguage) {
+          scope.translateLanguage = newTranslateLanguage;
+        });
+      };
+    }
+  };
+}
+
+translateLanguageDirective.displayName = 'translateLanguageDirective';
+

--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -5,7 +5,7 @@ angular.module('pascalprecht.translate')
  * @requires $compile
  * @requires $filter
  * @requires $interpolate
- * @restrict A
+ * @restrict AE
  *
  * @description
  * Translates given translation id either through attribute or DOM content.
@@ -259,7 +259,7 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
               translationId = translateNamespace + translationId;
             }
 
-            $translate(translationId, interpolateParams, translateInterpolation, defaultTranslationText)
+            $translate(translationId, interpolateParams, translateInterpolation, defaultTranslationText, scope.translateLanguage)
               .then(function (translation) {
                 applyTranslation(translation, scope, true, translateAttr);
               }, function (translationId) {
@@ -302,6 +302,7 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
         if (translateValuesExist || translateValueExist || iAttr.translateDefault) {
           scope.$watch('interpolateParams', updateTranslations, true);
         }
+        scope.$watch('translateLanguage', updateTranslations);
 
         // Ensures the text will be refreshed after the current language was changed
         // w/ $translate.use(...)

--- a/src/filter/translate.js
+++ b/src/filter/translate.js
@@ -56,13 +56,13 @@ function translateFilterFactory($parse, $translate) {
 
   'use strict';
 
-  var translateFilter = function (translationId, interpolateParams, interpolation) {
+  var translateFilter = function (translationId, interpolateParams, interpolation, forceLanguage) {
 
     if (!angular.isObject(interpolateParams)) {
       interpolateParams = $parse(interpolateParams)(this);
     }
 
-    return $translate.instant(translationId, interpolateParams, interpolation);
+    return $translate.instant(translationId, interpolateParams, interpolation, forceLanguage);
   };
 
   if ($translate.statefulFilter()) {

--- a/test/unit/directive/translate-language.spec.js
+++ b/test/unit/directive/translate-language.spec.js
@@ -1,0 +1,33 @@
+/* jshint camelcase: false, unused: false */
+/* global inject: false */
+'use strict';
+
+describe('pascalprecht.translate', function () {
+
+  describe('translate-language directive', function () {
+
+    var element;
+
+    beforeEach(module('pascalprecht.translate'));
+
+    var $compile, $rootScope;
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+    }));
+
+    it('should add translateLanguage to current scope', function () {
+      element = $compile('<div translate-language="he"></div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.scope().translateLanguage).toBe('he');
+    });
+
+    it('should not change parent scope language', function () {
+      $rootScope.translateLanguage = 'he';
+      element = $compile('<div translate-language="en"></div>')($rootScope);
+      $rootScope.$digest();
+      expect($rootScope.translateLanguage).toBe('he');
+    });
+  });
+});

--- a/test/unit/directive/translate.spec.js
+++ b/test/unit/directive/translate.spec.js
@@ -739,4 +739,45 @@ describe('pascalprecht.translate', function () {
       expect(element.attr('title')).toBe('Namespaced translation');
     });
   });
+
+  describe('translateLanguage forces language', function () {
+
+    var $compile, $rootScope, element;
+
+    beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+      $translateProvider
+        .translations('en', {
+          'HELLO': "Hello"
+        })
+        .translations('de', {
+          'HELLO': "Hallo"
+        })
+        .preferredLanguage('en');
+    }));
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+    }));
+
+    it('should use preferred without override', function () {
+      element = $compile('<translate>HELLO</translate>')($rootScope);
+      $rootScope.$digest();
+      expect(element.html()).toBe('Hello');
+    });
+
+    it('should use forced language with override', function () {
+      $rootScope.translateLanguage = 'de';
+      element = $compile('<translate>HELLO</translate>')($rootScope);
+      $rootScope.$digest();
+      expect(element.html()).toBe('Hallo');
+    });
+
+    it('should use forced language with translate-attr-*', function() {
+      $rootScope.translateLanguage = 'de';
+      element = $compile('<div translate translate-attr-title="HELLO" />')($rootScope);
+      $rootScope.$digest();
+      expect(element.attr('title')).toBe('Hallo');
+    });
+  });
 });

--- a/test/unit/filter/translate.spec.js
+++ b/test/unit/filter/translate.spec.js
@@ -89,28 +89,28 @@ describe('pascalprecht.translate', function () {
       expect(value[5]).toEqual('10');
       expect(value[6]).toEqual('55');
     });
-	  
-	it('should not throw errors when translation id is not a string', function() {
-		var value = [
-			$translate(4.5),
-			$translate(4),
-			$translate([]),
-			$translate({}),
-			$translate(true),
-			$translate(null),
-			$translate(undefined)	
-		];
-		
-		expect(value[0]).toEqual('4.5');
-		expect(value[1]).toEqual('4');
-		/* I don't care what these values are, as long as $translate doesn't throw an error.
-		expect(value[2]).toEqual({});
-		expect(value[3]).toEqual('[object Object]');	
-		expect(value[4]).toEqual('true');
-		expect(value[5]).toEqual(null);
-		expect(value[6]).toEqual(undefined);
-		*/
-	});
+
+  it('should not throw errors when translation id is not a string', function() {
+    var value = [
+      $translate(4.5),
+      $translate(4),
+      $translate([]),
+      $translate({}),
+      $translate(true),
+      $translate(null),
+      $translate(undefined)
+    ];
+
+    expect(value[0]).toEqual('4.5');
+    expect(value[1]).toEqual('4');
+    /* I don't care what these values are, as long as $translate doesn't throw an error.
+    expect(value[2]).toEqual({});
+    expect(value[3]).toEqual('[object Object]');
+    expect(value[4]).toEqual('true');
+    expect(value[5]).toEqual(null);
+    expect(value[6]).toEqual(undefined);
+    */
+  });
 
     if (angular.version.major === 1 && angular.version.minor <= 2) {
       // Until and including AJS 1.2, a filter was bound to a context (current scope). This was removed in AJS 1.3
@@ -283,5 +283,38 @@ describe('pascalprecht.translate', function () {
         }, 100);
       });
     }
+  });
+
+  describe('filter can receive a forced language', function () {
+
+    beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+      $translateProvider
+        .translations('en', {
+          'HELLO': 'Hello'
+        })
+        .translations('de', {
+          'HELLO': 'Hallo'
+        })
+        .preferredLanguage('en');
+    }));
+
+    var $translate, $rootScope, $compile;
+    beforeEach(inject(function (_$rootScope_, _$compile_, _$translate_) {
+      $rootScope = _$rootScope_;
+      $compile = _$compile_;
+      $translate = _$translate_;
+    }));
+
+    it('should use preferred without override', function () {
+      var element = $compile('<div>{{"HELLO" | translate}}</div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.html()).toBe('Hello');
+    });
+
+    it('should use forced with override', function () {
+      var element = $compile('<div>{{"HELLO" | translate:null:null:"de"}}</div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.html()).toBe('Hallo');
+    });
   });
 });


### PR DESCRIPTION
support multiple languages in the same template (discussed in #500) by
allowing to force the used language through:

* a parameter in $translate() and $translate.instant().
* scope variable for the translate directive, including a directive to
  change that variable.
* a parameter in translate filter.