### PR TITLE
Allow 1.4 and 1.5 beta releases to satisfy angular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
     "plato": "^1.5.0"
   },
   "dependencies": {
-    "angular": ">=1.2.26 <=1.5"
+    "angular": "^1.2.26 || >= 1.4.0-beta.0 || >= 1.5.0-beta.0"
   }
 }


### PR DESCRIPTION
Without this, npm won't allow a beta angular version in a parent project to satisfy angular-translate's angular dependency. See https://docs.npmjs.com/misc/semver#prerelease-tags