### PR TITLE
fix(service): prevent capitalization confusion

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -159,9 +159,9 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
       avail.push(angular.lowercase($availableLanguageKeys[i]));
     }
 
-    // Check for an exact match in our list of available keys
+    // Check for an exact (lowercase) match in our list of available keys
     if (indexOf(avail, locale) > -1) {
-      return preferred;
+      return $availableLanguageKeys[indexOf(avail, locale)];
     }
 
     if ($languageKeyAliases) {

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -92,8 +92,9 @@ describe('pascalprecht.translate', function () {
 
     beforeEach(module('pascalprecht.translate', function ($translateProvider) {
       $translateProvider
-        .registerAvailableLanguageKeys(['en', 'en_EN', 'de', 'de_DE'], {
-          'en_US': 'en_EN'
+        .registerAvailableLanguageKeys(['en', 'en_EN', 'en-us', 'de', 'de_DE'], {
+          'en_US': 'en_EN',
+          'en-*': 'en-us'
         })
         .translations('en', translationMock)
         .translations('en', {
@@ -246,6 +247,14 @@ describe('pascalprecht.translate', function () {
 
       it('should return resolved alias', function () {
         expect($translate.negotiateLocale('en_US')).toEqual('en_EN');
+      });
+
+      it('should not be duped by capitalization', function () {
+        expect($translate.negotiateLocale('EN-US')).toEqual('en-us');
+      });
+
+      it('should not be duped by mixed capitalization', function () {
+        expect($translate.negotiateLocale('en-US')).toEqual('en-us');
       });
 
       it('should return matching registered language if lang_REGION doesn\'t match', function () {


### PR DESCRIPTION
Greetings!

---

Given a key registration:
```
  .registerAvailableLanguageKeys(['en-us', 'zh-cn'], {
    'en*': 'en-us',
    'zh*': 'zh-cn',
    '*': 'en-us'
  })
```

We noticed an example where `en-US` was not being mapped to `en-us` as we expected.

This issue seems to be caused by:
```
if (indexOf(avail, locale) > -1) {
  return preferred;
}
```
Using our example, this bit would check whether or not the _lowercase version_ of 'en-US' is a registered language, which it is (in the form of 'en-us'), but then the mixed-cased version ('en-US') is returned instead of the registered key.

---

Thank you for `angular-translate`!