### PR TITLE
docs(): fix translate language directive example

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -520,13 +520,13 @@ module.exports = function (grunt) {
           'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.15/angular-animate.js',
           'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.15/angular-cookies.js',
           'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.15/angular-sanitize.js',
-          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate/2.8.1/angular-translate.js',
-          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate-interpolation-messageformat/2.8.1/angular-translate-interpolation-messageformat.js',
-          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate-storage-cookie/2.8.1/angular-translate-storage-cookie.js',
-          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate-storage-local/2.8.1/angular-translate-storage-local.js',
-          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate-loader-url/2.8.1/angular-translate-loader-url.js',
-          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate-loader-static-files/2.8.1/angular-translate-loader-static-files.js',
-          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate-handler-log/2.8.1/angular-translate-handler-log.js'
+          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate/2.9.0/angular-translate.js',
+          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate-interpolation-messageformat/2.9.0/angular-translate-interpolation-messageformat.js',
+          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate-storage-cookie/2.9.0/angular-translate-storage-cookie.js',
+          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate-storage-local/2.9.0/angular-translate-storage-local.js',
+          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate-loader-url/2.9.0/angular-translate-loader-url.js',
+          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate-loader-static-files/2.9.0/angular-translate-loader-static-files.js',
+          'https://cdnjs.cloudflare.com/ajax/libs/angular-translate-handler-log/2.9.0/angular-translate-handler-log.js'
         ],
         styles: ['docs/css/styles.css']
       },

--- a/src/directive/translate-language.js
+++ b/src/directive/translate-language.js
@@ -36,7 +36,7 @@ angular.module('pascalprecht.translate')
           .translations('de',{
             'HELLO': 'Hallo Welt!'
           })
-          .translations(.preferredLanguage('en');
+          .preferredLanguage('en');
 
       });
 


### PR DESCRIPTION
- Update ngDocs to use translate v2.9.0
- Correct translate language directive example

Fixes #1474