### PR TITLE
feat(service): Introduce post processing functionality

### DIFF
--- a/demo/ex14_async_loader_with_postProcessor.htm
+++ b/demo/ex14_async_loader_with_postProcessor.htm
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html ng-app='app'>
+
+<head>
+  <meta charset="utf-8">
+  <title translate="load.predefined.TITLE">lazy load files together with postProcessor</title>
+  <style>body { text-align: center; }</style>
+</head>
+
+<body ng-controller="ctrl">
+
+  <p>
+    <a href="#" ng-click="setLang('en_US')">English</a>
+    |
+    <a href="#" ng-click="setLang('ru_RU')">Русский</a>
+  </p>
+
+  <h1 translate>load.predefined.HEADER</h1>
+  <h2 translate>load.predefined.SUBHEADER</h2>
+  <h3 translate>load.static.ONLY_RU</h3>
+<script src="../bower_components/angular/angular.js"></script>
+<script src="../bower_components/angular-cookies/angular-cookies.js"></script>
+<!--<script src="../dist/angular-translate.js"></script>-->
+<!--<script src="../dist/angular-translate-storage-cookie/angular-translate-storage-cookie.js"></script>-->
+<!--<script src="../dist/angular-translate-loader-static-files/angular-translate-loader-static-files.js"></script>-->
+  <script src="../src/translate.js"></script>
+  <script src="../src/service/default-interpolation.js"></script>
+  <script src="../src/service/sanitization.js"></script>
+  <script src="../src/service/loader-static-files.js"></script>
+  <script src="../src/service/storage-key.js"></script>
+  <script src="../src/service/storage-cookie.js"></script>
+  <script src="../src/service/translate.js"></script>
+  <script src="../src/directive/translate.js"></script>
+  <script src="../src/filter/translate.js"></script>
+<script>
+angular.module('app', ['pascalprecht.translate', 'ngCookies'])
+
+.config(['$translateProvider', function($translateProvider){
+
+  // Register a loader for the static files
+  // So, the module will search missing translation tables under the specified urls.
+  // Those urls are [prefix][langKey][suffix].
+  $translateProvider.useStaticFilesLoader({
+    prefix: 'l10n/',
+    suffix: '.json'
+  });
+
+  // Tell the module what language to use by default
+  $translateProvider.preferredLanguage('en_US');
+  $translateProvider.fallbackLanguage('ru_RU');
+
+  // Tell the module to store the language in the cookies
+  $translateProvider.useCookieStorage();
+
+  // Tell the module to postprocess the translations in success cases
+  $translateProvider.postProcess(function (translationId, translation, interpolatedTranslation, params, lang) {
+    return '<span style="color: #cccccc">' + translationId + '(' + lang + '):</span> ' +
+      (interpolatedTranslation?interpolatedTranslation:translation);
+  })
+  $translateProvider.postProcessEnable(true);
+
+}])
+
+.controller('ctrl', ['$scope', '$translate', function($scope, $translate) {
+
+  $scope.setLang = function(langKey) {
+    // You can change the language during runtime
+    $translate.use(langKey);
+  };
+
+}]);
+</script>
+
+</body>
+</html>

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -2542,4 +2542,76 @@ describe('pascalprecht.translate', function () {
     });
   });
 
+  describe('$translate#postprocess() with an enabled fallback language', function () {
+
+     describe('single post processDemo', function () {
+
+       beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+         $translateProvider
+           //.translations('de_DE', translationMock)
+           .translations('de_DE', {'ONLY_GERMAN': 'DE_TRANS', 'BOTH': 'BOTH_DE'})
+           .translations('en_EN', {'TRANSLATION__ID': 'bazinga', 'BOTH': 'BOTH_EN'})
+           .preferredLanguage('de_DE')
+           .fallbackLanguage('en_EN')
+           .postProcess(function (translationId, translation, interpolatedTranslation, params, lang) {
+             return translationId + ',' + lang + ',' + (interpolatedTranslation?interpolatedTranslation:translation);
+           })
+           .postProcessEnable(true);
+       }));
+
+       var $translate, $q, $rootScope;
+
+       beforeEach(inject(function (_$translate_, _$q_, _$rootScope_) {
+         $translate = _$translate_;
+         $q = _$q_;
+         $rootScope = _$rootScope_;
+       }));
+
+       it('should return a formatted postprocessed string on fallback language', function () {
+         var deferred = $q.defer(),
+           promise = deferred.promise,
+           value;
+
+         promise.then(function (translation) {
+           value = translation;
+         });
+         $translate('TRANSLATION__ID').then(function (translation) {
+           deferred.resolve(translation);
+         });
+
+         $rootScope.$digest();
+         expect(value).toEqual('TRANSLATION__ID,en_EN,bazinga');
+       });
+       it('should return a formatted postprocessed string on preferred language', function () {
+         var deferred = $q.defer(),
+           promise = deferred.promise,
+           value;
+
+         promise.then(function (translation) {
+           value = translation;
+         });
+         $translate('ONLY_GERMAN').then(function (translation) {
+           deferred.resolve(translation);
+         });
+
+         $rootScope.$digest();
+         expect(value).toEqual('ONLY_GERMAN,de_DE,DE_TRANS');
+       });
+       fit('should return a formatted postprocessed string on preferred language', function () {
+                var deferred = $q.defer(),
+                  promise = deferred.promise,
+                  value;
+
+                promise.then(function (translation) {
+                  value = translation;
+                });
+                $translate('BOTH').then(function (translation) {
+                  deferred.resolve(translation);
+                });
+
+                $rootScope.$digest();
+                expect(value).toEqual('BOTH,de_DE,BOTH_DE');
+              });
+     });
+  });
 });


### PR DESCRIPTION
In some special cases, a developer or translation agency might need an easy way to see the contexts they're translating content for. 
To mark the keys and translations inside a page, the postProcessor gives the application developer the possibility to have such a behavior. It can also be used for other cases where translated content must be rewritten.

PR contains tests + new test case ex14_async_loader_with_postProcessor.htm

Open point: Shall we sanitize the output as this is intended to be an experimental / dev stage feature as of now?
