### PR TITLE
docs(guide): #1516 clarify documentation for failure cases

### DIFF
--- a/docs/content/guide/de/03_using-translate-service.ngdoc
+++ b/docs/content/guide/de/03_using-translate-service.ngdoc
@@ -40,12 +40,18 @@ eines Controllers wie folgt aussehen:
 app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
   $translate('HEADLINE').then(function (headline) {
     $scope.headline = headline;
+  }, function (error) {
+    $scope.headline = error;
   });
   $translate('PARAGRAPH').then(function (paragraph) {
     $scope.paragraph = paragraph;
+  }, function (error) {
+    $scope.paragraph = error;
   });
   $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
     $scope.namespaced_paragraph = anotherOne;
+  }, function (error) {
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -63,6 +69,10 @@ app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
     $scope.headline = translations.HEADLINE;
     $scope.paragraph = translations.PARAGRAPH;
     $scope.namespaced_paragraph = translations['NAMESPACE.PARAGRAPH'];
+  }, function (error) {
+    $scope.headline = error;
+    $scope.paragraph = error;
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -99,6 +109,8 @@ app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, 
   $rootScope.$on('$translateChangeSuccess', function () {
     $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;
+    }, function (error) {
+      $scope.headline = error;
     });
   });
 }]);
@@ -135,12 +147,18 @@ Hier ein funktionierendes Beispiel:
         // expose translation via `$translate` service
         $translate('HEADLINE').then(function (headline) {
           $scope.headline = headline;
+        }, function (error) {
+          $scope.headline = error;
         });
         $translate('PARAGRAPH').then(function (paragraph) {
           $scope.paragraph = paragraph;
+        }, function (error) {
+          $scope.paragraph = error;
         });
         $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
           $scope.namespaced_paragraph = anotherOne;
+        }, function (error) {
+          $scope.namespaced_paragraph = error;
         });
       }]);
     </script>

--- a/docs/content/guide/en/03_using-translate-service.ngdoc
+++ b/docs/content/guide/en/03_using-translate-service.ngdoc
@@ -34,21 +34,27 @@ app.controller('Ctrl', ['$translate', function ($translate) {
 Now to translate your contents with `$translate` service, all you have to do is
 to pass a translation ID which was registered with `$translateProvider` before.
 Since it could be that there's some asynchronous loading going on (we'll get into
-this later), `$translate` service behaves asynchronous too and returns a promise,
+this later), `$translate` service behaves asynchronously too and returns a promise,
 that either gets resolved with the translation of the given translation ID, or
-rejected with the translation ID. So the basic usage of `$translate` service
-on a controller (or service) level, would look like this:
+rejected with the translation ID as the error info. So the basic usage of `$translate`
+service on a controller (or service) level, would look like this:
 
 <pre>
 app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
   $translate('HEADLINE').then(function (headline) {
     $scope.headline = headline;
+  }, function (error) {
+    $scope.headline = error;
   });
   $translate('PARAGRAPH').then(function (paragraph) {
     $scope.paragraph = paragraph;
+  }, function (error) {
+    $scope.paragraph = error;
   });
   $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
     $scope.namespaced_paragraph = anotherOne;
+  }, function (error) {
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -67,6 +73,10 @@ app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
     $scope.headline = translations.HEADLINE;
     $scope.paragraph = translations.PARAGRAPH;
     $scope.namespaced_paragraph = translations['NAMESPACE.PARAGRAPH'];
+  }, function (error) {
+    $scope.headline = error;
+    $scope.paragraph = error;
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -89,7 +99,7 @@ Just call it this way:
 Please keep in mind that the usage of the `$translate` service doesn't provide a two-way
 data binding default! `$translate` service works asynchronously, which means
 it returns the translation for the given translation id, as soon as it could determine
-it. If it doesn't exist it'll probably just return the translation id.
+it. If it doesn't exist the promise will fail with the translation id.
 
 However, this doesn't mean that it knows when a languages has been changed. And because
 of that, translations translated through a directive `$translate` call, don't get
@@ -106,6 +116,8 @@ app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, 
   $rootScope.$on('$translateChangeSuccess', function () {
     $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;
+    }, function (error) {
+      $scope.headline = error;
     });
   });
 }]);
@@ -141,12 +153,18 @@ Here's a working sample:
         // expose translation via `$translate` service
         $translate('HEADLINE').then(function (headline) {
           $scope.headline = headline;
+        }, function (error) {
+          $scope.headline = error;
         });
         $translate('PARAGRAPH').then(function (paragraph) {
           $scope.paragraph = paragraph;
+        }, function (error) {
+          $scope.paragraph = error;
         });
         $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
           $scope.namespaced_paragraph = anotherOne;
+        }, function (error) {
+          $scope.namespaced_paragraph = error;
         });
       }]);
     </script>

