### PR TITLE
Feat translate instant sanitize strategy

### DIFF
--- a/docs/content/guide/de/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/de/15_custom-interpolators.ngdoc
@@ -20,7 +20,7 @@ die ein Objekt zurück gibt, die folgendes Interface implementiert:
 
 - `setLocale(langKey)` - Setzt die Sprache mit Sprachschlüssel
 - `getInterpolationIdentifier()` - Gibt einen Identifier für den Service zurück
-- `interpolate(string, interpolateParams)` - Interpoliert Strings gegen Interpolationparamter
+- `interpolate(string, interpolateParams, sanitizeStrategy)` - Interpoliert Strings gegen Interpolationparamter
 
 So könnte ein custom Interpolation-Service aussehen:
 
@@ -37,7 +37,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams) {
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
 
     }
   };
@@ -62,8 +62,8 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams) {
-      return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+      return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };
 });
@@ -144,8 +144,8 @@ So siehts aus:
             return 'custom';
           },
 
-          interpolate: function (string, interpolateParams) {
-            return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+          interpolate: function (string, interpolateParams, sanitizeStrategy) {
+            return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
           }
         };
       });

--- a/docs/content/guide/en/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/en/15_custom-interpolators.ngdoc
@@ -20,7 +20,7 @@ have to be provided by a custom interpolation service:
 
 - `setLocale(langKey)` - sets the currently used language
 - `getInterpolationIdentifier()` - returns an identifier for interpolation
-- `interpolate(string, interpolateParams)` - interpolates strings against interpolate params
+- `interpolate(string, interpolateParams, sanitizeStrategy)` - interpolates strings against interpolate params
 
 Let's see how it looks like when implementing a custom interpolation service. First,
 we implement the interface:
@@ -38,7 +38,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams) {
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
 
     }
   };
@@ -64,8 +64,8 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams) {
-      return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+      return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };
 });
@@ -148,8 +148,8 @@ Here' what it looks like:
             return 'custom';
           },
 
-          interpolate: function (string, interpolateParams) {
-            return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+          interpolate: function (string, interpolateParams, sanitizeStrategy) {
+            return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
           }
         };
       });

--- a/docs/content/guide/es/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/es/15_custom-interpolators.ngdoc
@@ -14,7 +14,7 @@ Cuando cree un serivcio de interpolación personalizado, hay muchas cosa que ya 
 
 - `setLocale(langKey)` - configura el lenguaje usado actualmente
 - `getInterpolationIdentifier()` - devuelve una clave para identificar la interpolación
-- `interpolate(string, interpolateParams)` - interpola cadenas contra parámetros de interpolación
+- `interpolate(string, interpolateParams, sanitizeStrategy)` - interpola cadenas contra parámetros de interpolación
 
 Veamos cómo se vería si implementáramos un servicio de interpolación personalizado. Primero, simplemente implementemos la interfaz:
 
@@ -31,7 +31,7 @@ app.factory('interpolacionPersonalizada', function () {
 
     },
 
-    interpolate: function (string, interpolateParams) {
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
 
     }
   };
@@ -55,8 +55,8 @@ app.factory('interpolacionPersonalizada', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams) {
-      return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+      return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };
 });
@@ -129,8 +129,8 @@ Así es como se vería:
             return 'custom';
           },
 
-          interpolate: function (string, interpolateParams) {
-            return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+          interpolate: function (string, interpolateParams, sanitizeStrategy) {
+            return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
           }
         };
       });

--- a/docs/content/guide/fr/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/fr/15_custom-interpolators.ngdoc
@@ -20,7 +20,7 @@ doivent être fournies par un service d'interpolation personnalisé :
 
 - `setLocale(langKey)` - définit la langue utilisée
 - `getInterpolationIdentifier()` - retourne un identifiant pour l'interpolation
-- `interpolate(string, interpolateParams)` - interpole le string en interpolateParams
+- `interpolate(string, interpolateParams, sanitizeStrategy)` - interpole le string en interpolateParams
 
 Regardons à quoi ressemble l'implémentation d'un service d'interpolation personnalisé. Tout d'abord,
 nous implémentons l'interface :
