### PR TITLE
fix(grunt): Work around uglify to preserveComments as expected

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -282,7 +282,7 @@ module.exports = function (grunt) {
     uglify: {
 
       options: {
-        preserveComments: 'some'
+        preserveComments: /(?:^!|@(?:license|preserve|cc_on))/
       },
 
       core: {


### PR DESCRIPTION
fix(grunt): Work around uglify to preserveComments as expected until it's fixed in their repo
Root cause: gruntjs/grunt-contrib-uglify#366 
Fixes #1461 