--- a/docs/content/guide/es/03_using-translate-service.ngdoc
+++ b/docs/content/guide/es/03_using-translate-service.ngdoc
@@ -38,12 +38,18 @@ Entonces, el uso básico de `$translate` en la capa de servicios o de controlado
 app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
   $translate('HEADLINE').then(function (headline) {
     $scope.headline = headline;
+  }, function (error) {
+    $scope.headline = error;
   });
   $translate('PARAGRAPH').then(function (paragraph) {
     $scope.paragraph = paragraph;
+  }, function (error) {
+    $scope.paragraph = error;
   });
   $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
     $scope.namespaced_paragraph = anotherOne;
+  }, function (error) {
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -63,6 +69,10 @@ app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
     $scope.headline = translations.HEADLINE;
     $scope.paragraph = translations.PARAGRAPH;
     $scope.namespaced_paragraph = translations['NAMESPACE.PARAGRAPH'];
+  }, function (error) {
+    $scope.headline = error;
+    $scope.paragraph = error;
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -105,6 +115,8 @@ app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, 
   $rootScope.$on('$translateChangeSuccess', function () {
     $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;
+    }, function (error) {
+      $scope.headline = error;
     });
   });
 }]);
@@ -140,12 +152,18 @@ Este es un ejemplo que anda:
         // exponer la traducción vía el servicio `$translate` 
         $translate('HEADLINE').then(function (headline) {
           $scope.encabezado = headline;
+        }, function (error) {
+          $scope.encabezado = error;
         });
         $translate('PARAGRAPH').then(function (paragraph) {
           $scope.parrafo = paragraph;
+        }, function (error) {
+          $scope.parrafo = error;
         });
         $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
           $scope.parrafoConNamespace = anotherOne;
+        }, function (error) {
+          $scope.parrafoConNamespace = error;
         });
       }]);
     </script>

--- a/docs/content/guide/fr/03_using-translate-service.ngdoc
+++ b/docs/content/guide/fr/03_using-translate-service.ngdoc
@@ -42,12 +42,18 @@ au niveau d'un contrôleur (ou d'un service) devrait ressembler à ceci :
 app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
   $translate('HEADLINE').then(function (headline) {
     $scope.headline = headline;
+  }, function (error) {
+    $scope.headline = error;
   });
   $translate('PARAGRAPH').then(function (paragraph) {
     $scope.paragraph = paragraph;
+  }, function (error) {
+    $scope.paragraph = error;
   });
   $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
     $scope.namespaced_paragraph = anotherOne;
+  }, function (error) {
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -66,6 +72,10 @@ app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
     $scope.headline = translations.HEADLINE;
     $scope.paragraph = translations.PARAGRAPH;
     $scope.namespaced_paragraph = translations['NAMESPACE.PARAGRAPH'];
+  }, function (error) {
+    $scope.headline = error;
+    $scope.paragraph = error;
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -105,6 +115,8 @@ app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, 
   $rootScope.$on('$translateChangeSuccess', function () {
     $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;
+    }, function (error) {
+      $scope.headline = error;
     });
   });
 }]);
@@ -140,12 +152,18 @@ Voici un exemple qui fonctionne :
         // exposer les traductions via le service `$translate`
         $translate('HEADLINE').then(function (headline) {
           $scope.headline = headline;
+        }, function (error) {
+          $scope.headline = error;
         });
         $translate('PARAGRAPH').then(function (paragraph) {
           $scope.paragraph = paragraph;
+        }, function (error) {
+          $scope.paragraph = error;
         });
         $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
           $scope.namespaced_paragraph = anotherOne;
+        }, function (error) {
+          $scope.namespaced_paragraph = error;
         });
       }]);
     </script>

--- a/docs/content/guide/ru/03_using-translate-service.ngdoc
+++ b/docs/content/guide/ru/03_using-translate-service.ngdoc
@@ -41,12 +41,18 @@ app.controller('Ctrl', ['$translate', function ($translate) {
 app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
   $translate('HEADLINE').then(function (headline) {
    $scope.headline = headline;
+  }, function (error) {
+    $scope.headline = error;
   });
   $translate('PARAGRAPH').then(function (paragraph) {
     $scope.paragraph = paragraph;
+  }, function (error) {
+    $scope.paragraph = error;
   });
   $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
     $scope.namespaced_paragraph = anotherOne;
+  }, function (error) {
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -64,6 +70,10 @@ app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
     $scope.headline = translations.HEADLINE;
     $scope.paragraph = translations.PARAGRAPH;
     $scope.namespaced_paragraph = translations['NAMESPACE.PARAGRAPH'];
+  }, function (error) {
+    $scope.headline = error;
+    $scope.paragraph = error;
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -102,6 +112,8 @@ app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, 
   $rootScope.$on('$translateChangeSuccess', function () {
     $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;
+    }, function (error) {
+      $scope.headline = error;
     });
   });
 }]);
