### PR TITLE
feat(service): add translationId to custom interpolation service

### DIFF
--- a/docs/content/guide/de/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/de/15_custom-interpolators.ngdoc
@@ -20,7 +20,7 @@ die ein Objekt zurück gibt, die folgendes Interface implementiert:
 
 - `setLocale(langKey)` - Setzt die Sprache mit Sprachschlüssel
 - `getInterpolationIdentifier()` - Gibt einen Identifier für den Service zurück
-- `interpolate(string, interpolateParams, sanitizeStrategy)` - Interpoliert Strings gegen Interpolationparamter
+- `interpolate(string, interpolateParams, context, sanitizeStrategy, translationId)` - Interpoliert Strings gegen Interpolationparamter
 
 So könnte ein custom Interpolation-Service aussehen:
 
@@ -37,7 +37,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
 
     }
   };
@@ -62,7 +62,7 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
       return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };

--- a/docs/content/guide/en/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/en/15_custom-interpolators.ngdoc
@@ -20,7 +20,7 @@ have to be provided by a custom interpolation service:
 
 - `setLocale(langKey)` - sets the currently used language
 - `getInterpolationIdentifier()` - returns an identifier for interpolation
-- `interpolate(string, interpolateParams, sanitizeStrategy)` - interpolates strings against interpolate params
+- `interpolate(string, interpolateParams, context, sanitizeStrategy, translationId)` - interpolates strings against interpolate params
 
 Let's see how it looks like when implementing a custom interpolation service. First,
 we implement the interface:
@@ -38,7 +38,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
 
     }
   };
@@ -64,7 +64,7 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
       return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };

--- a/docs/content/guide/es/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/es/15_custom-interpolators.ngdoc
@@ -14,7 +14,7 @@ Cuando cree un serivcio de interpolación personalizado, hay muchas cosa que ya 
 
 - `setLocale(langKey)` - configura el lenguaje usado actualmente
 - `getInterpolationIdentifier()` - devuelve una clave para identificar la interpolación
-- `interpolate(string, interpolateParams, sanitizeStrategy)` - interpola cadenas contra parámetros de interpolación
+- `interpolate(string, interpolateParams, context, sanitizeStrategy, translationId)` - interpola cadenas contra parámetros de interpolación
 
 Veamos cómo se vería si implementáramos un servicio de interpolación personalizado. Primero, simplemente implementemos la interfaz:
 
@@ -31,7 +31,7 @@ app.factory('interpolacionPersonalizada', function () {
 
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
 
     }
   };
@@ -55,7 +55,7 @@ app.factory('interpolacionPersonalizada', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
       return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };

--- a/docs/content/guide/fr/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/fr/15_custom-interpolators.ngdoc
@@ -20,7 +20,7 @@ doivent être fournies par un service d'interpolation personnalisé :
 
 - `setLocale(langKey)` - définit la langue utilisée
 - `getInterpolationIdentifier()` - retourne un identifiant pour l'interpolation
-- `interpolate(string, interpolateParams, sanitizeStrategy)` - interpole le string en interpolateParams
+- `interpolate(string, interpolateParams, context, sanitizeStrategy, translationId)` - interpole le string en interpolateParams
 
 Regardons à quoi ressemble l'implémentation d'un service d'interpolation personnalisé. Tout d'abord,
 nous implémentons l'interface :
@@ -38,7 +38,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
 
     }
   };
@@ -64,7 +64,7 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
       return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };

--- a/docs/content/guide/ru/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/ru/15_custom-interpolators.ngdoc
@@ -19,7 +19,7 @@
 
 - `setLocale(langKey)` - устанавливает текущий язык
 - `getInterpolationIdentifier()` - возвращает идентификатор интерполяции
-- `interpolate(string, interpolateParams, sanitizeStrategy)` - интерполирует строки с параметрами интерполяции
+- `interpolate(string, interpolateParams, context, sanitizeStrategy, translationId)` - интерполирует строки с параметрами интерполяции
 
 Давайте посмотрим как это выглядит при создании пользовательского сервиса интерполяции. Во-первых,
 мы реализуем интерфейс:
@@ -37,7 +37,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
 
     }
   };
@@ -63,7 +63,7 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
       return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };

--- a/docs/content/guide/uk/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/uk/15_custom-interpolators.ngdoc
@@ -18,7 +18,7 @@
 
 - `setLocale(langKey)` - встановлює поточну мову
 - `getInterpolationIdentifier()` - повертає ідентифікатор інтерполяції
