### PR TITLE
feat(directive): introduce standalone translate-attr directive

### DIFF
--- a/docs/content/guide/en/05_using-translate-directive.ngdoc
+++ b/docs/content/guide/en/05_using-translate-directive.ngdoc
@@ -70,17 +70,32 @@ $translateProvider.usePostCompiling(true);
 ## Translate HTML Attributes
 You can already translate any HTML element's attribute using the `translate` filter, 
 but as mentioned above this can create a ton of unnecessary watches on your pages. 
-Here's a better way to translate those attributes using the `translate` directive!
+Here's a better way to translate those attributes using the `translate-attr` directive (starting version 2.12)!
 
 ```
-<ANY translate translate-attr-ATTRIBUTE_NAME="TRANSLATION_ID></ANY>
+<ANY translate-attr="{ ATTRIBUTE_NAME: 'TRANSLATION_ID' }"></ANY>
 ```
 
 Substitute the HTML element attribute's name for `ATTRIBUTE_NAME` and you will get
 all the benefits of the `translate` directive used for that attribute!
 
 ```
-<img src="mylogo.png" translate translate-attr-alt="LOGO"></img>
+<img src="mylogo.png" translate-attr="{ alt: 'LOGO' }"></img>
+```
+
+This attribute is parsed and watched, so you can also supply a controller-provided object,
+and you can use one-time binding by prefixing your statement with `::`. Here's an example of both:
+
+```
+// given a scope variable attrTranslations = { alt: 'LOGO', title: 'TITLE' }
+<img src="mylogo.png" translate-attr="::attrTranslations">
+```
+
+If your angular-translate did not reach version 2.12, you can use the deprecated way to translate attributes
+using the `translate` directive:
+
+```
+<ANY translate translate-attr-ATTRIBUTE_NAME="TRANSLATION_ID"></ANY>
 ```
 
 ## Example
@@ -104,7 +119,7 @@ After that we update our view with our new translation IDs:
 
 <pre>
 <p>{{ 'HEADLINE' | translate }}</p>
-<img src="mylogo.png" translate translate-attr-alt="LOGO"></img>
+<img src="mylogo.png" translate-attr="{ alt: 'LOGO' }"></img>
 <p>{{ 'PARAGRAPH' | translate }}</p>
 
 <p translate>PASSED_AS_TEXT</p>
@@ -142,7 +157,7 @@ Our updated app then looks like this:
     </script>
     <div ng-controller="Ctrl">
       <p>{{ 'HEADLINE' | translate }}</p>
-      <img src="mylogo.png" translate translate-attr-alt="LOGO"></img>
+      <img src="mylogo.png" translate-attr="{ alt: 'LOGO' }"></img>
       <p>{{ 'PARAGRAPH' | translate }}</p>
 
       <p translate>PASSED_AS_TEXT</p>