@@ -137,12 +149,18 @@ app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, 
         // expose translation via `$translate` service
         $translate('HEADLINE').then(function (headline) {
           $scope.headline = headline;
+        }, function (error) {
+          $scope.headline = error;
         });
         $translate('PARAGRAPH').then(function (paragraph) {
           $scope.paragraph = paragraph;
+        }, function (error) {
+          $scope.paragraph = error;
         });
         $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
           $scope.namespaced_paragraph = anotherOne;
+        }, function (error) {
+          $scope.namespaced_paragraph = error;
         });
       }]);
     </script>

--- a/docs/content/guide/uk/03_using-translate-service.ngdoc
+++ b/docs/content/guide/uk/03_using-translate-service.ngdoc
@@ -41,12 +41,18 @@ app.controller('Ctrl', ['$translate', function ($translate) {
 app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
   $translate('HEADLINE').then(function (headline) {
    $scope.headline = headline;
+  }, function (error) {
+    $scope.headline = error;
   });
   $translate('PARAGRAPH').then(function (paragraph) {
     $scope.paragraph = paragraph;
+  }, function (error) {
+    $scope.paragraph = error;
   });
   $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
     $scope.namespaced_paragraph = anotherOne;
+  }, function (error) {
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -64,6 +70,10 @@ app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
     $scope.headline = translations.HEADLINE;
     $scope.paragraph = translations.PARAGRAPH;
     $scope.namespaced_paragraph = translations['NAMESPACE.PARAGRAPH'];
+  }, function (error) {
+    $scope.headline = error;
+    $scope.paragraph = error;
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -103,6 +113,8 @@ app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, 
   $rootScope.$on('$translateChangeSuccess', function () {
     $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;
+    }, function (error) {
+      $scope.headline = error;
     });
   });
 }]);
@@ -138,12 +150,18 @@ app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, 
         // expose translation via `$translate` service
         $translate('HEADLINE').then(function (headline) {
           $scope.headline = headline;
+        }, function (error) {
+          $scope.headline = error;
         });
         $translate('PARAGRAPH').then(function (paragraph) {
           $scope.paragraph = paragraph;
+        }, function (error) {
+          $scope.paragraph = error;
         });
         $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
           $scope.namespaced_paragraph = anotherOne;
+        }, function (error) {
+          $scope.namespaced_paragraph = error;
         });
       }]);
     </script>

--- a/docs/content/guide/zh-cn/03_using-translate-service.ngdoc
+++ b/docs/content/guide/zh-cn/03_using-translate-service.ngdoc
@@ -32,12 +32,18 @@ app.controller('Ctrl', ['$translate', function ($translate) {
 app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
   $translate('HEADLINE').then(function (headline) {
     $scope.headline = headline;
+  }, function (error) {
+    $scope.headline = error;
   });
   $translate('PARAGRAPH').then(function (paragraph) {
     $scope.paragraph = paragraph;
+  }, function (error) {
+    $scope.paragraph = error;
   });
   $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
     $scope.namespaced_paragraph = anotherOne;
+  }, function (error) {
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -55,6 +61,10 @@ app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
     $scope.headline = translations.HEADLINE;
     $scope.paragraph = translations.PARAGRAPH;
     $scope.namespaced_paragraph = translations['NAMESPACE.PARAGRAPH'];
+  }, function (error) {
+    $scope.headline = error;
+    $scope.paragraph = error;
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -87,6 +97,8 @@ app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, 
   $rootScope.$on('$translateChangeSuccess', function () {
     $translate('HEADLINE').then(function (translation) {
       $scope.headline = translation;
+    }, function (error) {
+      $scope.headline = error;
     });
   });
 }]);
@@ -122,12 +134,18 @@ app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, 
         // expose translation via `$translate` service
         $translate('HEADLINE').then(function (headline) {
           $scope.headline = headline;
+        }, function (error) {
+          $scope.headline = error;
         });
         $translate('PARAGRAPH').then(function (paragraph) {
           $scope.paragraph = paragraph;
+        }, function (error) {
+          $scope.paragraph = error;
         });
         $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
           $scope.namespaced_paragraph = anotherOne;
+        }, function (error) {
+          $scope.namespaced_paragraph = error;
         });
       }]);
     </script>