-- `interpolate(string, interpolateParams, sanitizeStrategy)` - інтерполює рядки з параметрами інтерполяції
+- `interpolate(string, interpolateParams, context, sanitizeStrategy, translationId)` - інтерполює рядки з параметрами інтерполяції
 
 Давайте подивимося, як це виглядає при створенні користувацького сервісу інтерполяції. По-перше, ми
 реалізуємо інтерфейс:
@@ -36,7 +36,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
 
     }
   };
@@ -62,7 +62,7 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
       return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };

--- a/docs/content/guide/zh-cn/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/zh-cn/15_custom-interpolators.ngdoc
@@ -15,7 +15,7 @@
 
 - `setLocale(langKey)` - 设置当前使用的语言
 - `getInterpolationIdentifier()` - 返回一个标识符插值
-- `interpolate(string, interpolateParams, sanitizeStrategy)` - 对字符串的params参数进行插值处理
+- `interpolate(string, interpolateParams, context, sanitizeStrategy, translationId)` - 对字符串的params参数进行插值处理
 
 让我们来看看怎么实现自定义的插值服务。首先，我们实现的接口：
 
@@ -32,7 +32,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
 
     }
   };
@@ -56,7 +56,7 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
       return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };

--- a/docs/content/guide/zh-tw/15_custom-interpolators.ngdoc
+++ b/docs/content/guide/zh-tw/15_custom-interpolators.ngdoc
@@ -15,7 +15,7 @@
 
 - `setLocale(langKey)` - 設置當前使用的語言
 - `getInterpolationIdentifier()` - 返回一個標識符插值
-- `interpolate(string, interpolateParams, sanitizeStrategy)` - 對字符串的params參數進行插值處理
+- `interpolate(string, interpolateParams, context, sanitizeStrategy, translationId)` - 對字符串的params參數進行插值處理
 
 讓我們來看看怎麼實現自定義的插值服務。首先，我們實現的接口：
 
@@ -32,7 +32,7 @@ app.factory('customInterpolation', function () {
 
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
 
     }
   };