--- a/src/directive/translate-attr.js
+++ b/src/directive/translate-attr.js
@@ -1,0 +1,141 @@
+angular.module('pascalprecht.translate')
+/**
+ * @ngdoc directive
+ * @name pascalprecht.translate.directive:translate-attr
+ * @restrict A
+ *
+ * @description
+ * Translates attributes like translate-attr-ATTR, but with an object like ng-class.
+ * Internally it uses `translate` service to translate translation id. It possible to
+ * pass an optional `translate-values` object literal as string into translation id.
+ *
+ * @param {string=} translate-attr Object literal mapping attributes to translation ids.
+ * @param {string=} translate-values Values to pass into the translation ids. Can be passed as object literal string.
+ *
+ * @example
+   <example module="ngView">
+    <file name="index.html">
+      <div ng-controller="TranslateCtrl">
+
+        <input translate-attr="{ placeholder: translationId, title: 'WITH_VALUES' }" translate-values="{value: 5}" />
+
+      </div>
+    </file>
+    <file name="script.js">
+      angular.module('ngView', ['pascalprecht.translate'])
+
+      .config(function ($translateProvider) {
+
+        $translateProvider.translations('en',{
+          'TRANSLATION_ID': 'Hello there!',
+          'WITH_VALUES': 'The following value is dynamic: {{value}}',
+        }).preferredLanguage('en');
+
+      });
+
+      angular.module('ngView').controller('TranslateCtrl', function ($scope) {
+        $scope.translationId = 'TRANSLATION_ID';
+
+        $scope.values = {
+          value: 78
+        };
+      });
+    </file>
+    <file name="scenario.js">
+      it('should translate', function () {
+        inject(function ($rootScope, $compile) {
+          $rootScope.translationId = 'TRANSLATION_ID';
+
+          element = $compile('<input translate-attr="{ placeholder: translationId, title: 'WITH_VALUES' }" translate-values="{ value: 5 }" />')($rootScope);
+          $rootScope.$digest();
+          expect(element.attr('placeholder)).toBe('Hello there!');
+          expect(element.attr('title)).toBe('The following value is dynamic: 5');
+        });
+      });
+    </file>
+   </example>
+ */
+.directive('translateAttr', translateAttrDirective);
+function translateAttrDirective($translate, $rootScope) {
+
+  'use strict';
+
+  return {
+    restrict: 'A',
+    priority: $translate.directivePriority(),
+    link: function linkFn(scope, element, attr) {
+
+      var translateAttr,
+          translateValues,
+          previousAttributes = {};
+
+      // Main update translations function
+      var updateTranslations = function() {
+        angular.forEach(translateAttr, function (translationId, attributeName) {
+          if (!translationId) return;
+          previousAttributes[attributeName] = true;
+
+          // if translation id starts with '.' and translateNamespace given, prepend namespace
+          if (scope.translateNamespace && translationId.charAt(0) === '.') {
+            translationId = scope.translateNamespace + translationId;
+          }
+          $translate(translationId, translateValues, attr.translateInterpolation, undefined, scope.translateLanguage)
+            .then(function (translation) {
+              element.attr(attributeName, translation);
+            }, function (translationId) {
+              element.attr(attributeName, translationId);
+            });
+        });
+
+        // Removing unused attributes that were previously used
+        angular.forEach(previousAttributes, function (flag, attributeName) {
+          if (!translateAttr[attributeName]) {
+            element.removeAttr(attributeName);
+            delete previousAttributes[attributeName];
+          }
+        });
+      }
+
+      // Watch for attribute changes
+      watchAttribute(
+        scope, attr.translateAttr,
+        function (newValue) { translateAttr = newValue; },
+        function() { updateTranslations() }
+      );
+      // Watch for value changes
+      watchAttribute(
+        scope, attr.translateValues,
+        function (newValue) { translateValues = newValue; },
+        function() { updateTranslations() }
+      );
+
+      if (attr.translateValues)
+        scope.$watch(attr.translateValues, updateTranslations, true);
+
+      // Replaced watcher on translateLanguage with event listener
+      scope.$on('translateLanguageChanged', updateTranslations);
+
+      // Ensures the text will be refreshed after the current language was changed
+      // w/ $translate.use(...)
+      var unbind = $rootScope.$on('$translateChangeSuccess', updateTranslations);
+
+      updateTranslations();
+      scope.$on('$destroy', unbind);
+    }
+  };
+}
+
+function watchAttribute(scope, attribute, valueCallback, changeCallback) {
+  if (!attribute) return;
+  if (attribute.substr(0, 2) === '::') {
+    attribute = attribute.substr(2);
+  } else {
+    scope.$watch(attribute, function(newValue) {
+      valueCallback(newValue);
+      changeCallback();
+    }, true);
+  }
+  valueCallback(scope.$eval(attribute));
+}
+
+translateAttrDirective.displayName = 'translateAttrDirective';