--- a/docs/content/guide/zh-tw/03_using-translate-service.ngdoc
+++ b/docs/content/guide/zh-tw/03_using-translate-service.ngdoc
@@ -30,15 +30,21 @@ app.controller('Ctrl', ['$translate', function ($translate) {
 
 <pre>
 app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
-$translate('HEADLINE').then(function (headline) {
-$scope.headline = headline;
-});
-$translate('PARAGRAPH').then(function (paragraph) {
-$scope.paragraph = paragraph;
-});
-$translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
-$scope.namespaced_paragraph = anotherOne;
-});
+  $translate('HEADLINE').then(function (headline) {
+   $scope.headline = headline;
+  }, function (error) {
+    $scope.headline = error;
+  });
+  $translate('PARAGRAPH').then(function (paragraph) {
+    $scope.paragraph = paragraph;
+  }, function (error) {
+    $scope.paragraph = error;
+  });
+  $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
+    $scope.namespaced_paragraph = anotherOne;
+  }, function (error) {
+    $scope.namespaced_paragraph = error;
+  });
 }]);
 </pre>
 
@@ -55,6 +61,10 @@ app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
     $scope.headline = translations.HEADLINE;
     $scope.paragraph = translations.PARAGRAPH;
     $scope.namespaced_paragraph = translations['NAMESPACE.PARAGRAPH'];
+  }, function (error) {
+    $scope.headline = error;
+    $scope.paragraph = error;
+    $scope.namespaced_paragraph = error;
   });
 }]);
 </pre>
@@ -84,11 +94,13 @@ Just call it this way:
 
 <pre>
 app.controller('Ctrl', ['$scope', '$translate', '$rootScope', function ($scope, $translate, $rootScope) {
-$rooScope.$on('$translateChangeSuccess', function () {
-$translate('HEADLINE').then(function (translation) {
-$scope.headline = translation;
-});
-});
+  $rootScope.$on('$translateChangeSuccess', function () {
+    $translate('HEADLINE').then(function (translation) {
+      $scope.headline = translation;
+    }, function (error) {
+      $scope.headline = error;
+    });
+  });
 }]);
 </pre>
 
@@ -99,44 +111,50 @@ $scope.headline = translation;
 這是一個例子：
 
 <doc:example module="myApp">
-<doc:source>
-<script>
-var translations = {
-HEADLINE: 'What an awesome module!',
-PARAGRAPH: 'Srsly!',
-NAMESPACE: {
-PARAGRAPH: 'And it comes with awesome features!'
-}
-};
+  <doc:source>
+    <script>
+      var translations = {
+        HEADLINE: 'What an awesome module!',
+        PARAGRAPH: 'Srsly!',
+        NAMESPACE: {
+          PARAGRAPH: 'And it comes with awesome features!'
+        }
+      };
 
-var app = angular.module('myApp', ['pascalprecht.translate']);
+      var app = angular.module('myApp', ['pascalprecht.translate']);
 
-app.config(['$translateProvider', function ($translateProvider) {
-// add translation table
-$translateProvider
-.translations('en', translations)
-.preferredLanguage('en');
-}]);
+      app.config(['$translateProvider', function ($translateProvider) {
+        // add translation table
+        $translateProvider
+          .translations('en', translations)
+          .preferredLanguage('en');
+      }]);
 
-app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
-// expose translation via `$translate` service
-$translate('HEADLINE').then(function (headline) {
-$scope.headline = headline;
-});
-$translate('PARAGRAPH').then(function (paragraph) {
-$scope.paragraph = paragraph;
-});
-$translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
-$scope.namespaced_paragraph = anotherOne;
-});
-}]);
-</script>
-<div ng-controller="Ctrl">
-<h1>{{headline}}</h1>
-<p>{{paragraph}}</p>
-<p>{{namespaced_paragraph}}</p>
-</div>
-</doc:source>
+      app.controller('Ctrl', ['$scope', '$translate', function ($scope, $translate) {
+        // expose translation via `$translate` service
+        $translate('HEADLINE').then(function (headline) {
+          $scope.headline = headline;
+        }, function (error) {
+          $scope.headline = error;
+        });
+        $translate('PARAGRAPH').then(function (paragraph) {
+          $scope.paragraph = paragraph;
+        }, function (error) {
+          $scope.paragraph = error;
+        });
+        $translate('NAMESPACE.PARAGRAPH').then(function (anotherOne) {
+          $scope.namespaced_paragraph = anotherOne;
+        }, function (error) {
+          $scope.namespaced_paragraph = error;
+        });
+      }]);
+    </script>
+    <div ng-controller="Ctrl">
+      <h1>{{headline}}</h1>
+      <p>{{paragraph}}</p>
+      <p>{{namespaced_paragraph}}</p>
+    </div>
+  </doc:source>
 </doc:example>
 
 <br>


### PR DESCRIPTION
### Description

This is a fix for the issues discussed on #1516, namely that the docs do not mention that users must include a failure callback when resolving the Promise returned by `$translate`, if they want to handle the case when the translation key was not found.

@knalli -- is this what you had in mind? I've done only the English version for now; I'll fix up the other languages if you are happy with this.