@@ -38,7 +38,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams) {
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
 
     }
   };
@@ -64,8 +64,8 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams) {
-      return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+      return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };
 });
@@ -148,8 +148,8 @@ Voici à quoi cela ressemble :
             return 'custom';
           },
 
-          interpolate: function (string, interpolateParams) {
-            return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+          interpolate: function (string, interpolateParams, sanitizeStrategy) {
+            return $locale + '_' + $interpolate(string)(interpolateParamsi, sanitizeStrategy) + '_' + $locale;
           }
         };
       });

--- a/docs/content/guide/ru/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/ru/15_custom-interpolators.ngdoc
@@ -19,7 +19,7 @@
 
 - `setLocale(langKey)` - устанавливает текущий язык
 - `getInterpolationIdentifier()` - возвращает идентификатор интерполяции
-- `interpolate(string, interpolateParams)` - интерполирует строки с параметрами интерполяции
+- `interpolate(string, interpolateParams, sanitizeStrategy)` - интерполирует строки с параметрами интерполяции
 
 Давайте посмотрим как это выглядит при создании пользовательского сервиса интерполяции. Во-первых,
 мы реализуем интерфейс:
@@ -37,7 +37,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams) {
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
 
     }
   };
@@ -63,8 +63,8 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams) {
-      return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+      return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };
 });
@@ -145,8 +145,8 @@ $translateProvider.addInterpolation('customInterpolation');
             return 'custom';
           },
 
-          interpolate: function (string, interpolateParams) {
-            return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+          interpolate: function (string, interpolateParams, sanitizeStrategy) {
+            return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
           }
         };
       });

--- a/docs/content/guide/uk/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/uk/15_custom-interpolators.ngdoc
@@ -18,7 +18,7 @@
 
 - `setLocale(langKey)` - встановлює поточну мову
 - `getInterpolationIdentifier()` - повертає ідентифікатор інтерполяції
-- `interpolate(string, interpolateParams)` - інтерполює рядки з параметрами інтерполяції
+- `interpolate(string, interpolateParams, sanitizeStrategy)` - інтерполює рядки з параметрами інтерполяції
 
 Давайте подивимося, як це виглядає при створенні користувацького сервісу інтерполяції. По-перше, ми
 реалізуємо інтерфейс:
@@ -36,7 +36,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams) {
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
 
     }
   };
@@ -62,8 +62,8 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams) {
-      return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+      return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };
 });
@@ -144,8 +144,8 @@ $translateProvider.addInterpolation('customInterpolation');
             return 'custom';
           },
 
-          interpolate: function (string, interpolateParams) {
-            return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+          interpolate: function (string, interpolateParams, sanitizeStrategy) {
+            return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
           }
         };
       });

--- a/docs/content/guide/zh-cn/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/zh-cn/15_custom-interpolators.ngdoc
@@ -15,7 +15,7 @@
 
 - `setLocale(langKey)` - 设置当前使用的语言
 - `getInterpolationIdentifier()` - 返回一个标识符插值
-- `interpolate(string, interpolateParams)` - 对字符串的params参数进行插值处理
+- `interpolate(string, interpolateParams, sanitizeStrategy)` - 对字符串的params参数进行插值处理
 
 让我们来看看怎么实现自定义的插值服务。首先，我们实现的接口：
 
@@ -32,7 +32,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams) {
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
 
     }
   };
@@ -56,8 +56,8 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams) {
-      return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+      return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };
 });
@@ -133,8 +133,8 @@ $translateProvider.addInterpolation('customInterpolation');
             return 'custom';
           },
 
-          interpolate: function (string, interpolateParams) {
-            return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+          interpolate: function (string, interpolateParams, sanitizeStrategy) {
+            return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
           }
         };
       });

--- a/docs/content/guide/zh-tw/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/zh-tw/15_custom-interpolators.ngdoc
@@ -15,7 +15,7 @@
 
 - `setLocale(langKey)` - 設置當前使用的語言
 - `getInterpolationIdentifier()` - 返回一個標識符插值