--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -2,7 +2,6 @@ angular.module('pascalprecht.translate')
 /**
  * @ngdoc directive
  * @name pascalprecht.translate.directive:translate
- * @requires $q, 
  * @requires $interpolate, 
  * @requires $compile, 
  * @requires $parse, 
@@ -95,7 +94,7 @@ angular.module('pascalprecht.translate')
    </example>
  */
 .directive('translate', translateDirective);
-function translateDirective($translate, $q, $interpolate, $compile, $parse, $rootScope) {
+function translateDirective($translate, $interpolate, $compile, $parse, $rootScope) {
 
   'use strict';
 
@@ -217,7 +216,7 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
         });
 
         for (var translateAttr in iAttr) {
-          if (iAttr.hasOwnProperty(translateAttr) && translateAttr.substr(0, 13) === 'translateAttr') {
+          if (iAttr.hasOwnProperty(translateAttr) && translateAttr.substr(0, 13) === 'translateAttr' && translateAttr.length > 13) {
             observeAttributeTranslation(translateAttr);
           }
         }
@@ -314,7 +313,7 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
         }
 
         // Replaced watcher on translateLanguage with event listener
-        var unbindTranslateLanguage = scope.$on('translateLanguageChanged', updateTranslations);
+        scope.$on('translateLanguageChanged', updateTranslations);
 
         // Ensures the text will be refreshed after the current language was changed
         // w/ $translate.use(...)
@@ -332,10 +331,7 @@ function translateDirective($translate, $q, $interpolate, $compile, $parse, $roo
           observeElementTranslation(iAttr.translate);
         }
         updateTranslations();
-        scope.$on('$destroy', function(){
-          unbindTranslateLanguage();
-          unbind();
-        });
+        scope.$on('$destroy', unbind);
       };
     }
   };

