### PR TITLE
docs(): add a link to Angular-Translate Quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ so make sure to check this list.
 - [angular-translate on GitHub](https://github.com/angular-translate/angular-translate) - The GitHub repository
 - [angular-translate on ngmodules.org](http://ngmodules.org/modules/angular-translate)
 - [angular-translate mailinglist](https://groups.google.com/forum/#!forum/angular-translate) - Discuss, ask et al!
+- [angular-translate-quality](https://www.npmjs.com/package/angular-translate-quality) - Quality check at build time
 
 ### Thank you, community!
 We got a lot of great feedback from the community so far! More and more people


### PR DESCRIPTION
Hi!

I use Angular Translate in our web application and I have developed a NodeJS library to verify the quality of our translation files. This humble pull request is about adding a link towards the project. Feedback is obviously welcome.