### PR TITLE
Just fixing a typo in a comment.

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1220,7 +1220,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
      * @private
      *
      * @description
-     * Kicks of registered async loader using `$injector` and applies existing
+     * Kicks off registered async loader using `$injector` and applies existing
      * loader options. When resolved, it updates translation tables accordingly
      * or rejects with given language key.
      *


### PR DESCRIPTION
While looking to bust cache in our project, ended up reading the source of `$translate.refresh()` method. Noticed a typo, so here is a minute and insignificant fix.