### PR TITLE
Angular translate handler log strict DI support

### DIFF
--- a/src/service/handler-log.js
+++ b/src/service/handler-log.js
@@ -11,7 +11,7 @@ angular.module('pascalprecht.translate')
  *
  * @returns {function} Handler function
  */
-.factory('$translateMissingTranslationHandlerLog', $translateMissingTranslationHandlerLog);
+.factory('$translateMissingTranslationHandlerLog', ['$log', $translateMissingTranslationHandlerLog]);
 
 function $translateMissingTranslationHandlerLog ($log) {
 


### PR DESCRIPTION
Add strict DI support to Angular translate handler log (src/service/handler-log.js).