### PR TITLE
fix(service): translate-language not working first time

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1086,9 +1086,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
         }
 
         var promiseToWaitFor = (function () {
-          var promise = $preferredLanguage ?
-            langPromises[$preferredLanguage] :
-            langPromises[uses];
+          var promise = langPromises[uses];
 
           fallbackIndex = 0;
 


### PR DESCRIPTION
We had a problem with the translate-language directive. When we used it with to force a different language on a child scope, the first time it still showed the preffered language. When we opened the page again, it showed the correct translations.
I debugged and found that the promise that is selected as the promiseToWaitFor is based on the prefferedLanguage and not the forced language. The code change fixes this, but I'm not entirely sure that it didn't break anything else.
Also note that the demo in the translate language directive api reference (or the plunker) does not seem to work (https://angular-translate.github.io/docs/#/api/pascalprecht.translate.directive:translateLanguage).