### PR TITLE
docs(guide): Confusing pluralization notes

### DIFF
--- a/docs/content/guide/en/14_pluralization.ngdoc
+++ b/docs/content/guide/en/14_pluralization.ngdoc
@@ -47,10 +47,6 @@ service. Don't forget to embed MessageFormat.js itself first:
 <script src="path/to/angular-translate-interpolation-messageformat"></script>
 </pre>
 
-**Note: Please make sure to embed a corresponding locale file provided by MessageFormat.
-These files provide locale rules for a specific locale this is required to get
-proper pluralization!**
-
 Once everything is there, we can use `$translateProvider` to tell angular-translate
 to use the MessageFormat interpolation, instead of the default one.
 `$translateProvider` provides a method called `useMessageFormatInterpolation()`
@@ -207,7 +203,7 @@ translation ID:
 // "He liked this."
 </pre>
 
-Here is a working example (please note: There is also an embedded file for locale 'de'):
+Here is a working example:
 
 <doc:example module="myApp">
   <doc:source>


### PR DESCRIPTION
### Your checklist for this pull request

🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **canary branch** (left side). Also you should start _your branch_ off _our canary_.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
### Description

The docs had old notes in them about including pluralization rules from MessageFormat.js. You should no longer do that. This was addressed a long time ago in [the actual code](https://github.com/angular-translate/angular-translate/commit/fa05144ccdcfe6f33dac961ad061317254cf8245), but the documentation was not updated.

💔Thank you!
