### PR TITLE
fix grunt default task didn't match contribution documentation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -652,7 +652,7 @@ module.exports = function (grunt) {
   });
 
 
-  grunt.registerTask('default', ['jshint:all', 'karma']);
+  grunt.registerTask('default', ['jshint:all']);
   grunt.registerTask('test', ['jshint:all', 'karma:unit', 'karma:midway']);
   grunt.registerTask('install-test', ['bower-install-simple']);
 


### PR DESCRIPTION
Default task did both a lint and a full test run instead of just a
lint as specified by the documentation.  Change that to only do a
lint.