### PR TITLE
fix (translate directive): do not translate content if empty

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -173,7 +173,8 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
                 });
               }
             } else {
-              translationIds.translate = iElementText;
+              // do not assigne the translation id if it is empty.
+              translationIds.translate = !iElementText ? undefined : iElementText;
             }
           } else {
             translationIds.translate = translationId;

--- a/test/unit/directive/translate.spec.js
+++ b/test/unit/directive/translate.spec.js
@@ -412,6 +412,7 @@ describe('pascalprecht.translate', function () {
     beforeEach(module('pascalprecht.translate', function ($translateProvider) {
       $translateProvider
         .translations('en', {
+          'SIMPLE': 'Hello',
           'FOO': 'hello my name is {{name}}',
           'BAR': 'and I\'m {{age}} years old',
           'BAZINGA': 'hello my name is {{name}} and I\'m {{age}} years old.',
@@ -475,6 +476,30 @@ describe('pascalprecht.translate', function () {
       element = $compile(markup)($rootScope);
       $rootScope.$digest();
       expect(element.children().text()).toEqual('hello my name is Pascal');
+    });
+
+    it('should not translate the content if the content is empty and an attribute is being translated', function () {
+      var markup = '<a href="#" translate translate-attr-title="SIMPLE">\n\t<i class="fa fa-home" />\n</a>';
+      element = $compile(markup)($rootScope);
+      $rootScope.$digest();
+      expect(element.attr('title')).toEqual('Hello');
+      expect(element.html().trim()).toEqual('<i class="fa fa-home"></i>');
+    });
+
+    it('should translate the content and the attribute if the element content is non empty text and the element has translated attributes', function () {
+      var markup = '<a href="#" translate translate-attr-title="SIMPLE">SIMPLE</a>';
+      element = $compile(markup)($rootScope);
+      $rootScope.$digest();
+      expect(element.attr('title')).toEqual('Hello');
+      expect(element.text()).toEqual('Hello');
+    });
+
+    it('should translate the content and the attribute if the element has a translation attribute with an assigned id and translated attributes', function () {
+      var markup = '<a href="#" translate="SIMPLE" translate-attr-title="SIMPLE">   </a>';
+      element = $compile(markup)($rootScope);
+      $rootScope.$digest();
+      expect(element.attr('title')).toEqual('Hello');
+      expect(element.text()).toEqual('Hello');
     });
   });
 


### PR DESCRIPTION
Do not translate the content of an element if the element has translate-attr-* attributes and
the element-content is empty. E.g. do not translate the content of 

```js
<a href="#" translate translate-attr-title="Home">
     <i class="fa fa-home"></i>
</a>
```

fixes #1338