### PR TITLE
Update 22_unit-testing-with-angular-translate.ngdoc

### DIFF
--- a/docs/content/guide/en/22_unit-testing-with-angular-translate.ngdoc
+++ b/docs/content/guide/en/22_unit-testing-with-angular-translate.ngdoc
@@ -61,7 +61,7 @@ there's no translation table cached yet, angular-translate calls the registered
 loader **implicitly**. Why can this cause issues when unit testing your
 application?
 
-Well, to understand that, we have to take a look how we would right unit tests with
+Well, to understand that, we have to take a look how we would write unit tests with,
 for example, Jasmine. We start with a `describe()` block and load our angular app
 for each spec:
 
@@ -73,9 +73,8 @@ describe('myApp', function () {
 });
 </pre>
 
-Okay, so what this does, it makes sure that on every following spec our app module
-is instantiated. Next, we set up our `LanguageController` with a mocked scope like
-this:
+This makes sure that on every following spec our app module is instantiated. Next,
+we set up our `LanguageController` with a mocked scope like this:
 
 <pre>
 describe('myApp', function () {
@@ -104,12 +103,12 @@ When we run this test, we'll get the following error:
 Error: Unexpected request: GET locale-en.json
 ```
 
-So why do we get this error? So problem here is, that angular-translate calls the
-asynchronous loader implicitly. Which means, when `$translate` service is instantiated
+So why do we get this error? The problem here is that angular-translate calls the
+asynchronous loader implicitly. This means that when the `$translate` service is instantiated
 through DI, there's a XHR happening without us doing anything about it.
 
 When writing tests and there are XHRs, one has to explicitly say that one expects
-a XHR in a certain spec. This is part of proper testing. In other words,
+an XHR in a certain spec. This is part of proper testing. In other words,
 when we explicitly say that there's a XHR happening, this error shouldn't occur,
 right?
 
@@ -140,7 +139,7 @@ describe('myApp', function () {
 });
 </pre>
 
-It turns out, that this doesn't work either, because at the time when `expectGET()`
+It turns out that this doesn't work either, because at the time when `expectGET()`
 is called, the asynchronous loader has already been executed. Hell, is there no
 way to get around this issue?
 
@@ -148,12 +147,12 @@ way to get around this issue?
 
 Unfortunately, this issue is caused by the design of angular-translate. To get
 around these errors, all we can do is to overwrite our module configuration in
-our test suite, that it **doesn't** use asynchronous loader at all. When there's
+our test suite so that it **doesn't** use asynchronous loader at all. When there's
 no asynchronous loader, there's no XHR and therefore no error.
 
 So how do we overwrite our module configuration at runtime for our test suite?
-When instantiating an angular module, we can always apply a inline function which
-is executed as configuration function. This configuration function can be used
+When instantiating an angular module, we can always apply an inline function which
+is executed as a configuration function. This configuration function can be used
 to overwrite the modules configuration since we have access to all providers.
 
 Using the `$provide` provider, we can build a custom loader factory, which should


### PR DESCRIPTION
Fixing some grammar in the docs.