-- `interpolate(string, interpolateParams)` - 對字符串的params參數進行插值處理
+- `interpolate(string, interpolateParams, sanitizeStrategy)` - 對字符串的params參數進行插值處理
 
 讓我們來看看怎麼實現自定義的插值服務。首先，我們實現的接口：
 
@@ -32,7 +32,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams) {
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
 
     }
   };
@@ -56,8 +56,8 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams) {
-      return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+      return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };
 });
@@ -133,8 +133,8 @@ $translateProvider.addInterpolation('customInterpolation');
             return 'custom';
           },
 
-          interpolate: function (string, interpolateParams) {
-            return $locale + '_' + $interpolate(string)(interpolateParams) + '_' + $locale;
+          interpolate: function (string, interpolateParams, sanitizeStrategy) {
+            return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
           }
         };
       });

--- a/src/service/default-interpolation.js
+++ b/src/service/default-interpolation.js
@@ -73,9 +73,9 @@ function $translateDefaultInterpolation ($interpolate, $translateSanitization) {
    *
    * @returns {string} interpolated string.
    */
-  $translateInterpolator.interpolate = function (value, interpolationParams, context) {
+  $translateInterpolator.interpolate = function (value, interpolationParams, context, sanitizeStrategy) {
     interpolationParams = interpolationParams || {};
-    interpolationParams = $translateSanitization.sanitize(interpolationParams, 'params', undefined, context);
+    interpolationParams = $translateSanitization.sanitize(interpolationParams, 'params', sanitizeStrategy, context);
 
     var interpolatedText;
     if (angular.isNumber(value)) {
@@ -84,7 +84,7 @@ function $translateDefaultInterpolation ($interpolate, $translateSanitization) {
     } else if (angular.isString(value)) {
       // strings must be interpolated (that's the job here)
       interpolatedText = $interpolate(value)(interpolationParams);
-      interpolatedText = $translateSanitization.sanitize(interpolatedText, 'text', undefined, context);
+      interpolatedText = $translateSanitization.sanitize(interpolatedText, 'text', sanitizeStrategy, context);
     } else {
       // neither a number or a string, cant interpolate => empty string
       interpolatedText = '';

--- a/src/service/messageformat-interpolation.js
+++ b/src/service/messageformat-interpolation.js
@@ -96,9 +96,9 @@ function $translateMessageFormatInterpolation($translateSanitization, $cacheFact
    *
    * @returns {string} interpolated string.
    */
-  $translateInterpolator.interpolate = function (string, interpolationParams/*, context*/) {
+  $translateInterpolator.interpolate = function (string, interpolationParams, context, sanitizeStrategy) {
     interpolationParams = interpolationParams || {};
-    interpolationParams = $translateSanitization.sanitize(interpolationParams, 'params');
+    interpolationParams = $translateSanitization.sanitize(interpolationParams, 'params', sanitizeStrategy);
 
     var compiledFunction = $cache.get('mf:' + string);
 
@@ -122,7 +122,7 @@ function $translateMessageFormatInterpolation($translateSanitization, $cacheFact
     }
 
     var interpolatedText = compiledFunction(interpolationParams);
-    return $translateSanitization.sanitize(interpolatedText, 'text');
+    return $translateSanitization.sanitize(interpolatedText, 'text', sanitizeStrategy);
   };
 
   return $translateInterpolator;

--- a/test/unit/service/default-interpolation.spec.js
+++ b/test/unit/service/default-interpolation.spec.js
@@ -99,6 +99,20 @@ describe('pascalprecht.translate', function () {
       expect($translateSanitization.sanitize).toHaveBeenCalledWith(params, 'params', undefined, undefined);
     }));
 
+    it('should not sanitize the interpolation params when a null strategy value is passed',
+       inject(function ($translateSanitization) {
+      var text = 'Foo bar {{value}}';
+      var paramValue = '<span>Test</span>';
+      var params =  { value: paramValue };
+      var unsanitizedText = 'Foo bar <span>Test</span>';
+
+      spyOn($translateSanitization, 'sanitize').and.callThrough();
+      $translateDefaultInterpolation.useSanitizeValueStrategy('escapeParameters');
+
+      expect($translateDefaultInterpolation.interpolate(text, params, 'service', null)).toBe(unsanitizedText);
+      expect($translateSanitization.sanitize).toHaveBeenCalledWith(params, 'params', null, 'service');
+    }));
+
     it('should not sanitize the interpolation params (defaults)', inject(function ($translateSanitization) {
       var text = 'Foo <span>bar</span> {{value}}';
       var params =  { value: 'value' };
@@ -135,6 +149,19 @@ describe('pascalprecht.translate', function () {
       $translateSanitization.useStrategy('escapeParameters');
       expect($translateDefaultInterpolation.interpolate(text, params)).toBe(sanitizedText);
       //expect()
+    }));
+
+    it('should not sanitize the interpolated text when a null strategy value is passed',
+       inject(function ($translateSanitization) {
+      var text = 'Foo <span>bar</span> {{value}}';
+      var params =  { value: 'value' };
+      var interPolatedText = 'Foo <span>bar</span> value';
+
+      spyOn($translateSanitization, 'sanitize').and.callThrough();
+      $translateDefaultInterpolation.useSanitizeValueStrategy('escape');
+
+      expect($translateDefaultInterpolation.interpolate(text, params, 'service', null)).toBe(interPolatedText);
+      expect($translateSanitization.sanitize).toHaveBeenCalledWith(interPolatedText, 'text', null, 'service');
     }));
   });
 

--- a/test/unit/service/messageformat-interpolation.spec.js
+++ b/test/unit/service/messageformat-interpolation.spec.js
@@ -139,7 +139,21 @@ describe('pascalprecht.translate', function () {
       $translateMessageFormatInterpolation.useSanitizeValueStrategy('escapeParameters');
 
       expect($translateMessageFormatInterpolation.interpolate(text, params)).toBe(sanitizedText);
-      expect($translateSanitization.sanitize).toHaveBeenCalledWith(params, 'params');
+      expect($translateSanitization.sanitize).toHaveBeenCalledWith(params, 'params', undefined);
+    }));
+
+    it('should not sanitize the interpolation params when a null strategy value is passed',
+       inject(function ($translateSanitization) {
+      var text = 'Foo bar {value}';
+      var paramValue = '<span>Test</span>';
+      var params =  { value: paramValue };
+      var unsanitizedText = 'Foo bar <span>Test</span>';
+
+      spyOn($translateSanitization, 'sanitize').and.callThrough();
+      $translateMessageFormatInterpolation.useSanitizeValueStrategy('escapeParameters');
+
+      expect($translateMessageFormatInterpolation.interpolate(text, params, 'service', null)).toBe(unsanitizedText);
+      expect($translateSanitization.sanitize).toHaveBeenCalledWith(params, 'params', null);
     }));
 
     it('should sanitize the interpolated text', inject(function ($translateSanitization) {
@@ -152,7 +166,20 @@ describe('pascalprecht.translate', function () {
       $translateMessageFormatInterpolation.useSanitizeValueStrategy('escape');
 
       expect($translateMessageFormatInterpolation.interpolate(text, params)).toBe(sanitizedText);
-      expect($translateSanitization.sanitize).toHaveBeenCalledWith(interPolatedText, 'text');
+      expect($translateSanitization.sanitize).toHaveBeenCalledWith(interPolatedText, 'text', undefined);
+    }));
+
+    it('should not sanitize the interpolated text when a null strategy value is passed',
+       inject(function ($translateSanitization) {
+      var text = 'Foo <span>bar</span> {value}';
+      var params =  { value: 'value' };
+      var interPolatedText = 'Foo <span>bar</span> value';
+
+      spyOn($translateSanitization, 'sanitize').and.callThrough();
+      $translateMessageFormatInterpolation.useSanitizeValueStrategy('escape');
+
+      expect($translateMessageFormatInterpolation.interpolate(text, params, 'service', null)).toBe(interPolatedText);
+      expect($translateSanitization.sanitize).toHaveBeenCalledWith(interPolatedText, 'text', null);
     }));
   });
 });

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -2264,11 +2264,13 @@ describe('pascalprecht.translate', function () {
         .translations('en', translationMock)
         .translations('en', {
           'FOO': 'bar',
-          'BAR': 'foo'
+          'BAR': 'foo',
+          'FOOBAR': 'Foo bar {{value}}',
         })
         .translations('de', {
           'FOO': 'faa'
         })
+        .useSanitizeValueStrategy('escape')
         .preferredLanguage('en');
     }));
 
@@ -2307,6 +2309,11 @@ describe('pascalprecht.translate', function () {
     it('should use forceLanguage with multiple translation ids', function() {
       expect($translate.instant(['FOO'], null, null, 'de').FOO).toEqual('faa');
     });
+
+    it('should override sanitize strategy for one call', function() {
+      expect($translate.instant('FOOBAR', { value: '<p>value</p>' }, null, null, null))
+        .toEqual('Foo bar <p>value</p>');
+    });
   });
 
   describe('$translate.instant (with fallback)', function () {
@@ -2316,11 +2323,13 @@ describe('pascalprecht.translate', function () {
         .useLoader('customLoader')
         .translations('en', {
           'FOO': 'bar',
-          'BAR': 'foo'
+          'BAR': 'foo',
+          'FOOBAR': 'Foo bar {{value}}',
         })
         .translations('de', {
           'FOO2': 'bar2'
         })
+        .useSanitizeValueStrategy('escape')
         .preferredLanguage('de')
         .fallbackLanguage('en');
 
@@ -2351,6 +2360,12 @@ describe('pascalprecht.translate', function () {
       expect($translate.instant('FOO2')).toEqual('bar2');
     });
 
+    it('should return translation if translation id exist' +
+       'in a fallback language and skip sanitize if a' +
+       'null value is passed', function () {
+      expect($translate.instant('FOOBAR', { value: '<p>value</p>' }, null, null, null)).toEqual('Foo bar <p>value</p>');
+    });
+
     it('should return translation id if translation id nost exist', function () {
       expect($translate.instant('FOO3')).toEqual('FOO3');
     });
@@ -2359,8 +2374,19 @@ describe('pascalprecht.translate', function () {
       expect($translate.instant('FOO4 {{value}}', {'value': 'PARAM'})).toEqual('FOO4 PARAM');
     });
 
+    it('should return translation id with default interpolator' +
+       'if translation id nost exist and don\'t sanitize if' +
+       'the sanitize strategy is overriden', function () {
+      expect($translate.instant('FOO4 {{value}}', { value: '<p>value</p>'}, null, null, null)).toEqual('FOO4 <p>value</p>');
+    });
+
     it('should return translation id if translation id exist with forceLanguage', function () {
       expect($translate.instant('FOO', null, null, 'de')).toEqual('bar');
+    });
+
+    it('should return translation id if translation id exist with forceLanguage' +
+       'and don\'t sanitize when sanitize strategy is overriden to null', function () {
+      expect($translate.instant('FOOBAR', { value: '<p>value</p>'}, null, 'de', null)).toEqual('Foo bar <p>value</p>');
     });
   });
 


### PR DESCRIPTION
## Motivation

Sometimes non html messages need to be translated. For example in notification popups, etc.
The only solution as for now, is to the disable sanitize strategy globally

```javascript
$translateProvider.useSanitizeValueStrategy(null);
```

or to use this kind of hacks:

```javascript
$translateSanitization.useStrategy(null);
var translation = $translate.instant('KEY');
$translateSanitization.useStrategy('escape');
```

which disables sanitization globally for a short period of time, and does a call to $translate.instant in that time lap.

## Proposed solution 

This modification add a `sanitizeStrategy` parameter to the $translate.instant function to allow to override sanitization strategy for one call. Without having to change it in the service configuration for all `$translate` calls.

### Usage

To disable sanitization: 

```javascript
var translation = $translate.instant('KEY  {{ value }}', { value: '<p>hello</p>' }, null, null, null);
console.log(translation)

-> KEY <p>hello</p>
```

The important parameter is the 5th one, and it could take any valid sanitization strategy: escape, escapeParameters, etc.  Including the `null` (!= undefined) value which disables sanitization.
   
Relates #1297 