### PR TITLE
fix(service): allow instant function to also take care of post proces…

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1377,6 +1377,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
         if (translationTable && Object.prototype.hasOwnProperty.call(translationTable, translationId)) {
           Interpolator.setLocale(langKey);
           result = Interpolator.interpolate(translationTable[translationId], interpolateParams);
+          result = applyPostProcessing(translationId, translationTable[translationId], result, interpolateParams, langKey);
           if (result.substr(0, 2) === '@:') {
             return getFallbackTranslationInstant(langKey, result.substr(2), interpolateParams, Interpolator);
           }
@@ -1591,6 +1592,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
             result = determineTranslationInstant(translation.substr(2), interpolateParams, interpolationId, uses);
           } else {
             result = Interpolator.interpolate(translation, interpolateParams);
+            result = applyPostProcessing(translationId, translation, result, interpolateParams, uses);
           }
         } else {
           var missingTranslationHandlerTranslation;

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -2809,6 +2809,11 @@ describe('pascalprecht.translate', function () {
         $rootScope.$digest();
         expect(value).toEqual('BOTH,de_DE,BOTH_DE');
       });
+      it('should return a formatted postprocessed string on preferred language with instant', function () {
+        var value;
+        value = $translate.instant('BOTH');
+        expect(value).toEqual('BOTH,de_DE,BOTH_DE');
+      });
     });
   });
 


### PR DESCRIPTION
…s configuration

fixes an issue where the newly introduced postprocessFn was not working with $translate.instant() - this fix now also corrects the behavior for this corner case.
But remember: instant - calls will not take care of async loaders!