### PR TITLE
feat(service): improve messageformat.js output caching

### DIFF
--- a/src/service/messageformat-interpolation.js
+++ b/src/service/messageformat-interpolation.js
@@ -100,10 +100,10 @@ function $translateMessageFormatInterpolation($translateSanitization, $cacheFact
     interpolationParams = interpolationParams || {};
     interpolationParams = $translateSanitization.sanitize(interpolationParams, 'params');
 
-    var interpolatedText = $cache.get(string + angular.toJson(interpolationParams));
+    var compiledFunction = $cache.get('mf:' + string);
 
-    // if given string wasn't interpolated yet, we do so now and never have to do it again
-    if (!interpolatedText) {
+    // if given string wasn't compiled yet, we do so now and never have to do it again
+    if (!compiledFunction) {
 
       // Ensure explicit type if possible
       // MessageFormat checks the actual type (i.e. for amount based conditions)
@@ -117,13 +117,12 @@ function $translateMessageFormatInterpolation($translateSanitization, $cacheFact
         }
       }
 
-      interpolatedText = $mf.compile(string)(interpolationParams);
-      interpolatedText = $translateSanitization.sanitize(interpolatedText, 'text');
-
-      $cache.put(string + angular.toJson(interpolationParams), interpolatedText);
+      compiledFunction = $mf.compile(string);
+      $cache.put('mf:' + string, compiledFunction);
     }
 
-    return interpolatedText;
+    var interpolatedText = compiledFunction(interpolationParams);
+    return $translateSanitization.sanitize(interpolatedText, 'text');
   };
 
   return $translateInterpolator;


### PR DESCRIPTION
Previously, the `$translateMessageFormatInterpolation` interpolator only cached results when both the
ICU MessageFormat string and the interpolation parameters matched. With this change, the compiled
function output by messageformat.js is cached, resulting in fewer cache misses that would require
the comparatively heavier `$mf.compile()` operation to be run.

An `mf:` namespace prefix is also added to the cache key, to make sure that a MessageFormat string like `'en'` would not match with the cached value of the `$mf` variable.