### PR TITLE
fix(service): fix and cover edge case where fallback language is set …

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1021,7 +1021,9 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
           startFallbackIteration;
 
       var $translate = function (translationId, interpolateParams, interpolationId, defaultTranslationText, forceLanguage) {
-
+        if (!$uses && $preferredLanguage) {
+          $uses = $preferredLanguage;
+        }
         var uses = (forceLanguage && forceLanguage !== $uses) ? // we don't want to re-negotiate $uses
               (negotiateLocale(forceLanguage) || forceLanguage) : $uses;
 


### PR DESCRIPTION
…and preferred language is determined. but use is not explicitly called before calling the $translate service

Fixes #1368 

plus possibly #1390, #1153 -- maybe #399?
I didn't have time to test all of these.

Fix is a proposal - so @knalli have a look if this is the best place to "fix" this or if we should do this in the determinePreferred already before, but then we have an order dependency on the initializers still.