@@ -56,7 +56,7 @@ app.factory('customInterpolation', function ($interpolate) {
       return 'custom';
     },
 
-    interpolate: function (string, interpolateParams, sanitizeStrategy) {
+    interpolate: function (string, interpolateParams, context, sanitizeStrategy, translationId) {
       return $locale + '_' + $interpolate(string)(interpolateParams, sanitizeStrategy) + '_' + $locale;
     }
   };

--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1349,7 +1349,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
      * @param Interpolator
      * @returns {Q.promise}
      */
-    var getFallbackTranslation = function (langKey, translationId, interpolateParams, Interpolator) {
+    var getFallbackTranslation = function (langKey, translationId, interpolateParams, Interpolator, sanitizeStrategy) {
       var deferred = $q.defer();
 
       var onResolve = function (translationTable) {
@@ -1357,10 +1357,10 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
           Interpolator.setLocale(langKey);
           var translation = translationTable[translationId];
           if (translation.substr(0, 2) === '@:') {
-            getFallbackTranslation(langKey, translation.substr(2), interpolateParams, Interpolator)
+            getFallbackTranslation(langKey, translation.substr(2), interpolateParams, Interpolator, sanitizeStrategy)
               .then(deferred.resolve, deferred.reject);
           } else {
-            var interpolatedValue = Interpolator.interpolate(translationTable[translationId], interpolateParams, 'service');
+            var interpolatedValue = Interpolator.interpolate(translationTable[translationId], interpolateParams, 'service', sanitizeStrategy, translationId);
             interpolatedValue = applyPostProcessing(translationId, translationTable[translationId], interpolatedValue, interpolateParams, langKey);
 
             deferred.resolve(interpolatedValue);
@@ -1399,7 +1399,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
 
       if (translationTable && Object.prototype.hasOwnProperty.call(translationTable, translationId)) {
         Interpolator.setLocale(langKey);
-        result = Interpolator.interpolate(translationTable[translationId], interpolateParams, 'filter', sanitizeStrategy);
+        result = Interpolator.interpolate(translationTable[translationId], interpolateParams, 'filter', sanitizeStrategy, translationId);
         result = applyPostProcessing(translationId, translationTable[translationId], result, interpolateParams, langKey, sanitizeStrategy);
         // workaround for TrustedValueHolderType
         if (!angular.isString(result) && angular.isFunction(result.$$unwrapTrustedValue)) {
@@ -1454,19 +1454,19 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
      * @param Interpolator
      * @returns {Q.promise} Promise that will resolve to the translation.
      */
-    var resolveForFallbackLanguage = function (fallbackLanguageIndex, translationId, interpolateParams, Interpolator, defaultTranslationText) {
+    var resolveForFallbackLanguage = function (fallbackLanguageIndex, translationId, interpolateParams, Interpolator, defaultTranslationText, sanitizeStrategy) {
       var deferred = $q.defer();
 
       if (fallbackLanguageIndex < $fallbackLanguage.length) {
         var langKey = $fallbackLanguage[fallbackLanguageIndex];
-        getFallbackTranslation(langKey, translationId, interpolateParams, Interpolator).then(
+        getFallbackTranslation(langKey, translationId, interpolateParams, Interpolator, sanitizeStrategy).then(
           function (data) {
             deferred.resolve(data);
           },
           function () {
             // Look in the next fallback language for a translation.
             // It delays the resolving by passing another promise to resolve.
-            return resolveForFallbackLanguage(fallbackLanguageIndex + 1, translationId, interpolateParams, Interpolator, defaultTranslationText).then(deferred.resolve, deferred.reject);
+            return resolveForFallbackLanguage(fallbackLanguageIndex + 1, translationId, interpolateParams, Interpolator, defaultTranslationText, sanitizeStrategy).then(deferred.resolve, deferred.reject);
           }
         );
       } else {
@@ -1524,9 +1524,9 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
      * @param Interpolator
      * @returns {Q.promise} Promise, that resolves to the translation.
      */
-    var fallbackTranslation = function (translationId, interpolateParams, Interpolator, defaultTranslationText) {
+    var fallbackTranslation = function (translationId, interpolateParams, Interpolator, defaultTranslationText, sanitizeStrategy) {
       // Start with the fallbackLanguage with index 0
-      return resolveForFallbackLanguage((startFallbackIteration > 0 ? startFallbackIteration : fallbackIndex), translationId, interpolateParams, Interpolator, defaultTranslationText);
+      return resolveForFallbackLanguage((startFallbackIteration > 0 ? startFallbackIteration : fallbackIndex), translationId, interpolateParams, Interpolator, defaultTranslationText, sanitizeStrategy);
     };
 
     /**
@@ -1542,7 +1542,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
       return resolveForFallbackLanguageInstant((startFallbackIteration > 0 ? startFallbackIteration : fallbackIndex), translationId, interpolateParams, Interpolator, sanitizeStrategy);
     };
 
-    var determineTranslation = function (translationId, interpolateParams, interpolationId, defaultTranslationText, uses) {
+    var determineTranslation = function (translationId, interpolateParams, interpolationId, defaultTranslationText, uses, sanitizeStrategy) {
 
       var deferred = $q.defer();
 
@@ -1560,7 +1560,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
             .then(deferred.resolve, deferred.reject);
         } else {
           //
-          var resolvedTranslation = Interpolator.interpolate(translation, interpolateParams, 'service');
+          var resolvedTranslation = Interpolator.interpolate(translation, interpolateParams, 'service', sanitizeStrategy, translationId);
           resolvedTranslation = applyPostProcessing(translationId, translation, resolvedTranslation, interpolateParams, uses);
           deferred.resolve(resolvedTranslation);
         }
@@ -1575,7 +1575,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
         // we try it now with one or more fallback languages, if fallback language(s) is
         // configured.
         if (uses && $fallbackLanguage && $fallbackLanguage.length) {
-          fallbackTranslation(translationId, interpolateParams, Interpolator, defaultTranslationText)
+          fallbackTranslation(translationId, interpolateParams, Interpolator, defaultTranslationText, sanitizeStrategy)
             .then(function (translation) {
               deferred.resolve(translation);
             }, function (_translationId) {
@@ -1619,7 +1619,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
         if (translation.substr(0, 2) === '@:') {
           result = determineTranslationInstant(translation.substr(2), interpolateParams, interpolationId, uses, sanitizeStrategy);
         } else {
-          result = Interpolator.interpolate(translation, interpolateParams, 'filter', sanitizeStrategy);
+          result = Interpolator.interpolate(translation, interpolateParams, 'filter', sanitizeStrategy, translationId);
           result = applyPostProcessing(translationId, translation, result, interpolateParams, uses, sanitizeStrategy);
         }
       } else {


### PR DESCRIPTION
### Included in this PR

* Adds `translationId` as a parameter to the method `interpolate` within the custom interpolation interface.
* Docs updated to reflect new feature.

### Use case

I'm creating a feature which allows users to suggest changes to translations. In order to know items which have been translated, the text must be wrapped in some kind of reference-able DOM element with a corresponding translationId.