--- a/test/unit/directive/translate-attr.spec.js
+++ b/test/unit/directive/translate-attr.spec.js
@@ -1,0 +1,172 @@
+/* jshint camelcase: false, quotmark: false, unused: false */
+/* global inject: false */
+'use strict';
+
+describe('pascalprecht.translate', function () {
+
+  describe('$translateDirective (single-lang)', function () {
+
+    beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+      $translateProvider
+        .translations('en', {
+          'message': 'Hello',
+          'second_message': 'Bye',
+          'with_value': 'This is {{value}}',
+          'namespace': {
+            'message': 'Namespaced',
+          }
+        }).translations('de', {
+          'message': 'Hallo'
+        }).preferredLanguage('en');
+    }));
+
+    var $compile, $rootScope, $translate, element;
+
+    beforeEach(inject(function (_$compile_, _$rootScope_, _$translate_) {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+      $translate = _$translate_;
+    }));
+
+    describe('multiple attributes', function() {
+      it('should support inline', function() {
+        element = $compile('<div translate-attr="{ one: \'message\', two: \'second_message\' }" />')($rootScope);
+        $rootScope.$digest();
+        expect(element.attr('one')).toBe('Hello');
+        expect(element.attr('two')).toBe('Bye');
+      });
+
+      it('should support addition', function() {
+        $rootScope.attributes = { 'one': 'message' };
+        element = $compile('<div translate-attr="attributes" />')($rootScope);
+
+        $rootScope.$digest();
+        expect(element.attr('one')).toBe('Hello');
+        expect(element[0].hasAttribute('two')).toBe(false);
+
+        $rootScope.attributes.two = 'second_message';
+        $rootScope.$digest();
+        expect(element.attr('one')).toBe('Hello');
+        expect(element.attr('two')).toBe('Bye');
+      });
+
+      it('should support remove', function() {
+        $rootScope.attributes = { 'one': 'message', 'two': 'second_message' };
+        element = $compile('<div translate-attr="attributes" />')($rootScope);
+
+        $rootScope.$digest();
+        expect(element.attr('one')).toBe('Hello');
+        expect(element.attr('two')).toBe('Bye');
+
+        delete $rootScope.attributes.two;
+        $rootScope.$digest();
+        expect(element.attr('one')).toBe('Hello');
+        expect(element[0].hasAttribute('two')).toBe(false);
+      });
+    });
+
+    describe('translation id', function() {
+      it('should support change', function() {
+        $rootScope.attributes = { 'attr': 'message' };
+        element = $compile('<div translate-attr="attributes" />')($rootScope);
+
+        $rootScope.$digest();
+        expect(element.attr('attr')).toBe('Hello');
+
+        $rootScope.attributes.attr = 'second_message';
+        $rootScope.$digest();
+        expect(element.attr('attr')).toBe('Bye');
+      });
+
+      it('should support remove', function() {
+        $rootScope.attributes = { 'attr': 'message' };
+        element = $compile('<div translate-attr="attributes" />')($rootScope);
+
+        $rootScope.$digest();
+        expect(element.attr('attr')).toBe('Hello');
+
+        $rootScope.attributes.attr = '';
+        $rootScope.$digest();
+        expect(element[0].hasAttribute('attr')).toBe(false);
+      });
+    });
+
+    it('should support changed value', function() {
+      $rootScope.values = { 'value': 'some value' };
+      element = $compile('<div translate-attr="{ attr: \'with_value\' }" translate-values="values" />')($rootScope);
+
+      $rootScope.$digest();
+      expect(element.attr('attr')).toBe('This is some value');
+
+      $rootScope.values.value = 'another value';
+      $rootScope.$digest();
+      expect(element.attr('attr')).toBe('This is another value');
+    });
+
+    describe('language', function() {
+      it('should support change', function() {
+        element = $compile('<div translate-attr="{ attr: \'message\' }" />')($rootScope);
+
+        $rootScope.$digest();
+        expect(element.attr('attr')).toBe('Hello');
+
+        $translate.use('de');
+        $rootScope.$digest();
+        expect(element.attr('attr')).toBe('Hallo');
+      });
+
+      it('should support translateLanguage', function() {
+        $rootScope.translateLanguage = 'de';
+        element = $compile('<div translate-attr="{ attr: \'message\' }" />')($rootScope);
+        $rootScope.$digest();
+        expect(element.attr('attr')).toBe('Hallo');
+      });
+    });
+
+    it('should support translateNamespace', function() {
+      $rootScope.translateNamespace = 'namespace';
+      element = $compile('<div translate-attr="{ attr: \'.message\' }" />')($rootScope);
+      $rootScope.$digest();
+      expect(element.attr('attr')).toBe('Namespaced');
+    });
+
+    describe('bind', function() {
+      it('should watch', function() {
+        var translation = "message";
+        $rootScope.generator = function() { return translation; };
+        spyOn($rootScope, 'generator').and.callThrough();
+
+        element = $compile('<div translate-attr="{ attr: generator() }" />')($rootScope);
+
+        $rootScope.$digest();
+        expect(element.attr('attr')).toBe('Hello');
+        expect($rootScope.generator).toHaveBeenCalled();
+
+        $rootScope.generator.calls.reset();
+        translation = 'second_message';
+        $rootScope.$digest();
+        expect(element.attr('attr')).toBe('Bye');
+        expect($rootScope.generator).toHaveBeenCalled();
+      });
+
+      it('should support one-time bind', function() {
+        var translation = "message";
+        $rootScope.generator = function() { return translation; };
+        spyOn($rootScope, 'generator').and.callThrough();
+
+        element = $compile('<div translate-attr="::{ attr: generator() }" />')($rootScope);
+
+        $rootScope.$digest();
+        expect(element.attr('attr')).toBe('Hello');
+        expect($rootScope.generator).toHaveBeenCalled();
+
+        $rootScope.generator.calls.reset();
+        translation = 'second_message';
+        $rootScope.$digest();
+        expect(element.attr('attr')).toBe('Hello');
+        expect($rootScope.generator).not.toHaveBeenCalled();
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
Relates to #1027, usage:

```html
<input translate-attr="{ placeholder: 'TRANSLATION_ID' }" />
```

Also, a few translate directive cleanups.