### PR TITLE
fix(service): return empty string when found in fallback

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1507,7 +1507,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
         if (fallbackLanguageIndex < $fallbackLanguage.length) {
           var langKey = $fallbackLanguage[fallbackLanguageIndex];
           result = getFallbackTranslationInstant(langKey, translationId, interpolateParams, Interpolator);
-          if (!result) {
+          if (!result && result !== '') {
             result = resolveForFallbackLanguageInstant(fallbackLanguageIndex + 1, translationId, interpolateParams, Interpolator);
           }
         }

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -2316,10 +2316,14 @@ describe('pascalprecht.translate', function () {
         .useLoader('customLoader')
         .translations('en', {
           'FOO': 'bar',
-          'BAR': 'foo'
+          'BAR': 'foo',
+          'BARE': ''
         })
         .translations('de', {
           'FOO2': 'bar2'
+        })
+        .translations('fr', {
+          'BARE': 'bare'
         })
         .preferredLanguage('de')
         .fallbackLanguage('en');
@@ -2349,10 +2353,15 @@ describe('pascalprecht.translate', function () {
     it('should return translation if translation id exist', function () {
       expect($translate.instant('FOO')).toEqual('bar');
       expect($translate.instant('FOO2')).toEqual('bar2');
+      expect($translate.instant('BARE')).toEqual('');
     });
 
     it('should return translation id if translation id nost exist', function () {
       expect($translate.instant('FOO3')).toEqual('FOO3');
+    });
+
+    it('should return the first translation if multiple fallbacks exist', function () {
+      expect($translate.instant('BARE')).toEqual('');
     });
 
     it('should return translation id with default interpolator if translation id nost exist', function () {


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
For some strings I'd like the default to be an empty string. Omitting the key/value pair `{}` and having a empty string value `{ EMPTY_DEFAULT: '' }` are treated the same - returning the KEY surrounded by not found indicators.

This change makes the behaviour of finding the fallback translation match that of finding a normal translation. See https://github.com/angular-translate/angular-translate/blob/master/src/service/translate.js#L2175

I've not looked in the angular-translate codebase before but I think this is a breaking change when the users have multiple fallback languages and an earlier one has an empty string (look at unit test - existing behaviour is returning `bare`)

💔Thank you!

