### PR TITLE
Ensure translate promise is rejected when translation is missing.

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1484,7 +1484,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
             if (defaultTranslationText) {
               deferred.resolve(defaultTranslationText);
               } else {
-                deferred.resolve(missingTranslationHandlerTranslation);
+                deferred.reject(missingTranslationHandlerTranslation);
               }
           } else {
             if (defaultTranslationText) {


### PR DESCRIPTION
Reject translate promise when translation is missing and a custom 'missingTranslationHandlerTranslation' is provided.

Solves https://github.com/angular-translate/angular-translate/issues/1359