### PR TITLE
chore(loaders): reuse deferred objects instead of creating new ones

### DIFF
--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -295,7 +295,6 @@ function $translatePartialLoader() {
       }
 
       var loaders = [],
-          deferred = $q.defer(),
           prioritizedParts = getPrioritizedParts();
 
       angular.forEach(prioritizedParts, function(part) {
@@ -305,19 +304,16 @@ function $translatePartialLoader() {
         part.urlTemplate = options.urlTemplate;
       });
 
-      $q.all(loaders)
+      return $q.all(loaders)
         .then(function() {
           var table = {};
           angular.forEach(prioritizedParts, function(part) {
             deepExtend(table, part.tables[options.key]);
           });
-          deferred.resolve(table);
+          return table;
         }, function() {
-          deferred.reject(options.key);
-        }
-      );
-
-      return deferred.promise;
+          return $q.reject(options.key);
+        });
     };
 
     /**

--- a/src/service/loader-static-files.js
+++ b/src/service/loader-static-files.js
@@ -52,8 +52,7 @@ function $translateStaticFilesLoader($q, $http) {
         });
     };
 
-    var deferred = $q.defer(),
-        promises = [],
+    var promises = [],
         length = options.files.length;
 
     for (var i = 0; i < length; i++) {
@@ -64,7 +63,7 @@ function $translateStaticFilesLoader($q, $http) {
       }));
     }
 
-    $q.all(promises)
+    return $q.all(promises)
       .then(function (data) {
         var length = data.length,
             mergedData = {};
@@ -75,12 +74,8 @@ function $translateStaticFilesLoader($q, $http) {
           }
         }
 
-        deferred.resolve(mergedData);
-      }, function (data) {
-        deferred.reject(data);
+        return mergedData;
       });
-
-    return deferred.promise;
   };
 }
 


### PR DESCRIPTION
The purpose of this PR is to remove the promise antipatterns from the loaders.