### PR TITLE
feat(directive): introduce a global keepContent setting

### DIFF
--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -286,7 +286,7 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
           }
           if (translateAttr === 'translate') {
             // default translate into innerHTML
-            if (successful || (!successful && typeof iAttr.translateKeepContent === 'undefined')) {
+            if (successful || (!successful && !$translate.isKeepContent() && typeof iAttr.translateKeepContent === 'undefined')) {
               iElement.empty().append(scope.preText + value + scope.postText);
             }
             var globallyEnabled = $translate.isPostCompilingEnabled();

--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -38,6 +38,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
       $forceAsyncReloadEnabled = false,
       $nestedObjectDelimeter = '.',
       $isReady = false,
+      $keepContent = false,
       loaderCache,
       directivePriority = 0,
       statefulFilter = true,
@@ -989,6 +990,29 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
     } else {
       postProcessFn = undefined;
     }
+    return this;
+  };
+
+  /**
+   * @ngdoc function
+   * @name pascalprecht.translate.$translateProvider#keepContent
+   * @methodOf pascalprecht.translate.$translateProvider
+   *
+   * @description
+   * If keepContent is set to true than translate directive will always use innerHTML
+   * as a default translation
+   *
+   * Example:
+   * <pre>
+   *  app.config(function ($translateProvider) {
+   *    $translateProvider.keepContent(true);
+   *  });
+   * </pre>
+   *
+   * @param {boolean} value - valid values are true or false
+   */
+  this.keepContent = function (value) {
+    $keepContent = !(!value);
     return this;
   };
 
@@ -1949,6 +1973,20 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
        */
       $translate.isForceAsyncReloadEnabled = function () {
         return $forceAsyncReloadEnabled;
+      };
+
+      /**
+       * @ngdoc function
+       * @name pascalprecht.translate.$translate#isKeepContent
+       * @methodOf pascalprecht.translate.$translate
+       *
+       * @description
+       * Returns whether keepContent or not
+       *
+       * @return {boolean} keepContent value
+       */
+      $translate.isKeepContent = function () {
+        return $keepContent;
       };
 
       /**

--- a/test/unit/directive/translate.spec.js
+++ b/test/unit/directive/translate.spec.js
@@ -852,4 +852,29 @@ describe('pascalprecht.translate', function () {
       expect(element.html()).toBe('Ich bin deutsch');
     });
   });
+
+  describe('set keepContent globally', function () {
+
+    var $compile, $rootScope, element;
+
+    beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+      $translateProvider
+        .translations('en', {
+          'HELLO': "Hello"
+        })
+        .keepContent(true)
+        .preferredLanguage('en');
+    }));
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+    }));
+
+    it('should use leave the inner content without change', function () {
+      element = $compile('<div translate="UNKNOWN">My content</divtranslate>')($rootScope);
+      $rootScope.$digest();
+      expect(element.html()).toBe('My content');
+    });
+  });
 });


### PR DESCRIPTION
Introduce a way to set `keepContent` globally.

If we set it to true we don't need to add `translate-keep-content` to every directive, it will become a default behavior