### PR TITLE
Prevent duplicate requests in partial loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+<a name="2.9.0"></a>
+# [2.9.0](https://github.com/angular-translate/angular-translate/compare/2.8.1...v2.9.0) (2016-01-24)
+
+
+### Bug Fixes
+
+* **$translate:** apply notFoundIndicators only when all configured language checked in $translate ([25b13c4](https://github.com/angular-translate/angular-translate/commit/25b13c4)), closes [#1314](https://github.com/angular-translate/angular-translate/issues/1314)
+* **directive:** add additional watcher validating cloak ([e7536b5](https://github.com/angular-translate/angular-translate/commit/e7536b5)), closes [#1287](https://github.com/angular-translate/angular-translate/issues/1287)
+* **directive:** enforce update on default text change only ([ea94acd](https://github.com/angular-translate/angular-translate/commit/ea94acd))
+* **docs:** correct all occurrences of language names PR #1243 ([5f89d55](https://github.com/angular-translate/angular-translate/commit/5f89d55))
+* **docs:** fix broken link ([e641fe4](https://github.com/angular-translate/angular-translate/commit/e641fe4))
+* **docs:** Fix some typos in spanish ([830a84b](https://github.com/angular-translate/angular-translate/commit/830a84b))
+* **docs:** refresh outdated link ([392cab0](https://github.com/angular-translate/angular-translate/commit/392cab0))
+* **package:** add missing run-scriptlet "clean-test-scopes" ([c22c727](https://github.com/angular-translate/angular-translate/commit/c22c727))
+* **service:** partial loader service refetches list of parts ([069eafd](https://github.com/angular-translate/angular-translate/commit/069eafd)), closes [#1326](https://github.com/angular-translate/angular-translate/issues/1326)
+
+### Features
+
+* **build:** update test scope "AJS 1.5" using rc0 ([26cdc05](https://github.com/angular-translate/angular-translate/commit/26cdc05))
+* **dependencies:** add `angular` as the required dependency ([475a9b6](https://github.com/angular-translate/angular-translate/commit/475a9b6))
+* **service:** expose `$translate.negotiateLocale` being public ([9247000](https://github.com/angular-translate/angular-translate/commit/9247000))
+* **service:** force language used for translating ([e591462](https://github.com/angular-translate/angular-translate/commit/e591462))
+
+
+
 <a name="2.8.1"></a>
 ## [2.8.1](https://github.com/angular-translate/angular-translate/compare/2.8.0...v2.8.1) (2015-10-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,50 @@
+<a name="2.7.0"></a>
+## 2.7.0 (2015-05-02)
+
+
+#### Bug Fixes
+
+* **directive:**
+  * fix translate-value-* weren't be available on init ([98e82798](http://github.com/angular-translate/angular-translate/commit/98e827980ec491152ab6108f5fd5eac28010e89e))
+  * fix wrong initial translation causing overloading ([657ed8a6](http://github.com/angular-translate/angular-translate/commit/657ed8a6e8d09cbf5fd53a26ea98cbcf928637cd))
+  * fix issue with `data-` prefixed attributes #954 ([ee253bc3](http://github.com/angular-translate/angular-translate/commit/ee253bc397aa70b8688893430ea814c0e2387344))
+  * make translate-values interpolate correctly with newer MessageFormat.js ([887dc1b4](http://github.com/angular-translate/angular-translate/commit/887dc1b4c0e928fbfd595a1d03cb292fcd536839))
+  * Make interpolate message format work smoothly also on message format > 0.1.7 - f ([2533f2d0](http://github.com/angular-translate/angular-translate/commit/2533f2d0b2e9f21007335c510772418a4c7a3962))
+  * handle interpolation of undefined keys correctly in updateTranslations, fixes is ([3f7cf4cf](http://github.com/angular-translate/angular-translate/commit/3f7cf4cf6eecb0487da2dc4dd8cb805500cb1aff))
+* **docs:**
+  * fix invalid link in directive ([985cfd5b](http://github.com/angular-translate/angular-translate/commit/985cfd5bedec12043e5f24b16b86394150c6182e))
+  * typo in module type ([f0527b14](http://github.com/angular-translate/angular-translate/commit/f0527b1431f7b426584e32b5f17bc181d409ce41))
+  * bug in "Flash of untranslated content" section ([af5d746a](http://github.com/angular-translate/angular-translate/commit/af5d746a6476d82f31968d608ebc21227212cd7e))
+* **feat:** export module name improving usage module loaders #944 ([cb33f63b](http://github.com/angular-translate/angular-translate/commit/cb33f63b8869aff386718c7d3b18365d2483d3eb))
+* **messageformat:** add duck type check for numbers #789 ([bbc1cbef](http://github.com/angular-translate/angular-translate/commit/bbc1cbefb69e80579f15f7da59ac5c5536388fc2))
+* **refresh:** it has to clear all tables if no language key is specified ([3cce7950](http://github.com/angular-translate/angular-translate/commit/3cce795022e790bc31656ab946ed63bba6c238c3))
+* **service:**
+  * fix possible npe ([1aaab980](http://github.com/angular-translate/angular-translate/commit/1aaab980760f8863551598ed748d200f1f03d9c6))
+  * do not try to load a predefined fallback language ([3be14df8](http://github.com/angular-translate/angular-translate/commit/3be14df809d3c162f4a1aecffb90d62b5296b4d9))
+  * fix an issue resolving after missing translations ([a13899fc](http://github.com/angular-translate/angular-translate/commit/a13899fcf677588e0c56b780c57f9aaba6d6e976))
+  * always remove stored ref for lang promises ([dbd5be93](http://github.com/angular-translate/angular-translate/commit/dbd5be936d0588a1ec6f29e5ce52a4e0f096ea36), closes [#824](http://github.com/angular-translate/angular-translate/issues/824), [#969](http://github.com/angular-translate/angular-translate/issues/969))
+
+
+#### Features
+
+* **$translatePartialLoader:** accept function in urlTemplate ([401204aa](http://github.com/angular-translate/angular-translate/commit/401204aade22e4729de5349a03689b02f9e6d20b))
+* **build:** introduce module definition ([00b73ff6](http://github.com/angular-translate/angular-translate/commit/00b73ff6f40daeabc54afade7b5e6217722b70e8))
+* **filter:** add new option `$translate.statefulFilter()` ([dec4bf34](http://github.com/angular-translate/angular-translate/commit/dec4bf34b7bb30bba4ca80df263df1858b3e68f5))
+* **missingTranslationHandlerFactory:** pass interpolationParams to missingTranslationHandlerFactory ([a361fd05](http://github.com/angular-translate/angular-translate/commit/a361fd050f490e550b7e2e5fbfea91b85ba3e879))
+* **sanitization:** refactored, fixed and extended sanitization #993 ([12dbc575](http://github.com/angular-translate/angular-translate/commit/12dbc5754c8315d41144794918f1ec8ca34c601e))
+* **service:** add uniformLanguageTagResolver ([b534e1a3](http://github.com/angular-translate/angular-translate/commit/b534e1a3c7e43f27b00a2579750d8136aebc57fd))
+
+
+#### Breaking Changes
+
+* You will get a warning message when using the default security option (not escaping the content).
+
+You can fix (and remove) this warning by explicit set a sanitization strategy
+within your config phase configuring $translateProvider. Even configuring the `null` mode will let the
+warning disapper. You are highly encouraged specifing any mode except `null` because of security concerns.
+ ([12dbc575](http://github.com/angular-translate/angular-translate/commit/12dbc5754c8315d41144794918f1ec8ca34c601e))
+
+
 <a name="2.6.1"></a>
 ### 2.6.1 (2015-03-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="2.4.1"></a>
+### 2.4.1 (2014-10-03)
+
+
+#### Bug Fixes
+
+* **service:**
+  * constructor `useUrlLoader()` missed optional options ([22f5c4b7](http://github.com/PascalPrecht/angular-translate/commit/22f5c4b7b9612b3645c5d79b9bc9d2fec917fe25))
+  * add missing final event on new (async) translations ([22cc8b42](http://github.com/PascalPrecht/angular-translate/commit/22cc8b42d61ca6c6e2641de565b4f61a13469a50))
+  * the loader options ($http) have been merged wrong #754 #547
+
+
 # 2.4.0 (2014-09-22)
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,870 +1,563 @@
-<a name="2.13.1"></a>
-## [2.13.1](https://github.com/angular-translate/angular-translate/compare/2.13.0...v2.13.1) (2016-12-06)
+# 2.1.0 (2014-04-02)
 
+## Features
+### directive
 
+* Support for camel casing interpolation variables. (4791e25)
 
-<a name="2.13.0"></a>
-# [2.13.0](https://github.com/angular-translate/angular-translate/compare/2.12.1...v2.13.0) (2016-10-30)
+* add option to define a default translation text (fc57d26)
 
+### service
 
-### Bug Fixes
+* add possibility to translate a set of translation ids (57bd07c)
 
-* **service:** fix .instant() not handling TrustedValueHolderType correctly ([1ede55e](https://github.com/angular-translate/angular-translate/commit/1ede55e)), closes [#1618](https://github.com/angular-translate/angular-translate/issues/1618)
-* **service:** reject promise if handler returns undefined ([8fe6f23](https://github.com/angular-translate/angular-translate/commit/8fe6f23)), closes [#1600](https://github.com/angular-translate/angular-translate/issues/1600)
-* **service:** return empty string when found in fallback ([d76227e](https://github.com/angular-translate/angular-translate/commit/d76227e))
 
 
-### Features
+## Bug fixes
+### $translate
 
-* **sanitize:** sanitize override on instant call ([01fecd0](https://github.com/angular-translate/angular-translate/commit/01fecd0))
-* **service:** add $translate.getTranslationTable(langKey) ([40f9e35](https://github.com/angular-translate/angular-translate/commit/40f9e35))
-* **service:** add file map lookup into static-files loader ([132e49a](https://github.com/angular-translate/angular-translate/commit/132e49a))
-* **service:** add mf configurer [#1619](https://github.com/angular-translate/angular-translate/issues/1619) ([676114b](https://github.com/angular-translate/angular-translate/commit/676114b))
+* use case-insensitive check for language key aliases (09a8bf1)
 
+* if translation exists, use the translated string even if it's empty (4ba736f)
 
+* docs annotation (8ef0415)
+### directive
 
-<a name="2.12.1"></a>
-## [2.12.1](https://github.com/angular-translate/angular-translate/compare/2.12.0...v2.12.1) (2016-09-15)
+* Make translate-value-* work inside ng-if and ng-repeat (f22624b)
 
+### package.json
 
-### Bug Fixes
+* fix repository url (a410c9a)
 
-* **build:** Add missing translate-attr directive to Gruntfile.js ([e70e9ad](https://github.com/angular-translate/angular-translate/commit/e70e9ad)), closes [#1577](https://github.com/angular-translate/angular-translate/issues/1577)
-* **style:** fix code style issues in ~-attr directive ([1848bc8](https://github.com/angular-translate/angular-translate/commit/1848bc8))
+### $translateProvider
 
+* fix comparison in one case of negotiateLocale() (c2b94ca)
 
+# 2.0.1 (2014-02-25)
 
-<a name="2.12.0"></a>
-# [2.12.0](https://github.com/angular-translate/angular-translate/compare/2.11.1...v2.12.0) (2016-09-05)
+## Features
+### instant
 
+* invoke missing handler within `$translate.instant(id)` (aaf52b5)
 
-### Bug Fixes
 
-* **service:** fix infinite loop when fallback language async loading fails ([233f30c](https://github.com/angular-translate/angular-translate/commit/233f30c))
-* **service:** treat date param as-is (no sanitize/escape) ([ab1ecce](https://github.com/angular-translate/angular-translate/commit/ab1ecce)), closes [#1560](https://github.com/angular-translate/angular-translate/issues/1560)
 
+## Bug fixes
+### instant
 
-### Features
+* fix possible npe in case of filters with undefineds (61a9490)
 
-* **directive:** introduce standalone translate-attr directive ([bcb0f2c](https://github.com/angular-translate/angular-translate/commit/bcb0f2c))
-* **partial loader:** add error response to errorHandler ([e3aba1c](https://github.com/angular-translate/angular-translate/commit/e3aba1c))
-* **service:** introduce new sanitize strategies: sce/sceParameters ([1624df5](https://github.com/angular-translate/angular-translate/commit/1624df5))
-* **service:** provide for sanitize/escape strategy 3rd argument context ([8504c60](https://github.com/angular-translate/angular-translate/commit/8504c60))
+* $translate.instant(id) does not return correct fallback (eec1d77)
 
+### refresh
 
+* fix bug in refresh if using partial loader (95c43b4)
 
-<a name="2.11.1"></a>
-## [2.11.1](https://github.com/angular-translate/angular-translate/compare/2.11.0...v2.11.1) (2016-07-17)
+### $translate
 
+* Ensuring that languages will be set based on the order they are requested, not the order the responses come in. (32e1851)
 
-### Bug Fixes
 
-* **dependencies:** Update messageformat to ~0.3.1 ([04e11c9](https://github.com/angular-translate/angular-translate/commit/04e11c9))
-* **grunt:** add work-around for uglify preserveComments as expected ([32cdedb](https://github.com/angular-translate/angular-translate/commit/32cdedb)), closes [#1461](https://github.com/angular-translate/angular-translate/issues/1461)
-* **service:** allow instant function to also take care of post process configuration ([b7d7907](https://github.com/angular-translate/angular-translate/commit/b7d7907))
-* **service:** avoid sanitizing of functions ([492d8e5](https://github.com/angular-translate/angular-translate/commit/492d8e5)), closes [#1529](https://github.com/angular-translate/angular-translate/issues/1529)
-* **service:** Correct descriptive ngdocs to match parameters on the service calls ([91711f7](https://github.com/angular-translate/angular-translate/commit/91711f7))
-* **service:** fix interpolation issue with non-string as input ([fa4a80e](https://github.com/angular-translate/angular-translate/commit/fa4a80e)), closes [#1511](https://github.com/angular-translate/angular-translate/issues/1511)
-* **service:** fix lost of data in async loader / error in runtime ([5ee0c3e](https://github.com/angular-translate/angular-translate/commit/5ee0c3e))
 
+# 2.0.0 (2014-02-16)
 
-### Features
+## Features
+###
 
-* **directive:** introduce a global keepContent setting ([2015f79](https://github.com/angular-translate/angular-translate/commit/2015f79))
+* add option to html escape all values (fe94c1f)
 
+* add option to html escape all values (e042c44)
 
+* add an option for post processing compiling (d5cd943)
 
-<a name="2.11.0"></a>
-# [2.11.0](https://github.com/angular-translate/angular-translate/compare/2.10.0...v2.11.0) (2016-03-20)
+### $translateProvider
 
+* adds determinePreferredLanguage() (7cbfabe)
 
-### Bug Fixes
+* adds registerAvailableLanguagesKeys for negotiation (6bef6bd)
 
-* **directive:** reduced number of watchers by applying translateLanguage watcher only when direc ([961fc92](https://github.com/angular-translate/angular-translate/commit/961fc92))
-* **service:** add missing hasOwnProperty check ([823afc0](https://github.com/angular-translate/angular-translate/commit/823afc0))
-* **service:** avoid try to load languages which are explicitly not wanted ([bde935e](https://github.com/angular-translate/angular-translate/commit/bde935e)), closes [#1390](https://github.com/angular-translate/angular-translate/issues/1390)
-* **service:** fix edge-case with .use() and .preferredLanguage() ([02688f2](https://github.com/angular-translate/angular-translate/commit/02688f2))
-* **service:** translations for `forceLanguage` will be loaded on demand ([14bc956](https://github.com/angular-translate/angular-translate/commit/14bc956)), closes [#1389](https://github.com/angular-translate/angular-translate/issues/1389)
+### translateDirective
 
-### Features
+* teaches directive custom translate-value-* attr (5c27467)
 
-* **depenceny:** Update messageformat.js to current 0.3.0 release ([fb48f78](https://github.com/angular-translate/angular-translate/commit/fb48f78))
-* **directive:** introduce attr translate-keep-content ([b2cf8a3](https://github.com/angular-translate/angular-translate/commit/b2cf8a3))
-* **service:** add `$translate.resolveClientLocale()` (also at provider) ([d0469ac](https://github.com/angular-translate/angular-translate/commit/d0469ac))
-* **service:** add support for uniformLanguageTag('iso639-1') ([1e037ec](https://github.com/angular-translate/angular-translate/commit/1e037ec)), closes [#1181](https://github.com/angular-translate/angular-translate/issues/1181)
-* **service:** improve messageformat.js output caching ([cb31608](https://github.com/angular-translate/angular-translate/commit/cb31608))
-* **service:** introduce getter returning available languages ([3988af0](https://github.com/angular-translate/angular-translate/commit/3988af0)), closes [#1304](https://github.com/angular-translate/angular-translate/issues/1304)
-* **service:** introduce post processing for translations ([f0c4874](https://github.com/angular-translate/angular-translate/commit/f0c4874))
-* **service:** support for default translation in missingTranslationHandler ([8c5044c](https://github.com/angular-translate/angular-translate/commit/8c5044c))
+### service
 
+* add $translate.instant() for instant translations (3a855eb)
 
+### filter
 
-<a name="2.10.0"></a>
-# [2.10.0](https://github.com/angular-translate/angular-translate/compare/2.9.2...v2.10.0) (2016-02-28)
+* filter now use $translate.instant() since promises could not use (a1b8a17)
 
+### translateCloak
 
-### Bug Fixes
+* adds translate-cloak directive (c125c56)
 
-* **service:** make the fallback $uses / $translate.use work in a correct manner ([7e71a5a](https://github.com/angular-translate/angular-translate/commit/7e71a5a))
 
 
+## Bug fixes
+### fallbackLanguage
 
-<a name="2.9.2"></a>
-## [2.9.2](https://github.com/angular-translate/angular-translate/compare/2.9.1...v2.9.2) (2016-02-21)
+* Fix fallback languages loading and applying (4c5c47c)
 
+### loader-static-files.js
 
-### Bug Fixes
+* Now allows empty string as prefix and postfix. (051f431)
 
-* **package:** redefine dependency version range (AJS 1.5) ([94eb844](https://github.com/angular-translate/angular-translate/commit/94eb844)), closes [#1394](https://github.com/angular-translate/angular-translate/issues/1394) [#1395](https://github.com/angular-translate/angular-translate/issues/1395) [#1397](https://github.com/angular-translate/angular-translate/issues/1397)
-* **package:** redefine dependency version range (AJS 1.5) (fixup) ([20da73d](https://github.com/angular-translate/angular-translate/commit/20da73d)), closes [#1394](https://github.com/angular-translate/angular-translate/issues/1394) [#1395](https://github.com/angular-translate/angular-translate/issues/1395) [#1397](https://github.com/angular-translate/angular-translate/issues/1397)
-* **service:** avoid call stack size error, print proper message ([73ea6e3](https://github.com/angular-translate/angular-translate/commit/73ea6e3))
-* **service:** ensure fallback language can be selected as `$uses` ([40ad523](https://github.com/angular-translate/angular-translate/commit/40ad523))
-* **service:** remove invalid argument for promise.finally ([2d72908](https://github.com/angular-translate/angular-translate/commit/2d72908))
+### translateDirective
 
+* fixes bad coding convention (d5db4ad)
 
+### demo
 
-<a name="2.9.1"></a>
-## [2.9.1](https://github.com/angular-translate/angular-translate/compare/2.9.0...v2.9.1) (2016-02-13)
+* links to demo resources updated to new locactions (fddaa49)
 
+* fix server routes + add index page (eb0a2dc)
 
-### Bug Fixes
+### $translate
 
-* **package:** redefine dependency version range (AJS 1.5) ([9ccce6b](https://github.com/angular-translate/angular-translate/commit/9ccce6b)), closes [#1394](https://github.com/angular-translate/angular-translate/issues/1394) [#1395](https://github.com/angular-translate/angular-translate/issues/1395) [#1397](https://github.com/angular-translate/angular-translate/issues/1397)
+* Trim whitespace off translationId (4939424)
 
+* check for fallbacklanguage (321803d)
 
+###
 
-<a name="2.9.0"></a>
-# [2.9.0](https://github.com/angular-translate/angular-translate/compare/2.8.1...v2.9.0) (2016-01-24)
+* fix npe introduced in 4939424a30 (#281) (173a9bc)
 
+* avoid calls with empty translationId (sub issue of #298) (08f087b)
 
-### Bug Fixes
+### *
 
-* **$translate:** apply notFoundIndicators only when all configured language checked in $translate ([25b13c4](https://github.com/angular-translate/angular-translate/commit/25b13c4)), closes [#1314](https://github.com/angular-translate/angular-translate/issues/1314)
-* **directive:** add additional watcher validating cloak ([e7536b5](https://github.com/angular-translate/angular-translate/commit/e7536b5)), closes [#1287](https://github.com/angular-translate/angular-translate/issues/1287)
-* **directive:** enforce update on default text change only ([ea94acd](https://github.com/angular-translate/angular-translate/commit/ea94acd))
-* **docs:** correct all occurrences of language names PR #1243 ([5f89d55](https://github.com/angular-translate/angular-translate/commit/5f89d55))
-* **docs:** fix broken link ([e641fe4](https://github.com/angular-translate/angular-translate/commit/e641fe4))
-* **docs:** Fix some typos in spanish ([830a84b](https://github.com/angular-translate/angular-translate/commit/830a84b))
-* **docs:** refresh outdated link ([392cab0](https://github.com/angular-translate/angular-translate/commit/392cab0))
-* **package:** add missing run-scriptlet "clean-test-scopes" ([c22c727](https://github.com/angular-translate/angular-translate/commit/c22c727))
-* **service:** partial loader service refetches list of parts ([069eafd](https://github.com/angular-translate/angular-translate/commit/069eafd)), closes [#1326](https://github.com/angular-translate/angular-translate/issues/1326)
+* jshint fixes (1e3f8a6)
 
-### Features
+### $translatePartialLoader
 
-* **build:** update test scope "AJS 1.5" using rc0 ([26cdc05](https://github.com/angular-translate/angular-translate/commit/26cdc05))
-* **dependencies:** add `angular` as the required dependency ([475a9b6](https://github.com/angular-translate/angular-translate/commit/475a9b6))
-* **service:** expose `$translate.negotiateLocale` being public ([9247000](https://github.com/angular-translate/angular-translate/commit/9247000))
-* **service:** force language used for translating ([e591462](https://github.com/angular-translate/angular-translate/commit/e591462))
+* fixes docs annotation (d6ea84b)
 
+### guide/ru,uk
 
+* Fix uses->use in multi language (af59c6a)
 
-<a name="2.8.1"></a>
-## [2.8.1](https://github.com/angular-translate/angular-translate/compare/2.8.0...v2.8.1) (2015-10-01)
+### service
 
+* fallback languages could not load when using `instant()` (26de486)
 
-### Bug Fixes
+### deps
 
-* **service:** Fix `$translate.isReady()` won't return true if ready ([b40a344](https://github.com/angular-translate/angular-translate/commit/b40a344)), closes [#1239](https://github.com/angular-translate/angular-translate/issues/1239)
-* **service:** should not abort fallback languages (feature #1070) ([cc410b1](https://github.com/angular-translate/angular-translate/commit/cc410b1)), closes [#1070](https://github.com/angular-translate/angular-translate/issues/1070)
+* add missing resolution (a98a2f6)
 
+### grunt
 
+* includes translate-cloak directive (84a59d2)
 
-<a name="2.8.0"></a>
-# [2.8.0](https://github.com/angular-translate/angular-translate/compare/2.7.2...2.8.0) (2015-09-18)
+### translateCloak
 
+* makes jshint happy (2058fd3)
 
-### Bug Fixes
+### docs
 
-* **build:** ensure MessageFormat will be added correctly when using UMD ([f5e039c](https://github.com/angular-translate/angular-translate/commit/f5e039c))
-* **directive:** Fix behavior of translate-cloak timing ([a6adf47](https://github.com/angular-translate/angular-translate/commit/a6adf47)), closes [#929](https://github.com/angular-translate/angular-translate/issues/929) [#1175](https://github.com/angular-translate/angular-translate/issues/1175)
-* **directive:** Fix special IE11 issue #925 ([c4b16d3](https://github.com/angular-translate/angular-translate/commit/c4b16d3)), closes [#925](https://github.com/angular-translate/angular-translate/issues/925)
-* **docs:** avoid using absolute links in lang chooser #1136 ([2cdc902](https://github.com/angular-translate/angular-translate/commit/2cdc902))
-* **docs:** Fix more typos in CONTRIBUTING.md, add some infos about tests ([e88b990](https://github.com/angular-translate/angular-translate/commit/e88b990))
-* **docs:** Fix typo in CONTRIBUTING.md ([1c2ac47](https://github.com/angular-translate/angular-translate/commit/1c2ac47))
-* **docs:** Fix typo in zh-cn docs ([2a16eb6](https://github.com/angular-translate/angular-translate/commit/2a16eb6))
-* **service:** abort the last loader if not finished #1070 ([dd4a8b4](https://github.com/angular-translate/angular-translate/commit/dd4a8b4))
-* **service:** update storage before triggering $translateChangeSuccess ([77dd5a2](https://github.com/angular-translate/angular-translate/commit/77dd5a2))
-* **service provider:** change/fix return of preferredLanguage() ([6014a81](https://github.com/angular-translate/angular-translate/commit/6014a81))
+* fixes links for languages (265490f)
 
-### Features
 
-* **directive:** translate-namespace directive ([45523bb](https://github.com/angular-translate/angular-translate/commit/45523bb))
-* **loaders:** addition to e7516dc #1080 (disable legacy $http cbs) ([233a012](https://github.com/angular-translate/angular-translate/commit/233a012))
-* **loaders:** remove use of legacy methods on $http promises #1080 ([e7516dc](https://github.com/angular-translate/angular-translate/commit/e7516dc))
-* **meta:** enrich copyright header with a leagl person ([21da61c](https://github.com/angular-translate/angular-translate/commit/21da61c))
-* **sanitize:** Allow sanitize strategy defined as a service ([8a6cc07](https://github.com/angular-translate/angular-translate/commit/8a6cc07))
-* **service:** add option to customize the nested delimiter ([78161f8](https://github.com/angular-translate/angular-translate/commit/78161f8))
-* **service:** introduce `isReady()` and `onReady()` with event ([9a4bd0d](https://github.com/angular-translate/angular-translate/commit/9a4bd0d))
+# 1.1.1 (2013-11-24)
 
+## Features
+### core
 
+* Update required Node up `0.10` (b7cf5f4)
 
-<a name="2.7.2"></a>
-## [2.7.2](https://github.com/angular-translate/angular-translate/compare/2.7.1...2.7.2) (2015-06-01)
+* shortcuts and links\n\nShortcuts creates a shorter translationId if the last key equals the one before(foo.bar.bar -> foo.bar). Also added support for linking one translationID to another by prepending '@:'. So if foo.bar = '@:chuck.norris', then the value for chuck.norris will be retrieved instead. (f9f2cf2)
 
+### docs
 
-### Bug Fixes
+* Ukrainian docs
 
-* **directive:** ensure value of `translate` will be translated always ([454d702](https://github.com/angular-translate/angular-translate/commit/454d702))
-* **sanitization:** fix/workaround issue when jQuery is not available ([ef1b10a](https://github.com/angular-translate/angular-translate/commit/ef1b10a))
-* **service:** fix silence on error, add missing catch on `refresh()` ([f3ec956](https://github.com/angular-translate/angular-translate/commit/f3ec956))
-* **service:** fix silence on error, add missing catch on `refresh()` ([5a85a64](https://github.com/angular-translate/angular-translate/commit/5a85a64))
-* **service:** make provider's storageKey chainable ([de8c253](https://github.com/angular-translate/angular-translate/commit/de8c253))
+## Bug fixes
+### docs
 
+* fixes encoding (084f08c)
 
+### grunt
 
-<a name="2.7.1"></a>
-## [2.7.1](https://github.com/angular-translate/angular-translate/compare/2.7.0...2.7.1) (2015-06-01)
+* fixes missing storage-key (635d290)
 
+### docs
 
-### Bug Fixes
+* fixes typo (7e1c4e9)
 
-* **docs:** fix typo in $translateChangeSuccess ([89e2569](https://github.com/angular-translate/angular-translate/commit/89e2569))
-* **service:** handle error "this.replace is not a function" ([8616dca](https://github.com/angular-translate/angular-translate/commit/8616dca))
-* **service:** integrate translationCache into service distribution file ([2fcbc60](https://github.com/angular-translate/angular-translate/commit/2fcbc60))
+* fixes typo in landing page (0b999ab)
 
-### Features
+### translateDirective
 
-* **$translateProvider:** add a new option to force async reload ([bdee77f](https://github.com/angular-translate/angular-translate/commit/bdee77f))
+* fixes occuring 'translation id undefined' erros (bb5a2c4)
 
+### translatePartialLoader
 
+* introduces setPart() to add static parts on translatePartialLoader
 
-<a name="2.7.0"></a>
-# [2.7.0](https://github.com/angular-translate/angular-translate/compare/2.6.1...2.7.0) (2015-05-02)
+# 1.1.0 (2013-09-02)
 
+## Features
+### translateService
 
-### Bug Fixes
+* added refresh() method (d41f91e)
 
-* **directive:** fix issue with `data-` prefixed attributes #954 ([ee253bc](https://github.com/angular-translate/angular-translate/commit/ee253bc)), closes [#954](https://github.com/angular-translate/angular-translate/issues/954)
-* **directive:** fix translate-value-* weren't be available on init ([98e8279](https://github.com/angular-translate/angular-translate/commit/98e8279))
-* **directive:** fix wrong initial translation causing overloading ([657ed8a](https://github.com/angular-translate/angular-translate/commit/657ed8a))
-* **directive:** handle interpolation of undefined keys correctly in updateTranslations, fixes is ([3f7cf4c](https://github.com/angular-translate/angular-translate/commit/3f7cf4c)), closes [#971](https://github.com/angular-translate/angular-translate/issues/971)
-* **directive:** Make interpolate message format work smoothly also on message format > 0.1.7 - f ([2533f2d](https://github.com/angular-translate/angular-translate/commit/2533f2d)), closes [#789](https://github.com/angular-translate/angular-translate/issues/789)
-* **directive:** make translate-values interpolate correctly with newer MessageFormat.js ([887dc1b](https://github.com/angular-translate/angular-translate/commit/887dc1b))
-* **docs:** bug in "Flash of untranslated content" section ([af5d746](https://github.com/angular-translate/angular-translate/commit/af5d746))
-* **docs:** fix invalid link in directive ([985cfd5](https://github.com/angular-translate/angular-translate/commit/985cfd5))
-* **docs:** typo in module type ([f0527b1](https://github.com/angular-translate/angular-translate/commit/f0527b1))
-* **feat:** export module name improving usage module loaders #944 ([cb33f63](https://github.com/angular-translate/angular-translate/commit/cb33f63))
-* **messageformat:** add duck type check for numbers #789 ([bbc1cbe](https://github.com/angular-translate/angular-translate/commit/bbc1cbe))
-* **refresh:** it has to clear all tables if no language key is specified ([3cce795](https://github.com/angular-translate/angular-translate/commit/3cce795))
-* **service:** always remove stored ref for lang promises ([dbd5be9](https://github.com/angular-translate/angular-translate/commit/dbd5be9)), closes [#824](https://github.com/angular-translate/angular-translate/issues/824) [#969](https://github.com/angular-translate/angular-translate/issues/969)
-* **service:** do not try to load a predefined fallback language ([3be14df](https://github.com/angular-translate/angular-translate/commit/3be14df))
-* **service:** fix an issue resolving after missing translations ([a13899f](https://github.com/angular-translate/angular-translate/commit/a13899f))
-* **service:** fix possible npe ([1aaab98](https://github.com/angular-translate/angular-translate/commit/1aaab98))
-* **test/refresh:** fix current table refreshing test ([a298ed8](https://github.com/angular-translate/angular-translate/commit/a298ed8))
+### translateProvider
 
-### Features
+* makes methods chainable (cdc9e9e)
 
-* **$translatePartialLoader:** accept function in urlTemplate ([401204a](https://github.com/angular-translate/angular-translate/commit/401204a))
-* **build:** introduce module definition ([00b73ff](https://github.com/angular-translate/angular-translate/commit/00b73ff))
-* **filter:** add new option `$translate.statefulFilter()` ([dec4bf3](https://github.com/angular-translate/angular-translate/commit/dec4bf3))
-* **missingTranslationHandlerFactory:** pass interpolationParams to missingTranslationHandlerFactory ([a361fd0](https://github.com/angular-translate/angular-translate/commit/a361fd0))
-* **sanitization:** refactored, fixed and extended sanitization #993 ([12dbc57](https://github.com/angular-translate/angular-translate/commit/12dbc57)), closes [#993](https://github.com/angular-translate/angular-translate/issues/993)
-* **service:** add uniformLanguageTagResolver ([b534e1a](https://github.com/angular-translate/angular-translate/commit/b534e1a))
+### $translatePartialLoader
 
-### Performance Improvements
+* Basic implementation (81222bf)
 
-* **directive:** watch parameters only if exist ([f0e2585](https://github.com/angular-translate/angular-translate/commit/f0e2585))
 
 
-### BREAKING CHANGES
+## Bug fixes
+### translateDirective
 
-* You will get a warning message when using the default setting (not escaping the content).
-You can fix (and remove) this warning by explicit set a sanitization strategy
-within your config phase configuring $translateProvider. Even configuring the `null` mode will let the
-warning disapper. You are highly encouraged specifing any mode except `null` because of security concerns.
+* fixes bug that directive writes into scope (4e06468)
 
+* fixes scope handling (c566586)
 
-<a name="2.6.1"></a>
-## [2.6.1](https://github.com/angular-translate/angular-translate/compare/2.6.0...2.6.1) (2015-03-01)
+### translateService
 
+* reset proposed language if there's no pending loader (6b477fc)
 
-### Bug Fixes
 
-* **bower spec:** fix bower main property #922 ([3a1ad10](https://github.com/angular-translate/angular-translate/commit/3a1ad10)), closes [#922](https://github.com/angular-translate/angular-translate/issues/922)
-* **custom interpolator:** improve handling of interpolator ids which don't exist ([373b46f](https://github.com/angular-translate/angular-translate/commit/373b46f))
-* **static-files-loader:** fix multiple files definition (docu update) #923, pr #936 ([e637c01](https://github.com/angular-translate/angular-translate/commit/e637c01)), closes [#923](https://github.com/angular-translate/angular-translate/issues/923) [#936](https://github.com/angular-translate/angular-translate/issues/936)
-* **static-files-loader:** fix multiple files definition #923 ([1b6256a](https://github.com/angular-translate/angular-translate/commit/1b6256a)), closes [#923](https://github.com/angular-translate/angular-translate/issues/923)
+# 1.0.2 (2013-08-07)
 
 
 
-<a name="2.6.0"></a>
-# [2.6.0](https://github.com/angular-translate/angular-translate/compare/2.5.2...2.6.0) (2015-02-08)
+## Bug fixes
+### typo
 
+* remove unnecessary semicolon (54cb232)
 
-### Bug Fixes
 
-* **directive:** ensure internal watcher will be removed ([e69f4a1](https://github.com/angular-translate/angular-translate/commit/e69f4a1))
-* **directive:** fix minor memory leak ([5e4533a](https://github.com/angular-translate/angular-translate/commit/5e4533a))
-* **directive:** fix missing update using dynamic translationIds ([faebe19](https://github.com/angular-translate/angular-translate/commit/faebe19)), closes [#854](https://github.com/angular-translate/angular-translate/issues/854)
-* **directive:** newlines before/after translation ids should be ignored ([8dcf3e2](https://github.com/angular-translate/angular-translate/commit/8dcf3e2)), closes [#909](https://github.com/angular-translate/angular-translate/issues/909)
-* **directive, service:** return value of translate-default also in case fallback languages are used - rel ([fcd6b3e](https://github.com/angular-translate/angular-translate/commit/fcd6b3e))
-* **filter:** apply notFoundIndicators also for instant translations correctly ([5a9f436](https://github.com/angular-translate/angular-translate/commit/5a9f436)), closes [#866](https://github.com/angular-translate/angular-translate/issues/866)
-* **service:** fallback languages follow shortcuts (fixes #758) ([cce897a](https://github.com/angular-translate/angular-translate/commit/cce897a)), closes [#758](https://github.com/angular-translate/angular-translate/issues/758)
-* **service:** fix an issue with default interpolator and expressions ([75b7381](https://github.com/angular-translate/angular-translate/commit/75b7381))
-* **service:** use $window/$windowProvider instead of window ([bfa7b7b](https://github.com/angular-translate/angular-translate/commit/bfa7b7b))
+# 1.0.1 (2013-07-26)
 
-### Features
+- Brings default interpolation back to core (you don't have to install it as extra package)
 
-* **$translatePartialLoader:** adds optional priority param to the addPart function ([570617c](https://github.com/angular-translate/angular-translate/commit/570617c))
-* **directive:** add $translateProvider.directityPriority ([b0b7716](https://github.com/angular-translate/angular-translate/commit/b0b7716))
-* **loader:** support for multiple static translation files ([c462ee6](https://github.com/angular-translate/angular-translate/commit/c462ee6))
-* **service:** extend loader api: add isPartLoaded and getRegisteredParts to $translatePartialL ([54f8ab3](https://github.com/angular-translate/angular-translate/commit/54f8ab3))
+## Bug fixes
+### platolink
 
+* deep link (d368bf3)
 
+### dependency
 
-<a name="2.5.2"></a>
-## [2.5.2](https://github.com/angular-translate/angular-translate/compare/2.5.0...2.5.2) (2014-12-10)
+* add 'angular-cookies' as bower devDependency (b6f1426)
 
+### demo
 
-### Bug Fixes
+* change src to angular-translate script (4be93b6)
 
-* **directive:** missing watch for expression within elements text nodes ([31c0356](https://github.com/angular-translate/angular-translate/commit/31c0356)), closes [#701](https://github.com/angular-translate/angular-translate/issues/701)
 
+# 1.0.0 (2013-07-23)
 
+## Features
+### translateService
 
-<a name="2.5.0"></a>
-# [2.5.0](https://github.com/angular-translate/angular-translate/compare/2.4.2...2.5.0) (2014-12-07)
+* missingTranslationHandler receives language (6fe6bb1)
 
+* adds method to configure indicators for not found translations (52a039f)
 
-### Bug Fixes
+* extracts default interpolation in standalone service (5d8cb56)
 
-* **directive:** ensure directive's text will be parsed at least once ([49cfef0](https://github.com/angular-translate/angular-translate/commit/49cfef0))
-* **loader:** under circum understances translation table got lost ([df37381](https://github.com/angular-translate/angular-translate/commit/df37381))
-* **messageformat-interpolation:** fix support for messageformat 0.2.* ([ac8d5ed](https://github.com/angular-translate/angular-translate/commit/ac8d5ed))
-* **service:** apply fix for empty strings in `navigator.language` ([5b4edd9](https://github.com/angular-translate/angular-translate/commit/5b4edd9))
-* **service:** fix npe when resolving fallback language for `instant` ([7c09d89](https://github.com/angular-translate/angular-translate/commit/7c09d89))
+* implements usage of different interpolation services (5e20e24)
 
-### Features
+* informs interpolator when locale has changed (e59b141)
 
-* **$translateUrlLoader:** allow to use custom query parameter name for url loader ([e360bf8](https://github.com/angular-translate/angular-translate/commit/e360bf8))
-* **module:** use same fallback for module.run when no storage key is set ([247253d](https://github.com/angular-translate/angular-translate/commit/247253d)), closes [#739](https://github.com/angular-translate/angular-translate/issues/739)
-* **storage:** rename set() into put() ([ef6a613](https://github.com/angular-translate/angular-translate/commit/ef6a613))
+* implements proposedLanguage() (6d34792)
 
+### messageformat-interpolation
 
-### BREAKING CHANGES
+* implements usage of messageformat (5596e8b)
 
-* This marks storage.set() as deprecated. In the
-next major release v3, the old method `set()` will be dropped in favor
-of `put()`.
-Relates #772
+### translateFilter
 
+* teaches filter to use custom interpolation (46f03cc)
 
-<a name="2.4.2"></a>
-## [2.4.2](https://github.com/angular-translate/angular-translate/compare/2.4.1...2.4.2) (2014-10-21)
+### translateDirective
 
+* teaches directives to use custom interpolation (bf3dbbb)
 
-### Bug Fixes
 
-* **partialloader:** fix possible circular dependency ([25f252c](https://github.com/angular-translate/angular-translate/commit/25f252c)), closes [#766](https://github.com/angular-translate/angular-translate/issues/766)
 
-### Features
+## Bug fixes
+### tests
 
-* **directive:** translate attributes (optimize process flow) ([508fd32](https://github.com/angular-translate/angular-translate/commit/508fd32))
-* **directive:** translate attributes using directive ([1d06d2a](https://github.com/angular-translate/angular-translate/commit/1d06d2a)), closes [#568](https://github.com/angular-translate/angular-translate/issues/568)
-* **directive:** translate-cloak supports optional value for cloaking ([f7ccb7f](https://github.com/angular-translate/angular-translate/commit/f7ccb7f))
+* travis CI (629bb8d)
 
+* travis CI (c8624bf)
 
+### docs
 
-<a name="2.4.1"></a>
-## [2.4.1](https://github.com/angular-translate/angular-translate/compare/2.4.0...2.4.1) (2014-10-03)
+* fixes methodOf declaration of addInterpolation method (f1eeba7)
 
+### gh-pages
 
-### Bug Fixes
+* plato report (b85e19b)
 
-* **service:** add missing final event on new (async) translations ([22cc8b4](https://github.com/angular-translate/angular-translate/commit/22cc8b4))
-* **service:** constructor `useUrlLoader()` missed optional options ([22f5c4b](https://github.com/angular-translate/angular-translate/commit/22f5c4b))
-* **service, loaders:** the loader options ($http) have been merged wrong ([0c35a95](https://github.com/angular-translate/angular-translate/commit/0c35a95)), closes [#754](https://github.com/angular-translate/angular-translate/issues/754) [#547](https://github.com/angular-translate/angular-translate/issues/547)
 
+# 0.9.4 (2013-06-21)
 
+## Features
+### translateService
 
-<a name="2.4.0"></a>
-# [2.4.0](https://github.com/angular-translate/angular-translate/compare/2.3.0...2.4.0) (2014-09-22)
+* removes empty options object requirement for loaders (c09d1dbe)
 
 
-### Bug Fixes
 
-* **filter:** interpolated params w/ scope aren't possible starting AJS1.3 ([9465318](https://github.com/angular-translate/angular-translate/commit/9465318))
-* **filter:** mark filter being stateful required since Angular 1.3 rc2 ([bffbf04](https://github.com/angular-translate/angular-translate/commit/bffbf04))
-* **service:** `$nextLang` should be not unset parallel loadings ([d1745e4](https://github.com/angular-translate/angular-translate/commit/d1745e4)), closes [#647](https://github.com/angular-translate/angular-translate/issues/647)
-* **service:** avoid possible doubled requested on refresh() ([98d429d](https://github.com/angular-translate/angular-translate/commit/98d429d))
-* **service:** avoid possible npe in internal getTranslationTable() ([9aaa9a0](https://github.com/angular-translate/angular-translate/commit/9aaa9a0))
-* **service:** correctly iterate in fallback languages (fixes #690) ([ac2f35c](https://github.com/angular-translate/angular-translate/commit/ac2f35c)), closes [#690](https://github.com/angular-translate/angular-translate/issues/690)
+## Bug fixes
+### translateService
 
-### Features
+* fixes missingTranslationHandler-invokation bug (525b3533)
 
-* **loader:** apply support for loaderOptions.$http ([8613bef](https://github.com/angular-translate/angular-translate/commit/8613bef))
-* **loaders:** introduce loader cache ([b685601](https://github.com/angular-translate/angular-translate/commit/b685601)), closes [#529](https://github.com/angular-translate/angular-translate/issues/529)
-* **service:** enrich events with the currently handled language key ([73b289d](https://github.com/angular-translate/angular-translate/commit/73b289d))
-* **service:** interpolate translationId in case of rejected translation ([3efaac5](https://github.com/angular-translate/angular-translate/commit/3efaac5)), closes [#730](https://github.com/angular-translate/angular-translate/issues/730)
-* **service:** introduce `versionInfo` function ([e37d89c](https://github.com/angular-translate/angular-translate/commit/e37d89c))
-* **service:** prefer detecting language by `navigator.languages` #722 ([2204f4f](https://github.com/angular-translate/angular-translate/commit/2204f4f))
 
 
-### BREAKING CHANGES
 
-* Since filters are stateless and have no access to its scope anymore (see https://github.com/angular/angular.js/commit/8863b9d04c722b278fa93c5d66ad1e578ad6eb1f), a context must be given explicitly. This removes the feature of an interpolation based on the scope (context), even without the $rootScope.
-However, the feature will still work in AJS <=1.2, so we won't remove it completely yet. Handle the feature as slightly deprecated.
+# 0.9.3 (2013-06-10)
 
+## Features
+### translateService
 
-<a name="2.3.0"></a>
-# [2.3.0](https://github.com/angular-translate/angular-translate/compare/2.2.0...2.3.0) (2014-09-16)
+* let translate service handle multiple promises (0e5d6d9d)
 
 
-### Bug Fixes
 
-* **$translate:** return $missingTranslationHandler result when no translation was found ([7625951](https://github.com/angular-translate/angular-translate/commit/7625951))
-* **bower.json:** Avoid 'invalid-meta angular-bootstrap-affix is missing "ignore" entry in bower.j ([595501a](https://github.com/angular-translate/angular-translate/commit/595501a)), closes [bower/bower#1388](https://github.com/bower/bower/issues/1388)
-* **demo:** fixes wrong method call in demo ([47fc943](https://github.com/angular-translate/angular-translate/commit/47fc943))
-* **directive:** change event for listening to `$translateChangeEnd` ([98fe649](https://github.com/angular-translate/angular-translate/commit/98fe649)), closes [#658](https://github.com/angular-translate/angular-translate/issues/658)
-* **directive:** improve the cloak-directive's performance ([acab18a](https://github.com/angular-translate/angular-translate/commit/acab18a))
-* **docs:** fix example in directive ngdoc-documentation (fixes #678) ([176b3e9](https://github.com/angular-translate/angular-translate/commit/176b3e9)), closes [#678](https://github.com/angular-translate/angular-translate/issues/678)
-* **docs:** Fix typo ([6c2ab30](https://github.com/angular-translate/angular-translate/commit/6c2ab30))
-* **package.json:** remove unnecessary relative paths from package.json ([8e5b87e](https://github.com/angular-translate/angular-translate/commit/8e5b87e))
-* **service:** add shim for indexOf and trim #638 ([b951fd5](https://github.com/angular-translate/angular-translate/commit/b951fd5))
-* **service:** addition of preferred language to fallback language stack is now preventing dupl ([b2bb166](https://github.com/angular-translate/angular-translate/commit/b2bb166))
-* **service:** load fallback languages also for instant and filter ([ed6023a](https://github.com/angular-translate/angular-translate/commit/ed6023a))
-* **service:** use hasOwnProperty of prototype #638 ([d8a5060](https://github.com/angular-translate/angular-translate/commit/d8a5060))
-* **storage:** fix 'DOM Exception 18' at feature detection ([75504cb](https://github.com/angular-translate/angular-translate/commit/75504cb)), closes [#629](https://github.com/angular-translate/angular-translate/issues/629)
-* **storage:** fixup 75504cbe ([53a8bad](https://github.com/angular-translate/angular-translate/commit/53a8bad))
-* **translateService:** fixup/rewrite for b48f6bb (specs) ([45ac14d](https://github.com/angular-translate/angular-translate/commit/45ac14d))
-* **translateService:** prevent multiple XHR calls ([b48f6bb](https://github.com/angular-translate/angular-translate/commit/b48f6bb))
 
-### Features
 
-* **directive:** add possibility to mix translation interpolation with other text in element body ([be62131](https://github.com/angular-translate/angular-translate/commit/be62131)), closes [#461](https://github.com/angular-translate/angular-translate/issues/461)
 
+# 0.9.2 (2013-05-30)
 
+## Features
+### translateProvider
 
-<a name="2.2.0"></a>
-# [2.2.0](https://github.com/angular-translate/angular-translate/compare/2.1.0...2.2.0) (2014-06-03)
+* add fallbackLanguage() method (018991e8)
 
 
-### Bug Fixes
 
-* **$translate:** checks modification ([b91e4de](https://github.com/angular-translate/angular-translate/commit/b91e4de))
-* **$translate:** if translation exists, use the translated string even if it's empty ([4ba736f](https://github.com/angular-translate/angular-translate/commit/4ba736f))
-* **$translate:** if translation exists, use the translated string even if it's empty ([eeb8c2a](https://github.com/angular-translate/angular-translate/commit/eeb8c2a))
-* **$translate:** use case-insensitive check for language key aliases ([09a8bf1](https://github.com/angular-translate/angular-translate/commit/09a8bf1)), closes [#431](https://github.com/angular-translate/angular-translate/issues/431)
-* **$translate:** use case-insensitive check for language key aliases ([26ec308](https://github.com/angular-translate/angular-translate/commit/26ec308)), closes [#431](https://github.com/angular-translate/angular-translate/issues/431)
-* **$translateProvider:** determinePreferredLanguage was not chainable ([7c29f2f](https://github.com/angular-translate/angular-translate/commit/7c29f2f)), closes [#487](https://github.com/angular-translate/angular-translate/issues/487)
-* **$translateProvider:** fix comparison in one case of negotiateLocale() ([c2b94ca](https://github.com/angular-translate/angular-translate/commit/c2b94ca))
-* **$translateProvider:** fix comparison in one case of negotiateLocale() ([fe04c72](https://github.com/angular-translate/angular-translate/commit/fe04c72))
-* **demo:** correct demo of `translate-values` ([efa74fa](https://github.com/angular-translate/angular-translate/commit/efa74fa))
-* **demo:** correct demo of `translate-values` ([7de2ae2](https://github.com/angular-translate/angular-translate/commit/7de2ae2))
-* **demo:** use `.instant()` ([6bea192](https://github.com/angular-translate/angular-translate/commit/6bea192))
-* **directive:** Make translate-value-* work inside ng-if and ng-repeat ([e07eea7](https://github.com/angular-translate/angular-translate/commit/e07eea7)), closes [#433](https://github.com/angular-translate/angular-translate/issues/433)
-* **directive:** Make translate-value-* work inside ng-if and ng-repeat ([f22624b](https://github.com/angular-translate/angular-translate/commit/f22624b)), closes [#433](https://github.com/angular-translate/angular-translate/issues/433)
-* **docs:** removes explicit protocol declaration for assets ([eaa9bf7](https://github.com/angular-translate/angular-translate/commit/eaa9bf7)), closes [#513](https://github.com/angular-translate/angular-translate/issues/513)
-* **gruntfile:** fix image link ([65fc8be](https://github.com/angular-translate/angular-translate/commit/65fc8be))
-* **package.json:** fix repository url ([40af7ce](https://github.com/angular-translate/angular-translate/commit/40af7ce))
-* **package.json:** fix repository url ([a410c9a](https://github.com/angular-translate/angular-translate/commit/a410c9a))
-* **partialLoader:** fixes deprecated usage of arguments.callee ([1ac3a0a](https://github.com/angular-translate/angular-translate/commit/1ac3a0a))
-* **service:** docs annotation ([8ef0415](https://github.com/angular-translate/angular-translate/commit/8ef0415))
-* **service:** docs annotation ([839c4e8](https://github.com/angular-translate/angular-translate/commit/839c4e8))
-* **service:** use the aliased language key if available ([675e9a2](https://github.com/angular-translate/angular-translate/commit/675e9a2)), closes [#530](https://github.com/angular-translate/angular-translate/issues/530)
-* **storageLocal:** fixes QUOTAEXCEEDEDERROR (safari private browsing) ([59aa2a0](https://github.com/angular-translate/angular-translate/commit/59aa2a0))
-* fix npe on empty strings (trim()) ([c69de7b](https://github.com/angular-translate/angular-translate/commit/c69de7b))
-* **translateInterpolator:** make it work with 1.3-beta ([97e2241](https://github.com/angular-translate/angular-translate/commit/97e2241))
+## Bug fixes
+### translate.js
 
-### Features
+* Allow blank translation values (97591a8f)
 
-* **directive:** add option to define a default translation text ([a802665](https://github.com/angular-translate/angular-translate/commit/a802665))
-* **directive:** add option to define a default translation text ([fc57d26](https://github.com/angular-translate/angular-translate/commit/fc57d26))
-* **directive:** Support for camel casing interpolation variables. ([b345041](https://github.com/angular-translate/angular-translate/commit/b345041))
-* **directive:** Support for camel casing interpolation variables. ([4791e25](https://github.com/angular-translate/angular-translate/commit/4791e25))
-* **messageformat-support:** enhancing for sanitization like default ([ad01686](https://github.com/angular-translate/angular-translate/commit/ad01686))
-* **missingFallbackDefaultText:** enables a feature to return a default text for displaying in case of missing tra ([f24b15e](https://github.com/angular-translate/angular-translate/commit/f24b15e))
-* **service:** add possibility to translate a set of translation ids ([612dc27](https://github.com/angular-translate/angular-translate/commit/612dc27))
-* **service:** add possibility to translate a set of translation ids ([57bd07c](https://github.com/angular-translate/angular-translate/commit/57bd07c))
-* **service:** allow using wildcards in language aliases ([6f0ae3b](https://github.com/angular-translate/angular-translate/commit/6f0ae3b)), closes [#426](https://github.com/angular-translate/angular-translate/issues/426)
+###
 
+* fix bower.json (c3898829)
 
 
-<a name="2.0.1"></a>
-## [2.0.1](https://github.com/angular-translate/angular-translate/compare/2.0.0...2.0.1) (2014-02-25)
 
 
-### Bug Fixes
+# 0.9.1 (2013-05-25)
 
-* **$translate:** Ensuring that languages will be set based on the order they are requested, not t ([c909cd2](https://github.com/angular-translate/angular-translate/commit/c909cd2))
-* **$translate:** Ensuring that languages will be set based on the order they are requested, not t ([ebd62af](https://github.com/angular-translate/angular-translate/commit/ebd62af))
-* **$translate:** Ensuring that languages will be set based on the order they are requested, not t ([32e1851](https://github.com/angular-translate/angular-translate/commit/32e1851))
-* **instant:** $translate.instant(id) does not return correct fallback ([eec1d77](https://github.com/angular-translate/angular-translate/commit/eec1d77))
-* **instant:** fix possible npe in case of filters with undefineds ([61a9490](https://github.com/angular-translate/angular-translate/commit/61a9490))
-* **refresh:** fix bug in refresh if using partial loader ([95c43b4](https://github.com/angular-translate/angular-translate/commit/95c43b4))
+Remove $translateMissingTranslationHandlerLog service
 
-### Features
 
-* **instant:** invoke missing handler within `$translate.instant(id)` ([aaf52b5](https://github.com/angular-translate/angular-translate/commit/aaf52b5))
 
 
+# 0.9.0 (2013-05-23)
 
-<a name="2.0.0"></a>
-# [2.0.0](https://github.com/angular-translate/angular-translate/compare/1.1.1...2.0.0) (2014-02-16)
+## Features
+### translateProvider
 
+* add use*() methods for async loaders (f2329cc2)
 
-### Bug Fixes
 
-* ***:** jshint fixes ([1e3f8a6](https://github.com/angular-translate/angular-translate/commit/1e3f8a6))
-* **$translate:** check for fallbacklanguage ([321803d](https://github.com/angular-translate/angular-translate/commit/321803d))
-* **$translate:** Trim whitespace off translationId ([4939424](https://github.com/angular-translate/angular-translate/commit/4939424))
-* **$translatePartialLoader:** fixes docs annotation ([d6ea84b](https://github.com/angular-translate/angular-translate/commit/d6ea84b))
-* **demo:** fix server routes + add index page ([eb0a2dc](https://github.com/angular-translate/angular-translate/commit/eb0a2dc))
-* **demo:** links to demo resources updated to new locactions ([fddaa49](https://github.com/angular-translate/angular-translate/commit/fddaa49))
-* **deps:** add missing resolution ([a98a2f6](https://github.com/angular-translate/angular-translate/commit/a98a2f6))
-* **docs:** fixes links for languages ([265490f](https://github.com/angular-translate/angular-translate/commit/265490f))
-* **fallbackLanguage:** Fix fallback languages loading and applying ([4c5c47c](https://github.com/angular-translate/angular-translate/commit/4c5c47c))
-* **grunt:** includes translate-cloak directive ([84a59d2](https://github.com/angular-translate/angular-translate/commit/84a59d2))
-* avoid calls with empty translationId (sub issue of #298) ([08f087b](https://github.com/angular-translate/angular-translate/commit/08f087b))
-* fix npe introduced in 4939424a30 (#281) ([173a9bc](https://github.com/angular-translate/angular-translate/commit/173a9bc)), closes [(#281](https://github.com/(/issues/281) [#298](https://github.com/angular-translate/angular-translate/issues/298)
-* **guide/ru,uk:** Fix uses->use in multi language ([af59c6a](https://github.com/angular-translate/angular-translate/commit/af59c6a))
-* **instant:** remove language-preload if there were used within instant ([9a3eda6](https://github.com/angular-translate/angular-translate/commit/9a3eda6))
-* **loader-static-files.js:** Now allows empty string as prefix and postfix. ([051f431](https://github.com/angular-translate/angular-translate/commit/051f431))
-* **service:** fallback languages could not load when using `instant()` ([26de486](https://github.com/angular-translate/angular-translate/commit/26de486))
-* **translateCloak:** makes jshint happy ([2058fd3](https://github.com/angular-translate/angular-translate/commit/2058fd3))
-* **translateDirective:** fixes bad coding convention ([d5db4ad](https://github.com/angular-translate/angular-translate/commit/d5db4ad))
 
-### Features
 
-* **$translateProvider:** adds determinePreferredLanguage() ([7cbfabe](https://github.com/angular-translate/angular-translate/commit/7cbfabe))
-* **$translateProvider:** adds registerAvailableLanguagesKeys for negotiation ([6bef6bd](https://github.com/angular-translate/angular-translate/commit/6bef6bd))
-* **filter:** filter now use $translate.instant() since promises could not use ([a1b8a17](https://github.com/angular-translate/angular-translate/commit/a1b8a17))
-* **service:** add $translate.instant() for instant translations ([3a855eb](https://github.com/angular-translate/angular-translate/commit/3a855eb))
-* add an option for post processing compiling ([d5cd943](https://github.com/angular-translate/angular-translate/commit/d5cd943))
-* add option to html escape all values ([e042c44](https://github.com/angular-translate/angular-translate/commit/e042c44))
-* **translateCloak:** adds translate-cloak directive ([c125c56](https://github.com/angular-translate/angular-translate/commit/c125c56))
-* **translateDirective:** teaches directive custom translate-value-* attr ([5c27467](https://github.com/angular-translate/angular-translate/commit/5c27467)), closes [#188](https://github.com/angular-translate/angular-translate/issues/188)
 
+## Breaking Changes
+### demo
 
+   Old demo files are not available from now.
 
-<a name="1.1.1"></a>
-## [1.1.1](https://github.com/angular-translate/angular-translate/compare/1.1.0...1.1.1) (2013-11-24)
+### extensions
 
+  There are now extensions for loaders and storages
 
-### Bug Fixes
 
-* fixes encoding ([084f08c](https://github.com/angular-translate/angular-translate/commit/084f08c))
-* **docs:** fixes typo ([7e1c4e9](https://github.com/angular-translate/angular-translate/commit/7e1c4e9))
-* **docs:** fixes typo in landing page ([0b999ab](https://github.com/angular-translate/angular-translate/commit/0b999ab))
-* **grunt:** fixes missing storage-key ([635d290](https://github.com/angular-translate/angular-translate/commit/635d290))
-* **translateDirective:** fixes occuring 'translation id undefined' erros ([bb5a2c4](https://github.com/angular-translate/angular-translate/commit/bb5a2c4))
 
-### Features
+# 0.8.1 (2013-05-16)
 
-* add option to html escape all values ([fe94c1f](https://github.com/angular-translate/angular-translate/commit/fe94c1f))
-* shortcuts and links\n\nShortcuts creates a shorter translationId if the last key ([f9f2cf2](https://github.com/angular-translate/angular-translate/commit/f9f2cf2))
-* Update required Node up `0.10` ([b7cf5f4](https://github.com/angular-translate/angular-translate/commit/b7cf5f4))
+## Features
+### translateProvider
 
+* add methods to use different missingTranslationHandlers (f6ed3e3)
 
 
-<a name="1.1.0"></a>
-# [1.1.0](https://github.com/angular-translate/angular-translate/compare/1.0.2...1.1.0) (2013-09-02)
 
+## Bug fixes
+### docs
 
-### Bug Fixes
+* corrected typo (82569f0)
 
-* **translateDirective:** fixes bug that directive writes into scope ([4e06468](https://github.com/angular-translate/angular-translate/commit/4e06468)), closes [#128](https://github.com/angular-translate/angular-translate/issues/128)
-* **translateDirective:** fixes scope handling ([c566586](https://github.com/angular-translate/angular-translate/commit/c566586))
-* **translateService:** reset proposed language if there's no pending loader ([6b477fc](https://github.com/angular-translate/angular-translate/commit/6b477fc))
 
-### Features
+# 0.8.0 (2013-05-14)
 
-* **$translatePartialLoader:** Basic implementation ([81222bf](https://github.com/angular-translate/angular-translate/commit/81222bf))
-* **invalidate:** added invalidate() method ([d41f91e](https://github.com/angular-translate/angular-translate/commit/d41f91e))
-* **translateProvider:** makes methods chainable ([cdc9e9e](https://github.com/angular-translate/angular-translate/commit/cdc9e9e))
+* rename module ngTranslate to pascalprecht.translate
 
 
+# 0.7.1 (2013-05-13)
 
-<a name="1.0.2"></a>
-## [1.0.2](https://github.com/angular-translate/angular-translate/compare/1.0.1...1.0.2) (2013-08-07)
+## Features
+### chore
 
+* rename ngTranslate folder to src (65012d9)
 
-### Bug Fixes
 
-* **fallbackLanguage:** fixes bug that fallbackLanguage is loaded without loader ([6aa3747](https://github.com/angular-translate/angular-translate/commit/6aa3747))
-* **translateService:** uses should only load if a loader is registered ([604daec](https://github.com/angular-translate/angular-translate/commit/604daec))
-* **typo:** remove unnecessary semicolon ([54cb232](https://github.com/angular-translate/angular-translate/commit/54cb232))
 
 
+# 0.7.0 (2013-05-13)
 
-<a name="1.0.1"></a>
-## [1.0.1](https://github.com/angular-translate/angular-translate/compare/1.0.0...1.0.1) (2013-07-26)
+## Features
+### chore
 
+* rename ngTranslate folder to src (65012d9)
 
-### Bug Fixes
 
-* **demo:** change src to angular-translate script ([4be93b6](https://github.com/angular-translate/angular-translate/commit/4be93b6))
-* **dependency:** add 'angular-cookies' as bower devDependency ([b6f1426](https://github.com/angular-translate/angular-translate/commit/b6f1426))
-* **platolink:** deep link ([d368bf3](https://github.com/angular-translate/angular-translate/commit/d368bf3))
 
 
+# 0.7.0 (2013-05-12)
 
-<a name="1.0.0"></a>
-# [1.0.0](https://github.com/angular-translate/angular-translate/compare/0.9.4...1.0.0) (2013-07-23)
+## Features
+### translateProvider
 
+* missingTranslationHandler (3a5819e)
 
-### Bug Fixes
+* add a preferredLanguage property (563e9bf)
 
-* **docs:** fixes methodOf declaration of addInterpolation method ([f1eeba7](https://github.com/angular-translate/angular-translate/commit/f1eeba7))
-* **gh-pages:** plato report ([b85e19b](https://github.com/angular-translate/angular-translate/commit/b85e19b))
-* **tests:** travis CI ([c8624bf](https://github.com/angular-translate/angular-translate/commit/c8624bf))
-* **tests:** travis CI ([629bb8d](https://github.com/angular-translate/angular-translate/commit/629bb8d))
-* fixes gruntfile ([0d500db](https://github.com/angular-translate/angular-translate/commit/0d500db))
+* make translationTable extendable (8e3a455)
 
-### Features
+* add useLoaderFactory() as shortcut method (2915e8b)
 
-* **messageformat-interpolation:** implements usage of messageformat ([5596e8b](https://github.com/angular-translate/angular-translate/commit/5596e8b))
-* **translateDirective:** teaches directives to use custom interpolation ([bf3dbbb](https://github.com/angular-translate/angular-translate/commit/bf3dbbb))
-* **translateFilter:** teaches filter to use custom interpolation ([46f03cc](https://github.com/angular-translate/angular-translate/commit/46f03cc))
-* **translateService:** adds method to configure indicators for not found translations ([52a039f](https://github.com/angular-translate/angular-translate/commit/52a039f)), closes [#77](https://github.com/angular-translate/angular-translate/issues/77)
-* **translateService:** extracts default interpolation in standalone service ([5d8cb56](https://github.com/angular-translate/angular-translate/commit/5d8cb56))
-* **translateService:** implements proposedLanguage() ([6d34792](https://github.com/angular-translate/angular-translate/commit/6d34792))
-* **translateService:** implements usage of different interpolation services ([5e20e24](https://github.com/angular-translate/angular-translate/commit/5e20e24))
-* **translateService:** informs interpolator when locale has changed ([e59b141](https://github.com/angular-translate/angular-translate/commit/e59b141))
-* **translateService:** missingTranslationHandler receives language ([6fe6bb1](https://github.com/angular-translate/angular-translate/commit/6fe6bb1))
+* add storagePrefix() method (64cd99b)
 
+### docs
 
+* add documentation comments (b1efbca)
 
-<a name="0.9.4"></a>
-## [0.9.4](https://github.com/angular-translate/angular-translate/compare/0.9.3...0.9.4) (2013-06-21)
+### storageKey
 
+* add a storageKey method (dabf822)
 
-### Bug Fixes
+### translateService
 
-* **translateService:** fixes missingTranslationHandler-invokation bug ([525b353](https://github.com/angular-translate/angular-translate/commit/525b353)), closes [#74](https://github.com/angular-translate/angular-translate/issues/74)
+* add storage() method (98c2b12)
 
-### Features
 
-* **translateService:** removes empty options object requirement for loaders ([c09d1db](https://github.com/angular-translate/angular-translate/commit/c09d1db))
 
+## Bug fixes
+### tests
 
+* fix tests for preferredLanguage() (f1b5084)
 
-<a name="0.9.3"></a>
-## [0.9.3](https://github.com/angular-translate/angular-translate/compare/0.9.2...0.9.3) (2013-06-10)
+* Fix preferredLanguage tests (73efcfc)
 
+* Old values won't be ignored, so they have to be discarded (625b1d6)
 
-### Features
+### directive
 
-* **translateService:** let translate service handle multiple promises ([0e5d6d9](https://github.com/angular-translate/angular-translate/commit/0e5d6d9)), closes [#70](https://github.com/angular-translate/angular-translate/issues/70)
+* trim off white space around element.text() (e10173a)
 
 
+# 0.6.0 (2013-05-03)
 
-<a name="0.9.2"></a>
-## [0.9.2](https://github.com/angular-translate/angular-translate/compare/0.9.1...0.9.2) (2013-05-30)
+## Features
+### ngmin
 
+* add grunt-ngmin (f630958)
 
-### Bug Fixes
+### $translate
+* add support for asynchronous loading
 
-* fix bower.json ([c389882](https://github.com/angular-translate/angular-translate/commit/c389882))
 
-### Features
+# 0.5.2 (2013-04-30)
 
-* **translateProvider:** add fallbackLanguage() method ([018991e](https://github.com/angular-translate/angular-translate/commit/018991e)), closes [#67](https://github.com/angular-translate/angular-translate/issues/67)
 
 
+## Bug fixes
+### translateDirective
 
-<a name="0.9.1"></a>
-## [0.9.1](https://github.com/angular-translate/angular-translate/compare/0.9.0...0.9.1) (2013-05-25)
+* check for truthy value in watch callback (98087c7)
 
 
-### Bug Fixes
+# 0.5.1 (2013-04-29)
 
-* **translate.js:** Allow blank translation values ([97591a8](https://github.com/angular-translate/angular-translate/commit/97591a8))
+## Features
+### .jshintrc
 
+* add .jshintrc (0c8d3da)
 
+### .bowerrc
 
-<a name="0.9.0"></a>
-# [0.9.0](https://github.com/angular-translate/angular-translate/compare/0.8.1...0.9.0) (2013-05-22)
+* add .bowerrc (42363ee)
 
+### bower.json
 
-### Features
+* rename component.json to bower.json (17acd10)
 
-* **translateProvider:** add use*() methods for async loaders ([f2329cc](https://github.com/angular-translate/angular-translate/commit/f2329cc)), closes [#58](https://github.com/angular-translate/angular-translate/issues/58)
 
 
 
-<a name="0.8.1"></a>
-## [0.8.1](https://github.com/angular-translate/angular-translate/compare/0.8.0...0.8.1) (2013-05-16)
+# 0.5.0 (2013-04-25)
 
+## Features
+### conventional-changelogs
 
-### Bug Fixes
+* Add grunt-conventional-changelog task (c8093a7)
 
-* **translate.js:** corrected typo ([82569f0](https://github.com/angular-translate/angular-translate/commit/82569f0))
 
-### Features
 
-* **translateProvider:** add methods to use different missingTranslationHandlers ([f6ed3e3](https://github.com/angular-translate/angular-translate/commit/f6ed3e3))
 
+# 0.4.4
 
-### BREAKING CHANGES
+## Features
+### editorconfig
+  * Added .editorconfig to make contribution as easy as possible
 
-* S:  missingTranslationHandler is no longer supported since its functionality will be replaced with  useMissingTranslationHandlerLog.
 
+# 0.4.3
 
-<a name="0.8.0"></a>
-# [0.8.0](https://github.com/angular-translate/angular-translate/compare/0.7.1...0.8.0) (2013-05-14)
+## Fixes
+### translateDirective
+  * Fixed bug that directive doesn't change contents when language is switched at runtime
 
 
+# 0.4.2
 
+## Fixes
+### karma-dependency
+  * Fixed dependencies (Karma 0.9.x isn't stable!)
 
-<a name="0.7.1"></a>
-## [0.7.1](https://github.com/angular-translate/angular-translate/compare/0.7.0...0.7.1) (2013-05-13)
 
+# 0.4.0
 
-### Features
+## Features
+### $translateProvider
+  * Introducing $translateProvider.rememberLanguage()
+  * You're now able to tell ngTranslate save lang state cross requests
 
-* **chore:** rename ngTranslate folder to src ([65012d9](https://github.com/angular-translate/angular-translate/commit/65012d9))
 
+# 0.3.0
 
+## Features
+### $translate
+  * $translate Service now has method uses(key) to ask for currently used language
+  * Language can now be changed at runtime
 
-<a name="0.7.0"></a>
-# [0.7.0](https://github.com/angular-translate/angular-translate/compare/0.6.0...0.7.0) (2013-05-12)
-
-
-### Bug Fixes
-
-* **directive:** trim off white space around element.text() ([e10173a](https://github.com/angular-translate/angular-translate/commit/e10173a))
-* **tests:** Fix preferredLanguage tests ([73efcfc](https://github.com/angular-translate/angular-translate/commit/73efcfc))
-* **tests:** fix tests for preferredLanguage() ([f1b5084](https://github.com/angular-translate/angular-translate/commit/f1b5084))
-* **tests:** Old values won't be ignored, so they have to be discarded ([625b1d6](https://github.com/angular-translate/angular-translate/commit/625b1d6))
-
-### Features
-
-* nested objects will be transformed when using `$translateProvider.translations`  ([b15cee4](https://github.com/angular-translate/angular-translate/commit/b15cee4))
-* **docs:** add documentation comments ([b1efbca](https://github.com/angular-translate/angular-translate/commit/b1efbca))
-* **storageKey:** add a storageKey method ([dabf822](https://github.com/angular-translate/angular-translate/commit/dabf822))
-* **translateProvider:** add a preferredLanguage property ([563e9bf](https://github.com/angular-translate/angular-translate/commit/563e9bf))
-* **translateProvider:** add storagePrefix() method ([64cd99b](https://github.com/angular-translate/angular-translate/commit/64cd99b))
-* **translateProvider:** add useLoaderFactory() as shortcut method ([2915e8b](https://github.com/angular-translate/angular-translate/commit/2915e8b))
-* **translateProvider:** make translationTable extendable ([8e3a455](https://github.com/angular-translate/angular-translate/commit/8e3a455)), closes [#33](https://github.com/angular-translate/angular-translate/issues/33)
-* **translateProvider:** missingTranslationHandler ([3a5819e](https://github.com/angular-translate/angular-translate/commit/3a5819e))
-* **translateService:** add storage() method ([98c2b12](https://github.com/angular-translate/angular-translate/commit/98c2b12))
-
-
-### BREAKING CHANGES
-
-* The $STORAGE_KEY isn't represent a current storage key
-from now. To discover which key is used now you have to call the storageKey
-method without params.
-
-
-<a name="0.6.0"></a>
-# [0.6.0](https://github.com/angular-translate/angular-translate/compare/0.5.2...0.6.0) (2013-05-03)
-
-
-### Features
-
-* **ngmin:** add grunt-ngmin ([f630958](https://github.com/angular-translate/angular-translate/commit/f630958)), closes [#20](https://github.com/angular-translate/angular-translate/issues/20)
-
-
-
-<a name="0.5.2"></a>
-## [0.5.2](https://github.com/angular-translate/angular-translate/compare/0.5.1...0.5.2) (2013-04-30)
-
-
-### Bug Fixes
-
-* **translateDirective:** check for truthy value in watch callback ([98087c7](https://github.com/angular-translate/angular-translate/commit/98087c7)), closes [#18](https://github.com/angular-translate/angular-translate/issues/18)
-
-
-
-<a name="0.5.1"></a>
-## [0.5.1](https://github.com/angular-translate/angular-translate/compare/0.5.0...0.5.1) (2013-04-29)
-
-
-### Features
-
-* **.bowerrc:** add .bowerrc ([42363ee](https://github.com/angular-translate/angular-translate/commit/42363ee)), closes [#16](https://github.com/angular-translate/angular-translate/issues/16)
-* **.jshintrc:** add .jshintrc ([0c8d3da](https://github.com/angular-translate/angular-translate/commit/0c8d3da)), closes [#17](https://github.com/angular-translate/angular-translate/issues/17)
-* **bower.json:** rename component.json to bower.json ([17acd10](https://github.com/angular-translate/angular-translate/commit/17acd10))
-
-
-
-<a name="0.5.0"></a>
-# [0.5.0](https://github.com/angular-translate/angular-translate/compare/0.4.4...0.5.0) (2013-04-25)
-
-
-### Features
-
-* **conventional-changelogs:** Add grunt-conventional-changelog task ([c8093a7](https://github.com/angular-translate/angular-translate/commit/c8093a7)), closes [#11](https://github.com/angular-translate/angular-translate/issues/11)
-
-
-
-<a name="0.4.4"></a>
-## [0.4.4](https://github.com/angular-translate/angular-translate/compare/0.4.2...0.4.4) (2013-04-23)
-
-
-
-
-<a name="0.4.2"></a>
-## [0.4.2](https://github.com/angular-translate/angular-translate/compare/0.4.0...0.4.2) (2013-04-17)
-
-
-
-
-<a name="0.4.0"></a>
-# [0.4.0](https://github.com/angular-translate/angular-translate/compare/0.3.0...0.4.0) (2013-04-07)
-
-
-
-
-<a name="0.3.0"></a>
-# [0.3.0](https://github.com/angular-translate/angular-translate/compare/0.2.1...0.3.0) (2013-04-06)
-
-
-
-
-<a name="0.2.1"></a>
-## [0.2.1](https://github.com/angular-translate/angular-translate/compare/0.2.0...0.2.1) (2013-04-05)
-
-
-
-
-<a name="0.2.0"></a>
-# [0.2.0](https://github.com/angular-translate/angular-translate/compare/0.1.2...0.2.0) (2013-04-03)
-
-
-
-
-<a name="0.1.2"></a>
-## [0.1.2](https://github.com/angular-translate/angular-translate/compare/0.1.1...0.1.2) (2013-04-02)
-
-
-
-
-<a name="0.1.1"></a>
-## [0.1.1](https://github.com/angular-translate/angular-translate/compare/0.1.0...0.1.1) (2013-04-01)
-
-
-
-
-<a name="0.1.0"></a>
-# [0.1.0](https://github.com/angular-translate/angular-translate/compare/0.0.5...0.1.0) (2013-04-01)
-
-
-
-
-<a name="0.0.5"></a>
-## [0.0.5](https://github.com/angular-translate/angular-translate/compare/0.0.4...0.0.5) (2013-04-01)
-
-
-
-
-<a name="0.0.4"></a>
-## [0.0.4](https://github.com/angular-translate/angular-translate/compare/0.0.2...0.0.4) (2013-04-01)
-
-
-
-
-<a name="0.0.2"></a>
-## [0.0.2](https://github.com/angular-translate/angular-translate/compare/0.0.1...0.0.2) (2013-03-30)
-
-
-
-
-<a name="0.0.1"></a>
-## 0.0.1 (2013-03-28)
-
-
-
-
+* v.0.2.1
+  * Revamped test suite structure
+  * Added more tests
+* v.0.2.0
+  * Added translate directive to handle translations
+* v.0.1.2
+  * Fixed unit tests
+  * Fixed karma.conf
+  * Introduced $translateProvider.uses(key);
+  * Implemented multi-lang support
+* v.0.1.1
+  * Added **CONTRIBUTING.md** as guide for contributers
+  * Added **CHANGELOG.md**
+* v.0.1.0
+  * Added automated tests using **karma** and **jasmine**
+  * Added Travis CI support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="2.13.1"></a>
+## [2.13.1](https://github.com/angular-translate/angular-translate/compare/2.13.0...v2.13.1) (2016-12-06)
+
+
+
 <a name="2.13.0"></a>
 # [2.13.0](https://github.com/angular-translate/angular-translate/compare/2.12.1...v2.13.0) (2016-10-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+<a name="2.7.2"></a>
+### 2.7.2 (2015-06-01)
+
+
+#### Bug Fixes
+
+* **directive:** ensure value of `translate` will be translated always ([454d7029](http://github.com/angular-translate/angular-translate/commit/454d70290aef706929c4894b70aef6d4a0dba0be))
+* **sanitization:** fix/workaround issue when jQuery is not available ([ef1b10a3](http://github.com/angular-translate/angular-translate/commit/ef1b10a3e3b113831b251a696dd19c7f9d240db3))
+* **service:**
+  * fix silence on error, add missing catch on `refresh()` ([5a85a64a](http://github.com/angular-translate/angular-translate/commit/5a85a64a4a9631afda73b71ce0509c06e0644189))
+  * make provider's storageKey chainable ([de8c253b](http://github.com/angular-translate/angular-translate/commit/de8c253b49f793ea85644610ca0cdef0cf4d024a))
+
+
 <a name="2.7.1"></a>
 ### 2.7.1 (2015-06-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+<a name="2.6.0"></a>
+## 2.6.0 (2015-02-08)
+
+
+#### Bug Fixes
+
+* **directive:**
+  * newlines before/after translation ids should be ignored ([8dcf3e23](http://github.com/angular-translate/angular-translate/commit/8dcf3e23e9623b59f71c4b18c19a066f649b7bdf), closes [#909](http://github.com/angular-translate/angular-translate/issues/909))
+  * fix missing update using dynamic translationIds ([faebe195](http://github.com/angular-translate/angular-translate/commit/faebe19598d35ac31678cce028d61c87ecd4b20a), closes [#854](http://github.com/angular-translate/angular-translate/issues/854))
+  * ensure internal watcher will be removed ([e69f4a14](http://github.com/angular-translate/angular-translate/commit/e69f4a14ccb4c549250900696c58ae4ede71c656))
+  * fix minor memory leak ([5e4533a4](http://github.com/angular-translate/angular-translate/commit/5e4533a4a485672ab7e1675d5d1a11f689e5d6ad))
+* **filter:** apply notFoundIndicators also for instant translations correctly ([5a9f436f](http://github.com/angular-translate/angular-translate/commit/5a9f436fb8444d4992b00383bd37b61580e816d4), closes [#866](http://github.com/angular-translate/angular-translate/issues/866))
+* **service:**
+  * fix an issue with default interpolator and expressions ([75b7381f](http://github.com/angular-translate/angular-translate/commit/75b7381fbfbb342b98a7fe8f9a9b7915004dc66c))
+  * use $window/$windowProvider instead of window fix(docs): update ngdocs on storag ([bfa7b7b2](http://github.com/angular-translate/angular-translate/commit/bfa7b7b28f6e2698205e774b4d13d34d85abfc2f))
+  * fallback languages follow shortcuts (fixes #758) ([cce897a3](http://github.com/angular-translate/angular-translate/commit/cce897a34a2087c6799cd11889bc90db3c56f227))
+
+
+#### Features
+
+* **$translatePartialLoader:** adds optional priority param to the addPart function ([570617cf](http://github.com/angular-translate/angular-translate/commit/570617cf68804fdd21ba215d9a6a7c4b3083fd2a))
+* **directive:** add $translateProvider.directityPriority ([b0b77162](http://github.com/angular-translate/angular-translate/commit/b0b771624cda1a51879c7f685f98e90923d4a3b0))
+* **loader:** support for multiple static translation files ([c462ee6a](http://github.com/angular-translate/angular-translate/commit/c462ee6aa6f095f3cd7e1b5ebc9d4b4d135c1ae2))
+* **service:** extend loader api: add isPartLoaded and getRegisteredParts to $translatePartialL ([54f8ab3e](http://github.com/angular-translate/angular-translate/commit/54f8ab3e166fa2e1ef1c1334263f9df612a4940e))
+
+
 <a name="2.5.2"></a>
 ### 2.5.2 (2014-12-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="2.8.1"></a>
+## [2.8.1](https://github.com/angular-translate/angular-translate/compare/2.8.0...v2.8.1) (2015-10-01)
+
+
+### Bug Fixes
+
+* **service:** Fix `$translate.isReady()` won't return true if ready ([b40a344](https://github.com/angular-translate/angular-translate/commit/b40a344)), closes [#1239](https://github.com/angular-translate/angular-translate/issues/1239)
+* **service:** should not abort fallback languages (feature #1070) ([cc410b1](https://github.com/angular-translate/angular-translate/commit/cc410b1)), closes [#1070](https://github.com/angular-translate/angular-translate/issues/1070)
+
+
+
 <a name="2.8.0"></a>
 # [2.8.0](https://github.com/angular-translate/angular-translate/compare/2.7.2...2.8.0) (2015-09-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+<a name="2.8.0"></a>
+# [2.8.0](https://github.com/angular-translate/angular-translate/compare/2.7.2...v2.8.0) (2015-09-18)
+
+
+### Bug Fixes
+
+* **build:** ensure MessageFormat will be added correctly when using UMD ([f5e039c](https://github.com/angular-translate/angular-translate/commit/f5e039c))
+* **directive:** Fix behavior of translate-cloak timing ([a6adf47](https://github.com/angular-translate/angular-translate/commit/a6adf47)), closes [#929](https://github.com/angular-translate/angular-translate/issues/929) [#1175](https://github.com/angular-translate/angular-translate/issues/1175)
+* **directive:** Fix special IE11 issue #925 ([c4b16d3](https://github.com/angular-translate/angular-translate/commit/c4b16d3)), closes [#925](https://github.com/angular-translate/angular-translate/issues/925)
+* **docs:** avoid using absolute links in lang chooser #1136 ([2cdc902](https://github.com/angular-translate/angular-translate/commit/2cdc902))
+* **docs:** Fix more typos in CONTRIBUTING.md, add some infos about tests ([e88b990](https://github.com/angular-translate/angular-translate/commit/e88b990))
+* **docs:** Fix typo in CONTRIBUTING.md ([1c2ac47](https://github.com/angular-translate/angular-translate/commit/1c2ac47))
+* **docs:** Fix typo in zh-cn docs ([2a16eb6](https://github.com/angular-translate/angular-translate/commit/2a16eb6))
+* **service:** abort the last loader if not finished #1070 ([dd4a8b4](https://github.com/angular-translate/angular-translate/commit/dd4a8b4))
+* **service:** update storage before triggering $translateChangeSuccess ([77dd5a2](https://github.com/angular-translate/angular-translate/commit/77dd5a2))
+* **service provider:** change/fix return of preferredLanguage() ([6014a81](https://github.com/angular-translate/angular-translate/commit/6014a81))
+
+### Features
+
+* **directive:** translate-namespace directive ([45523bb](https://github.com/angular-translate/angular-translate/commit/45523bb))
+* **loaders:** addition to e7516dc #1080 (disable legacy $http cbs) ([233a012](https://github.com/angular-translate/angular-translate/commit/233a012))
+* **loaders:** remove use of legacy methods on $http promises #1080 ([e7516dc](https://github.com/angular-translate/angular-translate/commit/e7516dc))
+* **meta:** enrich copyright header with a leagl person ([21da61c](https://github.com/angular-translate/angular-translate/commit/21da61c))
+* **sanitize:** Allow sanitize strategy defined as a service ([8a6cc07](https://github.com/angular-translate/angular-translate/commit/8a6cc07))
+* **service:** add option to customize the nested delimiter ([78161f8](https://github.com/angular-translate/angular-translate/commit/78161f8))
+* **service:** introduce `isReady()` and `onReady()` with event ([9a4bd0d](https://github.com/angular-translate/angular-translate/commit/9a4bd0d))
+
+
+
 <a name="2.7.2"></a>
 ### 2.7.2 (2015-06-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="2.6.1"></a>
+### 2.6.1 (2015-03-01)
+
+
+#### Bug Fixes
+
+* **static-files-loader:**
+  * fix multiple files definition (docu update) #923, pr #936 ([e637c01d](http://github.com/angular-translate/angular-translate/commit/e637c01df50afd506fa75bc2ce781aacf47ec777))
+  * fix multiple files definition #923 ([1b6256a8](http://github.com/angular-translate/angular-translate/commit/1b6256a8685ff344d75237d5f01cd32845315e54))
+
+
 <a name="2.6.0"></a>
 ## 2.6.0 (2015-02-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="2.12.1"></a>
+## [2.12.1](https://github.com/angular-translate/angular-translate/compare/2.12.0...v2.12.1) (2016-09-15)
+
+
+### Bug Fixes
+
+* **build:** Add missing translate-attr directive to Gruntfile.js ([e70e9ad](https://github.com/angular-translate/angular-translate/commit/e70e9ad)), closes [#1577](https://github.com/angular-translate/angular-translate/issues/1577)
+* **style:** fix code style issues in ~-attr directive ([1848bc8](https://github.com/angular-translate/angular-translate/commit/1848bc8))
+
+
+
 <a name="2.12.0"></a>
 # [2.12.0](https://github.com/angular-translate/angular-translate/compare/2.11.1...v2.12.0) (2016-09-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+<a name="2.13.0"></a>
+# [2.13.0](https://github.com/angular-translate/angular-translate/compare/2.12.1...v2.13.0) (2016-10-30)
+
+
+### Bug Fixes
+
+* **service:** fix .instant() not handling TrustedValueHolderType correctly ([1ede55e](https://github.com/angular-translate/angular-translate/commit/1ede55e)), closes [#1618](https://github.com/angular-translate/angular-translate/issues/1618)
+* **service:** reject promise if handler returns undefined ([8fe6f23](https://github.com/angular-translate/angular-translate/commit/8fe6f23)), closes [#1600](https://github.com/angular-translate/angular-translate/issues/1600)
+* **service:** return empty string when found in fallback ([d76227e](https://github.com/angular-translate/angular-translate/commit/d76227e))
+
+
+### Features
+
+* **sanitize:** sanitize override on instant call ([01fecd0](https://github.com/angular-translate/angular-translate/commit/01fecd0))
+* **service:** add $translate.getTranslationTable(langKey) ([40f9e35](https://github.com/angular-translate/angular-translate/commit/40f9e35))
+* **service:** add file map lookup into static-files loader ([132e49a](https://github.com/angular-translate/angular-translate/commit/132e49a))
+* **service:** add mf configurer [#1619](https://github.com/angular-translate/angular-translate/issues/1619) ([676114b](https://github.com/angular-translate/angular-translate/commit/676114b))
+
+
+
 <a name="2.12.1"></a>
 ## [2.12.1](https://github.com/angular-translate/angular-translate/compare/2.12.0...v2.12.1) (2016-09-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+<a name="2.12.0"></a>
+# [2.12.0](https://github.com/angular-translate/angular-translate/compare/2.11.1...v2.12.0) (2016-09-05)
+
+
+### Bug Fixes
+
+* **service:** fix infinite loop when fallback language async loading fails ([233f30c](https://github.com/angular-translate/angular-translate/commit/233f30c))
+* **service:** treat date param as-is (no sanitize/escape) ([ab1ecce](https://github.com/angular-translate/angular-translate/commit/ab1ecce)), closes [#1560](https://github.com/angular-translate/angular-translate/issues/1560)
+
+
+### Features
+
+* **directive:** introduce standalone translate-attr directive ([bcb0f2c](https://github.com/angular-translate/angular-translate/commit/bcb0f2c))
+* **partial loader:** add error response to errorHandler ([e3aba1c](https://github.com/angular-translate/angular-translate/commit/e3aba1c))
+* **service:** introduce new sanitize strategies: sce/sceParameters ([1624df5](https://github.com/angular-translate/angular-translate/commit/1624df5))
+* **service:** provide for sanitize/escape strategy 3rd argument context ([8504c60](https://github.com/angular-translate/angular-translate/commit/8504c60))
+
+
+
 <a name="2.11.1"></a>
 ## [2.11.1](https://github.com/angular-translate/angular-translate/compare/2.11.0...v2.11.1) (2016-07-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+<a name="2.3.0"></a>
+## 2.3.0 (2014-09-16)
+
+
+#### Bug Fixes
+
+* **$translate:** return $missingTranslationHandler result when no translation was found ([7625951d](http://github.com/PascalPrecht/angular-translate/commit/7625951de2474049be78294fa129c32ea46df6a9))
+* **bower.json:** Avoid 'invalid-meta angular-bootstrap-affix is missing "ignore" entry in bower.j ([595501a9](http://github.com/PascalPrecht/angular-translate/commit/595501a9d4882207e3ff510dec80dbe0a553d580))
+* **demo:** fixes wrong method call in demo ([47fc9436](http://github.com/PascalPrecht/angular-translate/commit/47fc9436cfc69347f8a9b7f09cf5c726c0ca1931))
+* **directive:**
+  * improve the cloak-directive's performance ([acab18ab](http://github.com/PascalPrecht/angular-translate/commit/acab18ab5e6f455db86f6c9dabbbbdbc2f7b7855))
+  * change event for listening to `$translateChangeEnd` ([98fe649a](http://github.com/PascalPrecht/angular-translate/commit/98fe649a241b79c245fb32d838b84f0fac319f5a), closes [#658](http://github.com/PascalPrecht/angular-translate/issues/658))
+* **docs:**
+  * fix example in directive ngdoc-documentation (fixes #678) ([176b3e96](http://github.com/PascalPrecht/angular-translate/commit/176b3e96a78c4590f42817e6dcf44addcc49a13f))
+  * Fix typo ([6c2ab307](http://github.com/PascalPrecht/angular-translate/commit/6c2ab307d5b31c0e2e70c2cce0ccbf804db4c540))
+* **package.json:** remove unnecessary relative paths from package.json ([8e5b87e7](http://github.com/PascalPrecht/angular-translate/commit/8e5b87e726562b2fcfdaefb49b35c114e92c66a0))
+* **service:**
+  * use hasOwnProperty of prototype #638 ([d8a5060b](http://github.com/PascalPrecht/angular-translate/commit/d8a5060b2273f699fa75e32d7a73e5f62aab670c))
+  * add shim for indexOf and trim #638 ([b951fd50](http://github.com/PascalPrecht/angular-translate/commit/b951fd50f1f312755de1fd66f51e38bef3f5b882))
+  * load fallback languages also for instant and filter ([ed6023a4](http://github.com/PascalPrecht/angular-translate/commit/ed6023a4aa2ebc51ba839b976eb1b8f8e8fa91b6))
+  * addition of preferred language to fallback language stack is now preventing dupl ([b2bb1669](http://github.com/PascalPrecht/angular-translate/commit/b2bb166944074aa174f0ed557bf4e2457128b3b8))
+* **storage:**
+  * fixup 75504cbe ([53a8badb](http://github.com/PascalPrecht/angular-translate/commit/53a8badbd1d8fe82d43ddc17e27eaae1a414ee9b))
+  * fix 'DOM Exception 18' at feature detection ([75504cbe](http://github.com/PascalPrecht/angular-translate/commit/75504cbe2ddc0d18e08288b0fa4453356aaafe73))
+* **translateService:**
+  * fixup/rewrite for b48f6bb (specs) ([45ac14d5](http://github.com/PascalPrecht/angular-translate/commit/45ac14d5bf7d8d9569fa0fff99a0dcb5bc419e68))
+  * prevent multiple XHR calls ([b48f6bb4](http://github.com/PascalPrecht/angular-translate/commit/b48f6bb438a193174df569beef24d193d5cd954c))
+
+
+#### Features
+
+* **directive:** add possibility to mix translation interpolation with other text in element body ([be621314](http://github.com/PascalPrecht/angular-translate/commit/be6213144a686b34cff3ba29b9a52041924b2c9e), closes [#461](http://github.com/PascalPrecht/angular-translate/issues/461))
+
+
 <a name="2.2.0"></a>
 ## 2.2.0 (2014-06-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+<a name="2.2.0"></a>
+## 2.2.0 (2014-06-03)
+
+
+#### Bug Fixes
+
+* fix npe on empty strings (trim()) ([c69de7b8](http://github.com/PascalPrecht/angular-translate/commit/c69de7b87a0efe05548f03b1f2767968d2dc6aac))
+* **$translate:**
+  * checks modification ([b91e4ded](http://github.com/PascalPrecht/angular-translate/commit/b91e4ded560a96a815248f116c893e10414296af))
+  * if translation exists, use the translated string even if it's empty ([eeb8c2ad](http://github.com/PascalPrecht/angular-translate/commit/eeb8c2ad23f915828e83c840ecb00c840812dfa2))
+  * use case-insensitive check for language key aliases ([26ec3088](http://github.com/PascalPrecht/angular-translate/commit/26ec3088bcc50bacb8370e352e556d4e48830b64))
+* **$translateProvider:**
+  * determinePreferredLanguage was not chainable ([7c29f2fc](http://github.com/PascalPrecht/angular-translate/commit/7c29f2fc5aeea17dd50ecfc40d1fad67ddd93650), closes [#487](http://github.com/PascalPrecht/angular-translate/issues/487))
+  * fix comparison in one case of negotiateLocale() ([fe04c72f](http://github.com/PascalPrecht/angular-translate/commit/fe04c72fc1bb2b9ff07ac0d974374e16397d58c7))
+* **demo:**
+  * use `.instant()` ([6bea1928](http://github.com/PascalPrecht/angular-translate/commit/6bea19281d52f8ae956f6e898616d01c097d8c23))
+  * correct demo of `translate-values` ([7de2ae23](http://github.com/PascalPrecht/angular-translate/commit/7de2ae23ee87a10921c3b4883d535fd69ecf2b89))
+* **directive:** Make translate-value-* work inside ng-if and ng-repeat ([e07eea75](http://github.com/PascalPrecht/angular-translate/commit/e07eea757aec8cf3d2342abcd94e97d1fe615c80))
+* **docs:** removes explicit protocol declaration for assets ([eaa9bf7b](http://github.com/PascalPrecht/angular-translate/commit/eaa9bf7b46cf5983e9f9fd97a22a606bf52480dd))
+* **gruntfile:** fix image link ([65fc8be3](http://github.com/PascalPrecht/angular-translate/commit/65fc8be35ddae016438fd627d788317c46bb22f3))
+* **package.json:** fix repository url ([40af7ce7](http://github.com/PascalPrecht/angular-translate/commit/40af7ce79228526068e11f1a3b6cc3f56e30a831))
+* **partialLoader:** fixes deprecated usage of arguments.callee ([1ac3a0a7](http://github.com/PascalPrecht/angular-translate/commit/1ac3a0a7c69f0e765a615a395ea467f9de95f0c9))
+* **service:**
+  * use the aliased language key if available ([675e9a21](http://github.com/PascalPrecht/angular-translate/commit/675e9a21b6b20b9aa78514deb602954a985a5f83), closes [#530](http://github.com/PascalPrecht/angular-translate/issues/530))
+  * docs annotation ([839c4e89](http://github.com/PascalPrecht/angular-translate/commit/839c4e89f1fa062bfceebf43126cc38b699f891c))
+* **storageLocal:** fixes QUOTAEXCEEDEDERROR (safari private browsing) ([59aa2a01](http://github.com/PascalPrecht/angular-translate/commit/59aa2a01dca73b8343eadd77d41dcb294bfad89a))
+* **translateInterpolator:** make it work with 1.3-beta ([97e2241c](http://github.com/PascalPrecht/angular-translate/commit/97e2241c9f612df347863b3fb57acc5416168b07))
+
+
+#### Features
+
+* **directive:**
+  * add option to define a default translation text ([a8026651](http://github.com/PascalPrecht/angular-translate/commit/a8026651b5fdc424c681c03cda1b1f749493ba26))
+  * Support for camel casing interpolation variables. ([b3450410](http://github.com/PascalPrecht/angular-translate/commit/b3450410686846291fd068616237586b35beb91e))
+* **messageformat-support:** enhancing for sanitization like default ([ad016861](http://github.com/PascalPrecht/angular-translate/commit/ad016861f6ed4d65a6ee074b8feba3f9911dfc20))
+* **missingFallbackDefaultText:** enables a feature to return a default text for displaying in case of missing tra ([f24b15e8](http://github.com/PascalPrecht/angular-translate/commit/f24b15e8d3ca6231deab64a843d4ca5830176343))
+* **service:**
+  * allow using wildcards in language aliases ([6f0ae3bf](http://github.com/PascalPrecht/angular-translate/commit/6f0ae3bf6dd873534c9957b2cce398b290c92da7), closes [#426](http://github.com/PascalPrecht/angular-translate/issues/426))
+  * add possibility to translate a set of translation ids ([612dc27b](http://github.com/PascalPrecht/angular-translate/commit/612dc27b1382679941061f71920f4ee0bc6f7834))
+
+
 # 2.1.0 (2014-04-02)
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+<a name="2.9.2"></a>
+## [2.9.2](https://github.com/angular-translate/angular-translate/compare/2.9.1...v2.9.2) (2016-02-21)
+
+
+### Bug Fixes
+
+* **package:** redefine dependency version range (AJS 1.5) ([94eb844](https://github.com/angular-translate/angular-translate/commit/94eb844)), closes [#1394](https://github.com/angular-translate/angular-translate/issues/1394) [#1395](https://github.com/angular-translate/angular-translate/issues/1395) [#1397](https://github.com/angular-translate/angular-translate/issues/1397)
+* **package:** redefine dependency version range (AJS 1.5) (fixup) ([20da73d](https://github.com/angular-translate/angular-translate/commit/20da73d)), closes [#1394](https://github.com/angular-translate/angular-translate/issues/1394) [#1395](https://github.com/angular-translate/angular-translate/issues/1395) [#1397](https://github.com/angular-translate/angular-translate/issues/1397)
+* **service:** avoid call stack size error, print proper message ([73ea6e3](https://github.com/angular-translate/angular-translate/commit/73ea6e3))
+* **service:** ensure fallback language can be selected as `$uses` ([40ad523](https://github.com/angular-translate/angular-translate/commit/40ad523))
+* **service:** remove invalid argument for promise.finally ([2d72908](https://github.com/angular-translate/angular-translate/commit/2d72908))
+
+
+
 <a name="2.9.1"></a>
 ## [2.9.1](https://github.com/angular-translate/angular-translate/compare/2.9.0...v2.9.1) (2016-02-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+<a name="2.5.0"></a>
+## 2.5.0 (2014-12-07)
+
+
+#### Bug Fixes
+
+* **directive:** ensure directive's text will be parsed at least once ([49cfef0f](http://github.com/angular-translate/angular-translate/commit/49cfef0f58dd8c8306e6c0d4c6e78854ff2bbd8b))
+* **loader:** under circum understances translation table got lost ([df373811](http://github.com/angular-translate/angular-translate/commit/df3738119677b6834b2d47455bf35161c9b0c588))
+* **messageformat-interpolation:** fix support for messageformat 0.2.* ([ac8d5ed1](http://github.com/angular-translate/angular-translate/commit/ac8d5ed1b43f3db7b269964383528b116ad26283))
+* **service:**
+  * fix npe when resolving fallback language for `instant` ([7c09d89d](http://github.com/angular-translate/angular-translate/commit/7c09d89d8b890a1a7018e051ec2491899b6d66f5))
+  * apply fix for empty strings in `navigator.language` ([5b4edd99](http://github.com/angular-translate/angular-translate/commit/5b4edd99ef2f2c75aa88176fd7331426be799453))
+
+
+#### Features
+
+* **$translateUrlLoader:** allow to use custom query parameter name for url loader ([e360bf8c](http://github.com/angular-translate/angular-translate/commit/e360bf8ca7266ba447bd23dd62ad5f8ae7d13b96))
+* **directive:**
+  * translate attributes (optimize process flow) ([508fd32e](http://github.com/angular-translate/angular-translate/commit/508fd32eedd483f972fb0e27472c48bc13b7149a))
+  * translate attributes using directive ([1d06d2a1](http://github.com/angular-translate/angular-translate/commit/1d06d2a11474aecbcc1fd2f0bd73563d889a8157), closes [#568](http://github.com/angular-translate/angular-translate/issues/568))
+* **module:** use same fallback for module.run when no storage key is set and not being able t ([247253dd](http://github.com/angular-translate/angular-translate/commit/247253ddf97f185cad507d345245881cc0ccb2c8), closes [#739](http://github.com/angular-translate/angular-translate/issues/739))
+* **storage:** rename set() into put() ([ef6a613e](http://github.com/angular-translate/angular-translate/commit/ef6a613e70c0e2fcf2c32fe4b0ad1ffa51be4f0c))
+
+
+#### Breaking Changes
+
+* This marks storage.set() as deprecated. In the
+next major release v3, the old method `set()` will be dropped in favor
+of `put()`.
+
+Relates #772
+ ([ef6a613e](http://github.com/angular-translate/angular-translate/commit/ef6a613e70c0e2fcf2c32fe4b0ad1ffa51be4f0c))
+
+
 <a name="2.4.2"></a>
 ### 2.4.2 (2014-10-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="2.8.0"></a>
-# [2.8.0](https://github.com/angular-translate/angular-translate/compare/2.7.2...v2.8.0) (2015-09-18)
+# [2.8.0](https://github.com/angular-translate/angular-translate/compare/2.7.2...2.8.0) (2015-09-18)
 
 
 ### Bug Fixes
@@ -28,870 +28,672 @@
 
 
 <a name="2.7.2"></a>
-### 2.7.2 (2015-06-01)
+## [2.7.2](https://github.com/angular-translate/angular-translate/compare/2.7.1...2.7.2) (2015-06-01)
 
 
-#### Bug Fixes
+### Bug Fixes
 
-* **directive:** ensure value of `translate` will be translated always ([454d7029](http://github.com/angular-translate/angular-translate/commit/454d70290aef706929c4894b70aef6d4a0dba0be))
-* **sanitization:** fix/workaround issue when jQuery is not available ([ef1b10a3](http://github.com/angular-translate/angular-translate/commit/ef1b10a3e3b113831b251a696dd19c7f9d240db3))
-* **service:**
-  * fix silence on error, add missing catch on `refresh()` ([5a85a64a](http://github.com/angular-translate/angular-translate/commit/5a85a64a4a9631afda73b71ce0509c06e0644189))
-  * make provider's storageKey chainable ([de8c253b](http://github.com/angular-translate/angular-translate/commit/de8c253b49f793ea85644610ca0cdef0cf4d024a))
+* **directive:** ensure value of `translate` will be translated always ([454d702](https://github.com/angular-translate/angular-translate/commit/454d702))
+* **sanitization:** fix/workaround issue when jQuery is not available ([ef1b10a](https://github.com/angular-translate/angular-translate/commit/ef1b10a))
+* **service:** fix silence on error, add missing catch on `refresh()` ([f3ec956](https://github.com/angular-translate/angular-translate/commit/f3ec956))
+* **service:** fix silence on error, add missing catch on `refresh()` ([5a85a64](https://github.com/angular-translate/angular-translate/commit/5a85a64))
+* **service:** make provider's storageKey chainable ([de8c253](https://github.com/angular-translate/angular-translate/commit/de8c253))
+
 
 
 <a name="2.7.1"></a>
-### 2.7.1 (2015-06-01)
+## [2.7.1](https://github.com/angular-translate/angular-translate/compare/2.7.0...2.7.1) (2015-06-01)
 
 
-#### Bug Fixes
+### Bug Fixes
 
-* **docs:** fix typo in $translateChangeSuccess ([89e25692](http://github.com/angular-translate/angular-translate/commit/89e2569217e15809c11bf9dd845532780a9bdc12))
-* **service:**
-  * integrate translationCache into service distribution file ([2fcbc601](http://github.com/angular-translate/angular-translate/commit/2fcbc601e3da82655c263b974448cc1300805f1e))
-  * handle error "this.replace is not a function" ([8616dcad](http://github.com/angular-translate/angular-translate/commit/8616dcad89cc42ab89219c76eb67c616a4c585d6))
+* **docs:** fix typo in $translateChangeSuccess ([89e2569](https://github.com/angular-translate/angular-translate/commit/89e2569))
+* **service:** handle error "this.replace is not a function" ([8616dca](https://github.com/angular-translate/angular-translate/commit/8616dca))
+* **service:** integrate translationCache into service distribution file ([2fcbc60](https://github.com/angular-translate/angular-translate/commit/2fcbc60))
 
+### Features
 
-#### Features
+* **$translateProvider:** add a new option to force async reload ([bdee77f](https://github.com/angular-translate/angular-translate/commit/bdee77f))
 
-* **$translateProvider:** add a new option to force async reload ([bdee77ff](http://github.com/angular-translate/angular-translate/commit/bdee77ffdbf5e7394c214a5a051097d969501cf9))
 
 
 <a name="2.7.0"></a>
-## 2.7.0 (2015-05-02)
+# [2.7.0](https://github.com/angular-translate/angular-translate/compare/2.6.1...2.7.0) (2015-05-02)
 
 
-#### Bug Fixes
+### Bug Fixes
 
-* **directive:**
-  * fix translate-value-* weren't be available on init ([98e82798](http://github.com/angular-translate/angular-translate/commit/98e827980ec491152ab6108f5fd5eac28010e89e))
-  * fix wrong initial translation causing overloading ([657ed8a6](http://github.com/angular-translate/angular-translate/commit/657ed8a6e8d09cbf5fd53a26ea98cbcf928637cd))
-  * fix issue with `data-` prefixed attributes #954 ([ee253bc3](http://github.com/angular-translate/angular-translate/commit/ee253bc397aa70b8688893430ea814c0e2387344))
-  * make translate-values interpolate correctly with newer MessageFormat.js ([887dc1b4](http://github.com/angular-translate/angular-translate/commit/887dc1b4c0e928fbfd595a1d03cb292fcd536839))
-  * Make interpolate message format work smoothly also on message format > 0.1.7 - f ([2533f2d0](http://github.com/angular-translate/angular-translate/commit/2533f2d0b2e9f21007335c510772418a4c7a3962))
-  * handle interpolation of undefined keys correctly in updateTranslations, fixes is ([3f7cf4cf](http://github.com/angular-translate/angular-translate/commit/3f7cf4cf6eecb0487da2dc4dd8cb805500cb1aff))
-* **docs:**
-  * fix invalid link in directive ([985cfd5b](http://github.com/angular-translate/angular-translate/commit/985cfd5bedec12043e5f24b16b86394150c6182e))
-  * typo in module type ([f0527b14](http://github.com/angular-translate/angular-translate/commit/f0527b1431f7b426584e32b5f17bc181d409ce41))
-  * bug in "Flash of untranslated content" section ([af5d746a](http://github.com/angular-translate/angular-translate/commit/af5d746a6476d82f31968d608ebc21227212cd7e))
-* **feat:** export module name improving usage module loaders #944 ([cb33f63b](http://github.com/angular-translate/angular-translate/commit/cb33f63b8869aff386718c7d3b18365d2483d3eb))
-* **messageformat:** add duck type check for numbers #789 ([bbc1cbef](http://github.com/angular-translate/angular-translate/commit/bbc1cbefb69e80579f15f7da59ac5c5536388fc2))
-* **refresh:** it has to clear all tables if no language key is specified ([3cce7950](http://github.com/angular-translate/angular-translate/commit/3cce795022e790bc31656ab946ed63bba6c238c3))
-* **service:**
-  * fix possible npe ([1aaab980](http://github.com/angular-translate/angular-translate/commit/1aaab980760f8863551598ed748d200f1f03d9c6))
-  * do not try to load a predefined fallback language ([3be14df8](http://github.com/angular-translate/angular-translate/commit/3be14df809d3c162f4a1aecffb90d62b5296b4d9))
-  * fix an issue resolving after missing translations ([a13899fc](http://github.com/angular-translate/angular-translate/commit/a13899fcf677588e0c56b780c57f9aaba6d6e976))
-  * always remove stored ref for lang promises ([dbd5be93](http://github.com/angular-translate/angular-translate/commit/dbd5be936d0588a1ec6f29e5ce52a4e0f096ea36), closes [#824](http://github.com/angular-translate/angular-translate/issues/824), [#969](http://github.com/angular-translate/angular-translate/issues/969))
+* **directive:** fix issue with `data-` prefixed attributes #954 ([ee253bc](https://github.com/angular-translate/angular-translate/commit/ee253bc)), closes [#954](https://github.com/angular-translate/angular-translate/issues/954)
+* **directive:** fix translate-value-* weren't be available on init ([98e8279](https://github.com/angular-translate/angular-translate/commit/98e8279))
+* **directive:** fix wrong initial translation causing overloading ([657ed8a](https://github.com/angular-translate/angular-translate/commit/657ed8a))
+* **directive:** handle interpolation of undefined keys correctly in updateTranslations, fixes is ([3f7cf4c](https://github.com/angular-translate/angular-translate/commit/3f7cf4c)), closes [#971](https://github.com/angular-translate/angular-translate/issues/971)
+* **directive:** Make interpolate message format work smoothly also on message format > 0.1.7 - f ([2533f2d](https://github.com/angular-translate/angular-translate/commit/2533f2d)), closes [#789](https://github.com/angular-translate/angular-translate/issues/789)
+* **directive:** make translate-values interpolate correctly with newer MessageFormat.js ([887dc1b](https://github.com/angular-translate/angular-translate/commit/887dc1b))
+* **docs:** bug in "Flash of untranslated content" section ([af5d746](https://github.com/angular-translate/angular-translate/commit/af5d746))
+* **docs:** fix invalid link in directive ([985cfd5](https://github.com/angular-translate/angular-translate/commit/985cfd5))
+* **docs:** typo in module type ([f0527b1](https://github.com/angular-translate/angular-translate/commit/f0527b1))
+* **feat:** export module name improving usage module loaders #944 ([cb33f63](https://github.com/angular-translate/angular-translate/commit/cb33f63))
+* **messageformat:** add duck type check for numbers #789 ([bbc1cbe](https://github.com/angular-translate/angular-translate/commit/bbc1cbe))
+* **refresh:** it has to clear all tables if no language key is specified ([3cce795](https://github.com/angular-translate/angular-translate/commit/3cce795))
+* **service:** always remove stored ref for lang promises ([dbd5be9](https://github.com/angular-translate/angular-translate/commit/dbd5be9)), closes [#824](https://github.com/angular-translate/angular-translate/issues/824) [#969](https://github.com/angular-translate/angular-translate/issues/969)
+* **service:** do not try to load a predefined fallback language ([3be14df](https://github.com/angular-translate/angular-translate/commit/3be14df))
+* **service:** fix an issue resolving after missing translations ([a13899f](https://github.com/angular-translate/angular-translate/commit/a13899f))
+* **service:** fix possible npe ([1aaab98](https://github.com/angular-translate/angular-translate/commit/1aaab98))
+* **test/refresh:** fix current table refreshing test ([a298ed8](https://github.com/angular-translate/angular-translate/commit/a298ed8))
+
+### Features
+
+* **$translatePartialLoader:** accept function in urlTemplate ([401204a](https://github.com/angular-translate/angular-translate/commit/401204a))
+* **build:** introduce module definition ([00b73ff](https://github.com/angular-translate/angular-translate/commit/00b73ff))
+* **filter:** add new option `$translate.statefulFilter()` ([dec4bf3](https://github.com/angular-translate/angular-translate/commit/dec4bf3))
+* **missingTranslationHandlerFactory:** pass interpolationParams to missingTranslationHandlerFactory ([a361fd0](https://github.com/angular-translate/angular-translate/commit/a361fd0))
+* **sanitization:** refactored, fixed and extended sanitization #993 ([12dbc57](https://github.com/angular-translate/angular-translate/commit/12dbc57)), closes [#993](https://github.com/angular-translate/angular-translate/issues/993)
+* **service:** add uniformLanguageTagResolver ([b534e1a](https://github.com/angular-translate/angular-translate/commit/b534e1a))
+
+### Performance Improvements
+
+* **directive:** watch parameters only if exist ([f0e2585](https://github.com/angular-translate/angular-translate/commit/f0e2585))
 
 
-#### Features
+### BREAKING CHANGES
 
-* **$translatePartialLoader:** accept function in urlTemplate ([401204aa](http://github.com/angular-translate/angular-translate/commit/401204aade22e4729de5349a03689b02f9e6d20b))
-* **build:** introduce module definition ([00b73ff6](http://github.com/angular-translate/angular-translate/commit/00b73ff6f40daeabc54afade7b5e6217722b70e8))
-* **filter:** add new option `$translate.statefulFilter()` ([dec4bf34](http://github.com/angular-translate/angular-translate/commit/dec4bf34b7bb30bba4ca80df263df1858b3e68f5))
-* **missingTranslationHandlerFactory:** pass interpolationParams to missingTranslationHandlerFactory ([a361fd05](http://github.com/angular-translate/angular-translate/commit/a361fd050f490e550b7e2e5fbfea91b85ba3e879))
-* **sanitization:** refactored, fixed and extended sanitization #993 ([12dbc575](http://github.com/angular-translate/angular-translate/commit/12dbc5754c8315d41144794918f1ec8ca34c601e))
-* **service:** add uniformLanguageTagResolver ([b534e1a3](http://github.com/angular-translate/angular-translate/commit/b534e1a3c7e43f27b00a2579750d8136aebc57fd))
-
-
-#### Breaking Changes
-
-* You will get a warning message when using the default security option (not escaping the content).
-
+* You will get a warning message when using the default setting (not escaping the content).
 You can fix (and remove) this warning by explicit set a sanitization strategy
 within your config phase configuring $translateProvider. Even configuring the `null` mode will let the
 warning disapper. You are highly encouraged specifing any mode except `null` because of security concerns.
- ([12dbc575](http://github.com/angular-translate/angular-translate/commit/12dbc5754c8315d41144794918f1ec8ca34c601e))
 
 
 <a name="2.6.1"></a>
-### 2.6.1 (2015-03-01)
+## [2.6.1](https://github.com/angular-translate/angular-translate/compare/2.6.0...2.6.1) (2015-03-01)
 
 
-#### Bug Fixes
+### Bug Fixes
 
-* **static-files-loader:**
-  * fix multiple files definition (docu update) #923, pr #936 ([e637c01d](http://github.com/angular-translate/angular-translate/commit/e637c01df50afd506fa75bc2ce781aacf47ec777))
-  * fix multiple files definition #923 ([1b6256a8](http://github.com/angular-translate/angular-translate/commit/1b6256a8685ff344d75237d5f01cd32845315e54))
+* **bower spec:** fix bower main property #922 ([3a1ad10](https://github.com/angular-translate/angular-translate/commit/3a1ad10)), closes [#922](https://github.com/angular-translate/angular-translate/issues/922)
+* **custom interpolator:** improve handling of interpolator ids which don't exist ([373b46f](https://github.com/angular-translate/angular-translate/commit/373b46f))
+* **static-files-loader:** fix multiple files definition (docu update) #923, pr #936 ([e637c01](https://github.com/angular-translate/angular-translate/commit/e637c01)), closes [#923](https://github.com/angular-translate/angular-translate/issues/923) [#936](https://github.com/angular-translate/angular-translate/issues/936)
+* **static-files-loader:** fix multiple files definition #923 ([1b6256a](https://github.com/angular-translate/angular-translate/commit/1b6256a)), closes [#923](https://github.com/angular-translate/angular-translate/issues/923)
+
 
 
 <a name="2.6.0"></a>
-## 2.6.0 (2015-02-08)
+# [2.6.0](https://github.com/angular-translate/angular-translate/compare/2.5.2...2.6.0) (2015-02-08)
 
 
-#### Bug Fixes
+### Bug Fixes
 
-* **directive:**
-  * newlines before/after translation ids should be ignored ([8dcf3e23](http://github.com/angular-translate/angular-translate/commit/8dcf3e23e9623b59f71c4b18c19a066f649b7bdf), closes [#909](http://github.com/angular-translate/angular-translate/issues/909))
-  * fix missing update using dynamic translationIds ([faebe195](http://github.com/angular-translate/angular-translate/commit/faebe19598d35ac31678cce028d61c87ecd4b20a), closes [#854](http://github.com/angular-translate/angular-translate/issues/854))
-  * ensure internal watcher will be removed ([e69f4a14](http://github.com/angular-translate/angular-translate/commit/e69f4a14ccb4c549250900696c58ae4ede71c656))
-  * fix minor memory leak ([5e4533a4](http://github.com/angular-translate/angular-translate/commit/5e4533a4a485672ab7e1675d5d1a11f689e5d6ad))
-* **filter:** apply notFoundIndicators also for instant translations correctly ([5a9f436f](http://github.com/angular-translate/angular-translate/commit/5a9f436fb8444d4992b00383bd37b61580e816d4), closes [#866](http://github.com/angular-translate/angular-translate/issues/866))
-* **service:**
-  * fix an issue with default interpolator and expressions ([75b7381f](http://github.com/angular-translate/angular-translate/commit/75b7381fbfbb342b98a7fe8f9a9b7915004dc66c))
-  * use $window/$windowProvider instead of window fix(docs): update ngdocs on storag ([bfa7b7b2](http://github.com/angular-translate/angular-translate/commit/bfa7b7b28f6e2698205e774b4d13d34d85abfc2f))
-  * fallback languages follow shortcuts (fixes #758) ([cce897a3](http://github.com/angular-translate/angular-translate/commit/cce897a34a2087c6799cd11889bc90db3c56f227))
+* **directive:** ensure internal watcher will be removed ([e69f4a1](https://github.com/angular-translate/angular-translate/commit/e69f4a1))
+* **directive:** fix minor memory leak ([5e4533a](https://github.com/angular-translate/angular-translate/commit/5e4533a))
+* **directive:** fix missing update using dynamic translationIds ([faebe19](https://github.com/angular-translate/angular-translate/commit/faebe19)), closes [#854](https://github.com/angular-translate/angular-translate/issues/854)
+* **directive:** newlines before/after translation ids should be ignored ([8dcf3e2](https://github.com/angular-translate/angular-translate/commit/8dcf3e2)), closes [#909](https://github.com/angular-translate/angular-translate/issues/909)
+* **directive, service:** return value of translate-default also in case fallback languages are used - rel ([fcd6b3e](https://github.com/angular-translate/angular-translate/commit/fcd6b3e))
+* **filter:** apply notFoundIndicators also for instant translations correctly ([5a9f436](https://github.com/angular-translate/angular-translate/commit/5a9f436)), closes [#866](https://github.com/angular-translate/angular-translate/issues/866)
+* **service:** fallback languages follow shortcuts (fixes #758) ([cce897a](https://github.com/angular-translate/angular-translate/commit/cce897a)), closes [#758](https://github.com/angular-translate/angular-translate/issues/758)
+* **service:** fix an issue with default interpolator and expressions ([75b7381](https://github.com/angular-translate/angular-translate/commit/75b7381))
+* **service:** use $window/$windowProvider instead of window ([bfa7b7b](https://github.com/angular-translate/angular-translate/commit/bfa7b7b))
 
+### Features
 
-#### Features
+* **$translatePartialLoader:** adds optional priority param to the addPart function ([570617c](https://github.com/angular-translate/angular-translate/commit/570617c))
+* **directive:** add $translateProvider.directityPriority ([b0b7716](https://github.com/angular-translate/angular-translate/commit/b0b7716))
+* **loader:** support for multiple static translation files ([c462ee6](https://github.com/angular-translate/angular-translate/commit/c462ee6))
+* **service:** extend loader api: add isPartLoaded and getRegisteredParts to $translatePartialL ([54f8ab3](https://github.com/angular-translate/angular-translate/commit/54f8ab3))
 
-* **$translatePartialLoader:** adds optional priority param to the addPart function ([570617cf](http://github.com/angular-translate/angular-translate/commit/570617cf68804fdd21ba215d9a6a7c4b3083fd2a))
-* **directive:** add $translateProvider.directityPriority ([b0b77162](http://github.com/angular-translate/angular-translate/commit/b0b771624cda1a51879c7f685f98e90923d4a3b0))
-* **loader:** support for multiple static translation files ([c462ee6a](http://github.com/angular-translate/angular-translate/commit/c462ee6aa6f095f3cd7e1b5ebc9d4b4d135c1ae2))
-* **service:** extend loader api: add isPartLoaded and getRegisteredParts to $translatePartialL ([54f8ab3e](http://github.com/angular-translate/angular-translate/commit/54f8ab3e166fa2e1ef1c1334263f9df612a4940e))
 
 
 <a name="2.5.2"></a>
-### 2.5.2 (2014-12-10)
-
-Internal release. No changes.
+## [2.5.2](https://github.com/angular-translate/angular-translate/compare/2.5.0...2.5.2) (2014-12-10)
 
 
-<a name="2.5.1"></a>
-### 2.5.1 (2014-12-10)
+### Bug Fixes
 
+* **directive:** missing watch for expression within elements text nodes ([31c0356](https://github.com/angular-translate/angular-translate/commit/31c0356)), closes [#701](https://github.com/angular-translate/angular-translate/issues/701)
 
-#### Bug Fixes
-
-* **directive:** missing watch for expression within elements text nodes ([31c03560](http://github.com/angular-translate/angular-translate/commit/31c03560ddb537734303c41419b147262d511841), closes [#701](http://github.com/angular-translate/angular-translate/issues/701))
 
 
 <a name="2.5.0"></a>
-## 2.5.0 (2014-12-07)
+# [2.5.0](https://github.com/angular-translate/angular-translate/compare/2.4.2...2.5.0) (2014-12-07)
 
 
-#### Bug Fixes
+### Bug Fixes
 
-* **directive:** ensure directive's text will be parsed at least once ([49cfef0f](http://github.com/angular-translate/angular-translate/commit/49cfef0f58dd8c8306e6c0d4c6e78854ff2bbd8b))
-* **loader:** under certain circumstances translation table got lost ([df373811](http://github.com/angular-translate/angular-translate/commit/df3738119677b6834b2d47455bf35161c9b0c588))
-* **messageformat-interpolation:** fix support for messageformat 0.2.* ([ac8d5ed1](http://github.com/angular-translate/angular-translate/commit/ac8d5ed1b43f3db7b269964383528b116ad26283))
-* **service:**
-  * fix npe when resolving fallback language for `instant` ([7c09d89d](http://github.com/angular-translate/angular-translate/commit/7c09d89d8b890a1a7018e051ec2491899b6d66f5))
-  * apply fix for empty strings in `navigator.language` ([5b4edd99](http://github.com/angular-translate/angular-translate/commit/5b4edd99ef2f2c75aa88176fd7331426be799453))
+* **directive:** ensure directive's text will be parsed at least once ([49cfef0](https://github.com/angular-translate/angular-translate/commit/49cfef0))
+* **loader:** under circum understances translation table got lost ([df37381](https://github.com/angular-translate/angular-translate/commit/df37381))
+* **messageformat-interpolation:** fix support for messageformat 0.2.* ([ac8d5ed](https://github.com/angular-translate/angular-translate/commit/ac8d5ed))
+* **service:** apply fix for empty strings in `navigator.language` ([5b4edd9](https://github.com/angular-translate/angular-translate/commit/5b4edd9))
+* **service:** fix npe when resolving fallback language for `instant` ([7c09d89](https://github.com/angular-translate/angular-translate/commit/7c09d89))
 
+### Features
 
-#### Features
-
-* **$translateUrlLoader:** allow to use custom query parameter name for url loader ([e360bf8c](http://github.com/angular-translate/angular-translate/commit/e360bf8ca7266ba447bd23dd62ad5f8ae7d13b96))
-* **directive:**
-  * translate attributes (optimize process flow) ([508fd32e](http://github.com/angular-translate/angular-translate/commit/508fd32eedd483f972fb0e27472c48bc13b7149a))
-  * translate attributes using directive ([1d06d2a1](http://github.com/angular-translate/angular-translate/commit/1d06d2a11474aecbcc1fd2f0bd73563d889a8157), closes [#568](http://github.com/angular-translate/angular-translate/issues/568))
-* **module:** use same fallback for module.run when no storage key is set and not being able t ([247253dd](http://github.com/angular-translate/angular-translate/commit/247253ddf97f185cad507d345245881cc0ccb2c8), closes [#739](http://github.com/angular-translate/angular-translate/issues/739))
-* **storage:** rename set() into put() ([ef6a613e](http://github.com/angular-translate/angular-translate/commit/ef6a613e70c0e2fcf2c32fe4b0ad1ffa51be4f0c))
+* **$translateUrlLoader:** allow to use custom query parameter name for url loader ([e360bf8](https://github.com/angular-translate/angular-translate/commit/e360bf8))
+* **module:** use same fallback for module.run when no storage key is set ([247253d](https://github.com/angular-translate/angular-translate/commit/247253d)), closes [#739](https://github.com/angular-translate/angular-translate/issues/739)
+* **storage:** rename set() into put() ([ef6a613](https://github.com/angular-translate/angular-translate/commit/ef6a613))
 
 
-#### Breaking Changes
+### BREAKING CHANGES
 
 * This marks storage.set() as deprecated. In the
 next major release v3, the old method `set()` will be dropped in favor
 of `put()`.
-
 Relates #772
- ([ef6a613e](http://github.com/angular-translate/angular-translate/commit/ef6a613e70c0e2fcf2c32fe4b0ad1ffa51be4f0c))
 
 
 <a name="2.4.2"></a>
-### 2.4.2 (2014-10-21)
+## [2.4.2](https://github.com/angular-translate/angular-translate/compare/2.4.1...2.4.2) (2014-10-21)
 
 
-#### Bug Fixes
+### Bug Fixes
 
-* **partialloader:** fix possible circular dependency ([25f252c1](http://github.com/angular-translate/angular-translate/commit/25f252c14aab58b9e2dc61e2765420b584106b6f), closes [#766](http://github.com/angular-translate/angular-translate/issues/766))
+* **partialloader:** fix possible circular dependency ([25f252c](https://github.com/angular-translate/angular-translate/commit/25f252c)), closes [#766](https://github.com/angular-translate/angular-translate/issues/766)
 
+### Features
 
-#### Features
+* **directive:** translate attributes (optimize process flow) ([508fd32](https://github.com/angular-translate/angular-translate/commit/508fd32))
+* **directive:** translate attributes using directive ([1d06d2a](https://github.com/angular-translate/angular-translate/commit/1d06d2a)), closes [#568](https://github.com/angular-translate/angular-translate/issues/568)
+* **directive:** translate-cloak supports optional value for cloaking ([f7ccb7f](https://github.com/angular-translate/angular-translate/commit/f7ccb7f))
 
-* **directive:** translate-cloak supports optional value for cloaking ([f7ccb7fb](http://github.com/angular-translate/angular-translate/commit/f7ccb7fbdac184b6a8b216966ebf89b4a8d3fb5e))
 
 
 <a name="2.4.1"></a>
-### 2.4.1 (2014-10-03)
+## [2.4.1](https://github.com/angular-translate/angular-translate/compare/2.4.0...2.4.1) (2014-10-03)
 
 
-#### Bug Fixes
+### Bug Fixes
 
-* **service:**
-  * constructor `useUrlLoader()` missed optional options ([22f5c4b7](http://github.com/PascalPrecht/angular-translate/commit/22f5c4b7b9612b3645c5d79b9bc9d2fec917fe25))
-  * add missing final event on new (async) translations ([22cc8b42](http://github.com/PascalPrecht/angular-translate/commit/22cc8b42d61ca6c6e2641de565b4f61a13469a50))
-  * the loader options ($http) have been merged wrong #754 #547
-
-
-# 2.4.0 (2014-09-22)
-
-## Features
-### service
-
-* introduce `versionInfo` function (e37d89c)
-
-* prefer detecting language by `navigator.languages` #722 (2204f4f)
-
-* enrich events with the currently handled language key (73b289d)
-
-* interpolate translationId in case of rejected translation (3efaac5)
-
-### loaders
-
-* introduce loader cache (b685601)
-
-### loader
-
-* apply support for loaderOptions.$http (8613bef)
+* **service:** add missing final event on new (async) translations ([22cc8b4](https://github.com/angular-translate/angular-translate/commit/22cc8b4))
+* **service:** constructor `useUrlLoader()` missed optional options ([22f5c4b](https://github.com/angular-translate/angular-translate/commit/22f5c4b))
+* **service, loaders:** the loader options ($http) have been merged wrong ([0c35a95](https://github.com/angular-translate/angular-translate/commit/0c35a95)), closes [#754](https://github.com/angular-translate/angular-translate/issues/754) [#547](https://github.com/angular-translate/angular-translate/issues/547)
 
 
 
-## Bug fixes
-### service
+<a name="2.4.0"></a>
+# [2.4.0](https://github.com/angular-translate/angular-translate/compare/2.3.0...2.4.0) (2014-09-22)
 
-* correctly iterate in fallback languages (fixes #690) (ac2f35c)
 
-* `$nextLang` should be not unset parallel loadings (d1745e4)
+### Bug Fixes
 
-* avoid possible doubled requested on refresh() (98d429d)
+* **filter:** interpolated params w/ scope aren't possible starting AJS1.3 ([9465318](https://github.com/angular-translate/angular-translate/commit/9465318))
+* **filter:** mark filter being stateful required since Angular 1.3 rc2 ([bffbf04](https://github.com/angular-translate/angular-translate/commit/bffbf04))
+* **service:** `$nextLang` should be not unset parallel loadings ([d1745e4](https://github.com/angular-translate/angular-translate/commit/d1745e4)), closes [#647](https://github.com/angular-translate/angular-translate/issues/647)
+* **service:** avoid possible doubled requested on refresh() ([98d429d](https://github.com/angular-translate/angular-translate/commit/98d429d))
+* **service:** avoid possible npe in internal getTranslationTable() ([9aaa9a0](https://github.com/angular-translate/angular-translate/commit/9aaa9a0))
+* **service:** correctly iterate in fallback languages (fixes #690) ([ac2f35c](https://github.com/angular-translate/angular-translate/commit/ac2f35c)), closes [#690](https://github.com/angular-translate/angular-translate/issues/690)
 
-* avoid possible npe in internal getTranslationTable() (9aaa9a0)
+### Features
 
-### filter
+* **loader:** apply support for loaderOptions.$http ([8613bef](https://github.com/angular-translate/angular-translate/commit/8613bef))
+* **loaders:** introduce loader cache ([b685601](https://github.com/angular-translate/angular-translate/commit/b685601)), closes [#529](https://github.com/angular-translate/angular-translate/issues/529)
+* **service:** enrich events with the currently handled language key ([73b289d](https://github.com/angular-translate/angular-translate/commit/73b289d))
+* **service:** interpolate translationId in case of rejected translation ([3efaac5](https://github.com/angular-translate/angular-translate/commit/3efaac5)), closes [#730](https://github.com/angular-translate/angular-translate/issues/730)
+* **service:** introduce `versionInfo` function ([e37d89c](https://github.com/angular-translate/angular-translate/commit/e37d89c))
+* **service:** prefer detecting language by `navigator.languages` #722 ([2204f4f](https://github.com/angular-translate/angular-translate/commit/2204f4f))
 
-* mark filter being stateful required since Angular 1.3 rc2 (bffbf04)
 
-* interpolated params w/ scope aren't possible starting AJS1.3 (9465318)
+### BREAKING CHANGES
+
+* Since filters are stateless and have no access to its scope anymore (see https://github.com/angular/angular.js/commit/8863b9d04c722b278fa93c5d66ad1e578ad6eb1f), a context must be given explicitly. This removes the feature of an interpolation based on the scope (context), even without the $rootScope.
+However, the feature will still work in AJS <=1.2, so we won't remove it completely yet. Handle the feature as slightly deprecated.
 
 
 <a name="2.3.0"></a>
-## 2.3.0 (2014-09-16)
+# [2.3.0](https://github.com/angular-translate/angular-translate/compare/2.2.0...2.3.0) (2014-09-16)
 
 
-#### Bug Fixes
+### Bug Fixes
 
-* **$translate:** return $missingTranslationHandler result when no translation was found ([7625951d](http://github.com/PascalPrecht/angular-translate/commit/7625951de2474049be78294fa129c32ea46df6a9))
-* **bower.json:** Avoid 'invalid-meta angular-bootstrap-affix is missing "ignore" entry in bower.j ([595501a9](http://github.com/PascalPrecht/angular-translate/commit/595501a9d4882207e3ff510dec80dbe0a553d580))
-* **demo:** fixes wrong method call in demo ([47fc9436](http://github.com/PascalPrecht/angular-translate/commit/47fc9436cfc69347f8a9b7f09cf5c726c0ca1931))
-* **directive:**
-  * improve the cloak-directive's performance ([acab18ab](http://github.com/PascalPrecht/angular-translate/commit/acab18ab5e6f455db86f6c9dabbbbdbc2f7b7855))
-  * change event for listening to `$translateChangeEnd` ([98fe649a](http://github.com/PascalPrecht/angular-translate/commit/98fe649a241b79c245fb32d838b84f0fac319f5a), closes [#658](http://github.com/PascalPrecht/angular-translate/issues/658))
-* **docs:**
-  * fix example in directive ngdoc-documentation (fixes #678) ([176b3e96](http://github.com/PascalPrecht/angular-translate/commit/176b3e96a78c4590f42817e6dcf44addcc49a13f))
-  * Fix typo ([6c2ab307](http://github.com/PascalPrecht/angular-translate/commit/6c2ab307d5b31c0e2e70c2cce0ccbf804db4c540))
-* **package.json:** remove unnecessary relative paths from package.json ([8e5b87e7](http://github.com/PascalPrecht/angular-translate/commit/8e5b87e726562b2fcfdaefb49b35c114e92c66a0))
-* **service:**
-  * use hasOwnProperty of prototype #638 ([d8a5060b](http://github.com/PascalPrecht/angular-translate/commit/d8a5060b2273f699fa75e32d7a73e5f62aab670c))
-  * add shim for indexOf and trim #638 ([b951fd50](http://github.com/PascalPrecht/angular-translate/commit/b951fd50f1f312755de1fd66f51e38bef3f5b882))
-  * load fallback languages also for instant and filter ([ed6023a4](http://github.com/PascalPrecht/angular-translate/commit/ed6023a4aa2ebc51ba839b976eb1b8f8e8fa91b6))
-  * addition of preferred language to fallback language stack is now preventing dupl ([b2bb1669](http://github.com/PascalPrecht/angular-translate/commit/b2bb166944074aa174f0ed557bf4e2457128b3b8))
-* **storage:**
-  * fixup 75504cbe ([53a8badb](http://github.com/PascalPrecht/angular-translate/commit/53a8badbd1d8fe82d43ddc17e27eaae1a414ee9b))
-  * fix 'DOM Exception 18' at feature detection ([75504cbe](http://github.com/PascalPrecht/angular-translate/commit/75504cbe2ddc0d18e08288b0fa4453356aaafe73))
-* **translateService:**
-  * fixup/rewrite for b48f6bb (specs) ([45ac14d5](http://github.com/PascalPrecht/angular-translate/commit/45ac14d5bf7d8d9569fa0fff99a0dcb5bc419e68))
-  * prevent multiple XHR calls ([b48f6bb4](http://github.com/PascalPrecht/angular-translate/commit/b48f6bb438a193174df569beef24d193d5cd954c))
+* **$translate:** return $missingTranslationHandler result when no translation was found ([7625951](https://github.com/angular-translate/angular-translate/commit/7625951))
+* **bower.json:** Avoid 'invalid-meta angular-bootstrap-affix is missing "ignore" entry in bower.j ([595501a](https://github.com/angular-translate/angular-translate/commit/595501a)), closes [bower/bower#1388](https://github.com/bower/bower/issues/1388)
+* **demo:** fixes wrong method call in demo ([47fc943](https://github.com/angular-translate/angular-translate/commit/47fc943))
+* **directive:** change event for listening to `$translateChangeEnd` ([98fe649](https://github.com/angular-translate/angular-translate/commit/98fe649)), closes [#658](https://github.com/angular-translate/angular-translate/issues/658)
+* **directive:** improve the cloak-directive's performance ([acab18a](https://github.com/angular-translate/angular-translate/commit/acab18a))
+* **docs:** fix example in directive ngdoc-documentation (fixes #678) ([176b3e9](https://github.com/angular-translate/angular-translate/commit/176b3e9)), closes [#678](https://github.com/angular-translate/angular-translate/issues/678)
+* **docs:** Fix typo ([6c2ab30](https://github.com/angular-translate/angular-translate/commit/6c2ab30))
+* **package.json:** remove unnecessary relative paths from package.json ([8e5b87e](https://github.com/angular-translate/angular-translate/commit/8e5b87e))
+* **service:** add shim for indexOf and trim #638 ([b951fd5](https://github.com/angular-translate/angular-translate/commit/b951fd5))
+* **service:** addition of preferred language to fallback language stack is now preventing dupl ([b2bb166](https://github.com/angular-translate/angular-translate/commit/b2bb166))
+* **service:** load fallback languages also for instant and filter ([ed6023a](https://github.com/angular-translate/angular-translate/commit/ed6023a))
+* **service:** use hasOwnProperty of prototype #638 ([d8a5060](https://github.com/angular-translate/angular-translate/commit/d8a5060))
+* **storage:** fix 'DOM Exception 18' at feature detection ([75504cb](https://github.com/angular-translate/angular-translate/commit/75504cb)), closes [#629](https://github.com/angular-translate/angular-translate/issues/629)
+* **storage:** fixup 75504cbe ([53a8bad](https://github.com/angular-translate/angular-translate/commit/53a8bad))
+* **translateService:** fixup/rewrite for b48f6bb (specs) ([45ac14d](https://github.com/angular-translate/angular-translate/commit/45ac14d))
+* **translateService:** prevent multiple XHR calls ([b48f6bb](https://github.com/angular-translate/angular-translate/commit/b48f6bb))
 
+### Features
 
-#### Features
+* **directive:** add possibility to mix translation interpolation with other text in element body ([be62131](https://github.com/angular-translate/angular-translate/commit/be62131)), closes [#461](https://github.com/angular-translate/angular-translate/issues/461)
 
-* **directive:** add possibility to mix translation interpolation with other text in element body ([be621314](http://github.com/PascalPrecht/angular-translate/commit/be6213144a686b34cff3ba29b9a52041924b2c9e), closes [#461](http://github.com/PascalPrecht/angular-translate/issues/461))
 
 
 <a name="2.2.0"></a>
-## 2.2.0 (2014-06-03)
+# [2.2.0](https://github.com/angular-translate/angular-translate/compare/2.1.0...2.2.0) (2014-06-03)
+
+
+### Bug Fixes
+
+* **$translate:** checks modification ([b91e4de](https://github.com/angular-translate/angular-translate/commit/b91e4de))
+* **$translate:** if translation exists, use the translated string even if it's empty ([4ba736f](https://github.com/angular-translate/angular-translate/commit/4ba736f))
+* **$translate:** if translation exists, use the translated string even if it's empty ([eeb8c2a](https://github.com/angular-translate/angular-translate/commit/eeb8c2a))
+* **$translate:** use case-insensitive check for language key aliases ([09a8bf1](https://github.com/angular-translate/angular-translate/commit/09a8bf1)), closes [#431](https://github.com/angular-translate/angular-translate/issues/431)
+* **$translate:** use case-insensitive check for language key aliases ([26ec308](https://github.com/angular-translate/angular-translate/commit/26ec308)), closes [#431](https://github.com/angular-translate/angular-translate/issues/431)
+* **$translateProvider:** determinePreferredLanguage was not chainable ([7c29f2f](https://github.com/angular-translate/angular-translate/commit/7c29f2f)), closes [#487](https://github.com/angular-translate/angular-translate/issues/487)
+* **$translateProvider:** fix comparison in one case of negotiateLocale() ([c2b94ca](https://github.com/angular-translate/angular-translate/commit/c2b94ca))
+* **$translateProvider:** fix comparison in one case of negotiateLocale() ([fe04c72](https://github.com/angular-translate/angular-translate/commit/fe04c72))
+* **demo:** correct demo of `translate-values` ([efa74fa](https://github.com/angular-translate/angular-translate/commit/efa74fa))
+* **demo:** correct demo of `translate-values` ([7de2ae2](https://github.com/angular-translate/angular-translate/commit/7de2ae2))
+* **demo:** use `.instant()` ([6bea192](https://github.com/angular-translate/angular-translate/commit/6bea192))
+* **directive:** Make translate-value-* work inside ng-if and ng-repeat ([e07eea7](https://github.com/angular-translate/angular-translate/commit/e07eea7)), closes [#433](https://github.com/angular-translate/angular-translate/issues/433)
+* **directive:** Make translate-value-* work inside ng-if and ng-repeat ([f22624b](https://github.com/angular-translate/angular-translate/commit/f22624b)), closes [#433](https://github.com/angular-translate/angular-translate/issues/433)
+* **docs:** removes explicit protocol declaration for assets ([eaa9bf7](https://github.com/angular-translate/angular-translate/commit/eaa9bf7)), closes [#513](https://github.com/angular-translate/angular-translate/issues/513)
+* **gruntfile:** fix image link ([65fc8be](https://github.com/angular-translate/angular-translate/commit/65fc8be))
+* **package.json:** fix repository url ([40af7ce](https://github.com/angular-translate/angular-translate/commit/40af7ce))
+* **package.json:** fix repository url ([a410c9a](https://github.com/angular-translate/angular-translate/commit/a410c9a))
+* **partialLoader:** fixes deprecated usage of arguments.callee ([1ac3a0a](https://github.com/angular-translate/angular-translate/commit/1ac3a0a))
+* **service:** docs annotation ([8ef0415](https://github.com/angular-translate/angular-translate/commit/8ef0415))
+* **service:** docs annotation ([839c4e8](https://github.com/angular-translate/angular-translate/commit/839c4e8))
+* **service:** use the aliased language key if available ([675e9a2](https://github.com/angular-translate/angular-translate/commit/675e9a2)), closes [#530](https://github.com/angular-translate/angular-translate/issues/530)
+* **storageLocal:** fixes QUOTAEXCEEDEDERROR (safari private browsing) ([59aa2a0](https://github.com/angular-translate/angular-translate/commit/59aa2a0))
+* fix npe on empty strings (trim()) ([c69de7b](https://github.com/angular-translate/angular-translate/commit/c69de7b))
+* **translateInterpolator:** make it work with 1.3-beta ([97e2241](https://github.com/angular-translate/angular-translate/commit/97e2241))
 
+### Features
 
-#### Bug Fixes
+* **directive:** add option to define a default translation text ([a802665](https://github.com/angular-translate/angular-translate/commit/a802665))
+* **directive:** add option to define a default translation text ([fc57d26](https://github.com/angular-translate/angular-translate/commit/fc57d26))
+* **directive:** Support for camel casing interpolation variables. ([b345041](https://github.com/angular-translate/angular-translate/commit/b345041))
+* **directive:** Support for camel casing interpolation variables. ([4791e25](https://github.com/angular-translate/angular-translate/commit/4791e25))
+* **messageformat-support:** enhancing for sanitization like default ([ad01686](https://github.com/angular-translate/angular-translate/commit/ad01686))
+* **missingFallbackDefaultText:** enables a feature to return a default text for displaying in case of missing tra ([f24b15e](https://github.com/angular-translate/angular-translate/commit/f24b15e))
+* **service:** add possibility to translate a set of translation ids ([612dc27](https://github.com/angular-translate/angular-translate/commit/612dc27))
+* **service:** add possibility to translate a set of translation ids ([57bd07c](https://github.com/angular-translate/angular-translate/commit/57bd07c))
+* **service:** allow using wildcards in language aliases ([6f0ae3b](https://github.com/angular-translate/angular-translate/commit/6f0ae3b)), closes [#426](https://github.com/angular-translate/angular-translate/issues/426)
 
-* fix npe on empty strings (trim()) ([c69de7b8](http://github.com/PascalPrecht/angular-translate/commit/c69de7b87a0efe05548f03b1f2767968d2dc6aac))
-* **$translate:**
-  * checks modification ([b91e4ded](http://github.com/PascalPrecht/angular-translate/commit/b91e4ded560a96a815248f116c893e10414296af))
-  * if translation exists, use the translated string even if it's empty ([eeb8c2ad](http://github.com/PascalPrecht/angular-translate/commit/eeb8c2ad23f915828e83c840ecb00c840812dfa2))
-  * use case-insensitive check for language key aliases ([26ec3088](http://github.com/PascalPrecht/angular-translate/commit/26ec3088bcc50bacb8370e352e556d4e48830b64))
-* **$translateProvider:**
-  * determinePreferredLanguage was not chainable ([7c29f2fc](http://github.com/PascalPrecht/angular-translate/commit/7c29f2fc5aeea17dd50ecfc40d1fad67ddd93650), closes [#487](http://github.com/PascalPrecht/angular-translate/issues/487))
-  * fix comparison in one case of negotiateLocale() ([fe04c72f](http://github.com/PascalPrecht/angular-translate/commit/fe04c72fc1bb2b9ff07ac0d974374e16397d58c7))
-* **demo:**
-  * use `.instant()` ([6bea1928](http://github.com/PascalPrecht/angular-translate/commit/6bea19281d52f8ae956f6e898616d01c097d8c23))
-  * correct demo of `translate-values` ([7de2ae23](http://github.com/PascalPrecht/angular-translate/commit/7de2ae23ee87a10921c3b4883d535fd69ecf2b89))
-* **directive:** Make translate-value-* work inside ng-if and ng-repeat ([e07eea75](http://github.com/PascalPrecht/angular-translate/commit/e07eea757aec8cf3d2342abcd94e97d1fe615c80))
-* **docs:** removes explicit protocol declaration for assets ([eaa9bf7b](http://github.com/PascalPrecht/angular-translate/commit/eaa9bf7b46cf5983e9f9fd97a22a606bf52480dd))
-* **gruntfile:** fix image link ([65fc8be3](http://github.com/PascalPrecht/angular-translate/commit/65fc8be35ddae016438fd627d788317c46bb22f3))
-* **package.json:** fix repository url ([40af7ce7](http://github.com/PascalPrecht/angular-translate/commit/40af7ce79228526068e11f1a3b6cc3f56e30a831))
-* **partialLoader:** fixes deprecated usage of arguments.callee ([1ac3a0a7](http://github.com/PascalPrecht/angular-translate/commit/1ac3a0a7c69f0e765a615a395ea467f9de95f0c9))
-* **service:**
-  * use the aliased language key if available ([675e9a21](http://github.com/PascalPrecht/angular-translate/commit/675e9a21b6b20b9aa78514deb602954a985a5f83), closes [#530](http://github.com/PascalPrecht/angular-translate/issues/530))
-  * docs annotation ([839c4e89](http://github.com/PascalPrecht/angular-translate/commit/839c4e89f1fa062bfceebf43126cc38b699f891c))
-* **storageLocal:** fixes QUOTAEXCEEDEDERROR (safari private browsing) ([59aa2a01](http://github.com/PascalPrecht/angular-translate/commit/59aa2a01dca73b8343eadd77d41dcb294bfad89a))
-* **translateInterpolator:** make it work with 1.3-beta ([97e2241c](http://github.com/PascalPrecht/angular-translate/commit/97e2241c9f612df347863b3fb57acc5416168b07))
 
 
-#### Features
+<a name="2.0.1"></a>
+## [2.0.1](https://github.com/angular-translate/angular-translate/compare/2.0.0...2.0.1) (2014-02-25)
 
-* **directive:**
-  * add option to define a default translation text ([a8026651](http://github.com/PascalPrecht/angular-translate/commit/a8026651b5fdc424c681c03cda1b1f749493ba26))
-  * Support for camel casing interpolation variables. ([b3450410](http://github.com/PascalPrecht/angular-translate/commit/b3450410686846291fd068616237586b35beb91e))
-* **messageformat-support:** enhancing for sanitization like default ([ad016861](http://github.com/PascalPrecht/angular-translate/commit/ad016861f6ed4d65a6ee074b8feba3f9911dfc20))
-* **missingFallbackDefaultText:** enables a feature to return a default text for displaying in case of missing tra ([f24b15e8](http://github.com/PascalPrecht/angular-translate/commit/f24b15e8d3ca6231deab64a843d4ca5830176343))
-* **service:**
-  * allow using wildcards in language aliases ([6f0ae3bf](http://github.com/PascalPrecht/angular-translate/commit/6f0ae3bf6dd873534c9957b2cce398b290c92da7), closes [#426](http://github.com/PascalPrecht/angular-translate/issues/426))
-  * add possibility to translate a set of translation ids ([612dc27b](http://github.com/PascalPrecht/angular-translate/commit/612dc27b1382679941061f71920f4ee0bc6f7834))
 
+### Bug Fixes
 
-# 2.1.0 (2014-04-02)
+* **$translate:** Ensuring that languages will be set based on the order they are requested, not t ([c909cd2](https://github.com/angular-translate/angular-translate/commit/c909cd2))
+* **$translate:** Ensuring that languages will be set based on the order they are requested, not t ([ebd62af](https://github.com/angular-translate/angular-translate/commit/ebd62af))
+* **$translate:** Ensuring that languages will be set based on the order they are requested, not t ([32e1851](https://github.com/angular-translate/angular-translate/commit/32e1851))
+* **instant:** $translate.instant(id) does not return correct fallback ([eec1d77](https://github.com/angular-translate/angular-translate/commit/eec1d77))
+* **instant:** fix possible npe in case of filters with undefineds ([61a9490](https://github.com/angular-translate/angular-translate/commit/61a9490))
+* **refresh:** fix bug in refresh if using partial loader ([95c43b4](https://github.com/angular-translate/angular-translate/commit/95c43b4))
 
-## Features
-### directive
+### Features
 
-* Support for camel casing interpolation variables. (4791e25)
+* **instant:** invoke missing handler within `$translate.instant(id)` ([aaf52b5](https://github.com/angular-translate/angular-translate/commit/aaf52b5))
 
-* add option to define a default translation text (fc57d26)
 
-### service
 
-* add possibility to translate a set of translation ids (57bd07c)
+<a name="2.0.0"></a>
+# [2.0.0](https://github.com/angular-translate/angular-translate/compare/1.1.1...2.0.0) (2014-02-16)
 
 
+### Bug Fixes
 
-## Bug fixes
-### $translate
+* ***:** jshint fixes ([1e3f8a6](https://github.com/angular-translate/angular-translate/commit/1e3f8a6))
+* **$translate:** check for fallbacklanguage ([321803d](https://github.com/angular-translate/angular-translate/commit/321803d))
+* **$translate:** Trim whitespace off translationId ([4939424](https://github.com/angular-translate/angular-translate/commit/4939424))
+* **$translatePartialLoader:** fixes docs annotation ([d6ea84b](https://github.com/angular-translate/angular-translate/commit/d6ea84b))
+* **demo:** fix server routes + add index page ([eb0a2dc](https://github.com/angular-translate/angular-translate/commit/eb0a2dc))
+* **demo:** links to demo resources updated to new locactions ([fddaa49](https://github.com/angular-translate/angular-translate/commit/fddaa49))
+* **deps:** add missing resolution ([a98a2f6](https://github.com/angular-translate/angular-translate/commit/a98a2f6))
+* **docs:** fixes links for languages ([265490f](https://github.com/angular-translate/angular-translate/commit/265490f))
+* **fallbackLanguage:** Fix fallback languages loading and applying ([4c5c47c](https://github.com/angular-translate/angular-translate/commit/4c5c47c))
+* **grunt:** includes translate-cloak directive ([84a59d2](https://github.com/angular-translate/angular-translate/commit/84a59d2))
+* avoid calls with empty translationId (sub issue of #298) ([08f087b](https://github.com/angular-translate/angular-translate/commit/08f087b))
+* fix npe introduced in 4939424a30 (#281) ([173a9bc](https://github.com/angular-translate/angular-translate/commit/173a9bc)), closes [(#281](https://github.com/(/issues/281) [#298](https://github.com/angular-translate/angular-translate/issues/298)
+* **guide/ru,uk:** Fix uses->use in multi language ([af59c6a](https://github.com/angular-translate/angular-translate/commit/af59c6a))
+* **instant:** remove language-preload if there were used within instant ([9a3eda6](https://github.com/angular-translate/angular-translate/commit/9a3eda6))
+* **loader-static-files.js:** Now allows empty string as prefix and postfix. ([051f431](https://github.com/angular-translate/angular-translate/commit/051f431))
+* **service:** fallback languages could not load when using `instant()` ([26de486](https://github.com/angular-translate/angular-translate/commit/26de486))
+* **translateCloak:** makes jshint happy ([2058fd3](https://github.com/angular-translate/angular-translate/commit/2058fd3))
+* **translateDirective:** fixes bad coding convention ([d5db4ad](https://github.com/angular-translate/angular-translate/commit/d5db4ad))
 
-* use case-insensitive check for language key aliases (09a8bf1)
+### Features
 
-* if translation exists, use the translated string even if it's empty (4ba736f)
+* **$translateProvider:** adds determinePreferredLanguage() ([7cbfabe](https://github.com/angular-translate/angular-translate/commit/7cbfabe))
+* **$translateProvider:** adds registerAvailableLanguagesKeys for negotiation ([6bef6bd](https://github.com/angular-translate/angular-translate/commit/6bef6bd))
+* **filter:** filter now use $translate.instant() since promises could not use ([a1b8a17](https://github.com/angular-translate/angular-translate/commit/a1b8a17))
+* **service:** add $translate.instant() for instant translations ([3a855eb](https://github.com/angular-translate/angular-translate/commit/3a855eb))
+* add an option for post processing compiling ([d5cd943](https://github.com/angular-translate/angular-translate/commit/d5cd943))
+* add option to html escape all values ([e042c44](https://github.com/angular-translate/angular-translate/commit/e042c44))
+* **translateCloak:** adds translate-cloak directive ([c125c56](https://github.com/angular-translate/angular-translate/commit/c125c56))
+* **translateDirective:** teaches directive custom translate-value-* attr ([5c27467](https://github.com/angular-translate/angular-translate/commit/5c27467)), closes [#188](https://github.com/angular-translate/angular-translate/issues/188)
 
-* docs annotation (8ef0415)
-### directive
 
-* Make translate-value-* work inside ng-if and ng-repeat (f22624b)
 
-### package.json
+<a name="1.1.1"></a>
+## [1.1.1](https://github.com/angular-translate/angular-translate/compare/1.1.0...1.1.1) (2013-11-24)
 
-* fix repository url (a410c9a)
 
-### $translateProvider
+### Bug Fixes
 
-* fix comparison in one case of negotiateLocale() (c2b94ca)
+* fixes encoding ([084f08c](https://github.com/angular-translate/angular-translate/commit/084f08c))
+* **docs:** fixes typo ([7e1c4e9](https://github.com/angular-translate/angular-translate/commit/7e1c4e9))
+* **docs:** fixes typo in landing page ([0b999ab](https://github.com/angular-translate/angular-translate/commit/0b999ab))
+* **grunt:** fixes missing storage-key ([635d290](https://github.com/angular-translate/angular-translate/commit/635d290))
+* **translateDirective:** fixes occuring 'translation id undefined' erros ([bb5a2c4](https://github.com/angular-translate/angular-translate/commit/bb5a2c4))
 
-# 2.0.1 (2014-02-25)
+### Features
 
-## Features
-### instant
+* add option to html escape all values ([fe94c1f](https://github.com/angular-translate/angular-translate/commit/fe94c1f))
+* shortcuts and links\n\nShortcuts creates a shorter translationId if the last key ([f9f2cf2](https://github.com/angular-translate/angular-translate/commit/f9f2cf2))
+* Update required Node up `0.10` ([b7cf5f4](https://github.com/angular-translate/angular-translate/commit/b7cf5f4))
 
-* invoke missing handler within `$translate.instant(id)` (aaf52b5)
 
 
+<a name="1.1.0"></a>
+# [1.1.0](https://github.com/angular-translate/angular-translate/compare/1.0.2...1.1.0) (2013-09-02)
 
-## Bug fixes
-### instant
 
-* fix possible npe in case of filters with undefineds (61a9490)
+### Bug Fixes
 
-* $translate.instant(id) does not return correct fallback (eec1d77)
+* **translateDirective:** fixes bug that directive writes into scope ([4e06468](https://github.com/angular-translate/angular-translate/commit/4e06468)), closes [#128](https://github.com/angular-translate/angular-translate/issues/128)
+* **translateDirective:** fixes scope handling ([c566586](https://github.com/angular-translate/angular-translate/commit/c566586))
+* **translateService:** reset proposed language if there's no pending loader ([6b477fc](https://github.com/angular-translate/angular-translate/commit/6b477fc))
 
-### refresh
+### Features
 
-* fix bug in refresh if using partial loader (95c43b4)
+* **$translatePartialLoader:** Basic implementation ([81222bf](https://github.com/angular-translate/angular-translate/commit/81222bf))
+* **invalidate:** added invalidate() method ([d41f91e](https://github.com/angular-translate/angular-translate/commit/d41f91e))
+* **translateProvider:** makes methods chainable ([cdc9e9e](https://github.com/angular-translate/angular-translate/commit/cdc9e9e))
 
-### $translate
 
-* Ensuring that languages will be set based on the order they are requested, not the order the responses come in. (32e1851)
 
+<a name="1.0.2"></a>
+## [1.0.2](https://github.com/angular-translate/angular-translate/compare/1.0.1...1.0.2) (2013-08-07)
 
 
-# 2.0.0 (2014-02-16)
+### Bug Fixes
 
-## Features
-###
+* **fallbackLanguage:** fixes bug that fallbackLanguage is loaded without loader ([6aa3747](https://github.com/angular-translate/angular-translate/commit/6aa3747))
+* **translateService:** uses should only load if a loader is registered ([604daec](https://github.com/angular-translate/angular-translate/commit/604daec))
+* **typo:** remove unnecessary semicolon ([54cb232](https://github.com/angular-translate/angular-translate/commit/54cb232))
 
-* add option to html escape all values (fe94c1f)
 
-* add option to html escape all values (e042c44)
 
-* add an option for post processing compiling (d5cd943)
+<a name="1.0.1"></a>
+## [1.0.1](https://github.com/angular-translate/angular-translate/compare/1.0.0...1.0.1) (2013-07-26)
 
-### $translateProvider
 
-* adds determinePreferredLanguage() (7cbfabe)
+### Bug Fixes
 
-* adds registerAvailableLanguagesKeys for negotiation (6bef6bd)
+* **demo:** change src to angular-translate script ([4be93b6](https://github.com/angular-translate/angular-translate/commit/4be93b6))
+* **dependency:** add 'angular-cookies' as bower devDependency ([b6f1426](https://github.com/angular-translate/angular-translate/commit/b6f1426))
+* **platolink:** deep link ([d368bf3](https://github.com/angular-translate/angular-translate/commit/d368bf3))
 
-### translateDirective
 
-* teaches directive custom translate-value-* attr (5c27467)
 
-### service
+<a name="1.0.0"></a>
+# [1.0.0](https://github.com/angular-translate/angular-translate/compare/0.9.4...1.0.0) (2013-07-23)
 
-* add $translate.instant() for instant translations (3a855eb)
 
-### filter
+### Bug Fixes
 
-* filter now use $translate.instant() since promises could not use (a1b8a17)
+* **docs:** fixes methodOf declaration of addInterpolation method ([f1eeba7](https://github.com/angular-translate/angular-translate/commit/f1eeba7))
+* **gh-pages:** plato report ([b85e19b](https://github.com/angular-translate/angular-translate/commit/b85e19b))
+* **tests:** travis CI ([c8624bf](https://github.com/angular-translate/angular-translate/commit/c8624bf))
+* **tests:** travis CI ([629bb8d](https://github.com/angular-translate/angular-translate/commit/629bb8d))
+* fixes gruntfile ([0d500db](https://github.com/angular-translate/angular-translate/commit/0d500db))
 
-### translateCloak
+### Features
 
-* adds translate-cloak directive (c125c56)
+* **messageformat-interpolation:** implements usage of messageformat ([5596e8b](https://github.com/angular-translate/angular-translate/commit/5596e8b))
+* **translateDirective:** teaches directives to use custom interpolation ([bf3dbbb](https://github.com/angular-translate/angular-translate/commit/bf3dbbb))
+* **translateFilter:** teaches filter to use custom interpolation ([46f03cc](https://github.com/angular-translate/angular-translate/commit/46f03cc))
+* **translateService:** adds method to configure indicators for not found translations ([52a039f](https://github.com/angular-translate/angular-translate/commit/52a039f)), closes [#77](https://github.com/angular-translate/angular-translate/issues/77)
+* **translateService:** extracts default interpolation in standalone service ([5d8cb56](https://github.com/angular-translate/angular-translate/commit/5d8cb56))
+* **translateService:** implements proposedLanguage() ([6d34792](https://github.com/angular-translate/angular-translate/commit/6d34792))
+* **translateService:** implements usage of different interpolation services ([5e20e24](https://github.com/angular-translate/angular-translate/commit/5e20e24))
+* **translateService:** informs interpolator when locale has changed ([e59b141](https://github.com/angular-translate/angular-translate/commit/e59b141))
+* **translateService:** missingTranslationHandler receives language ([6fe6bb1](https://github.com/angular-translate/angular-translate/commit/6fe6bb1))
 
 
 
-## Bug fixes
-### fallbackLanguage
+<a name="0.9.4"></a>
+## [0.9.4](https://github.com/angular-translate/angular-translate/compare/0.9.3...0.9.4) (2013-06-21)
 
-* Fix fallback languages loading and applying (4c5c47c)
 
-### loader-static-files.js
+### Bug Fixes
 
-* Now allows empty string as prefix and postfix. (051f431)
+* **translateService:** fixes missingTranslationHandler-invokation bug ([525b353](https://github.com/angular-translate/angular-translate/commit/525b353)), closes [#74](https://github.com/angular-translate/angular-translate/issues/74)
 
-### translateDirective
+### Features
 
-* fixes bad coding convention (d5db4ad)
+* **translateService:** removes empty options object requirement for loaders ([c09d1db](https://github.com/angular-translate/angular-translate/commit/c09d1db))
 
-### demo
 
-* links to demo resources updated to new locactions (fddaa49)
 
-* fix server routes + add index page (eb0a2dc)
+<a name="0.9.3"></a>
+## [0.9.3](https://github.com/angular-translate/angular-translate/compare/0.9.2...0.9.3) (2013-06-10)
 
-### $translate
 
-* Trim whitespace off translationId (4939424)
+### Features
 
-* check for fallbacklanguage (321803d)
+* **translateService:** let translate service handle multiple promises ([0e5d6d9](https://github.com/angular-translate/angular-translate/commit/0e5d6d9)), closes [#70](https://github.com/angular-translate/angular-translate/issues/70)
 
-###
 
-* fix npe introduced in 4939424a30 (#281) (173a9bc)
 
-* avoid calls with empty translationId (sub issue of #298) (08f087b)
+<a name="0.9.2"></a>
+## [0.9.2](https://github.com/angular-translate/angular-translate/compare/0.9.1...0.9.2) (2013-05-30)
 
-### *
 
-* jshint fixes (1e3f8a6)
+### Bug Fixes
 
-### $translatePartialLoader
+* fix bower.json ([c389882](https://github.com/angular-translate/angular-translate/commit/c389882))
 
-* fixes docs annotation (d6ea84b)
+### Features
 
-### guide/ru,uk
+* **translateProvider:** add fallbackLanguage() method ([018991e](https://github.com/angular-translate/angular-translate/commit/018991e)), closes [#67](https://github.com/angular-translate/angular-translate/issues/67)
 
-* Fix uses->use in multi language (af59c6a)
 
-### service
 
-* fallback languages could not load when using `instant()` (26de486)
+<a name="0.9.1"></a>
+## [0.9.1](https://github.com/angular-translate/angular-translate/compare/0.9.0...0.9.1) (2013-05-25)
 
-### deps
 
-* add missing resolution (a98a2f6)
+### Bug Fixes
 
-### grunt
+* **translate.js:** Allow blank translation values ([97591a8](https://github.com/angular-translate/angular-translate/commit/97591a8))
 
-* includes translate-cloak directive (84a59d2)
 
-### translateCloak
 
-* makes jshint happy (2058fd3)
+<a name="0.9.0"></a>
+# [0.9.0](https://github.com/angular-translate/angular-translate/compare/0.8.1...0.9.0) (2013-05-22)
 
-### docs
 
-* fixes links for languages (265490f)
+### Features
 
+* **translateProvider:** add use*() methods for async loaders ([f2329cc](https://github.com/angular-translate/angular-translate/commit/f2329cc)), closes [#58](https://github.com/angular-translate/angular-translate/issues/58)
 
-# 1.1.1 (2013-11-24)
 
-## Features
-### core
 
-* Update required Node up `0.10` (b7cf5f4)
+<a name="0.8.1"></a>
+## [0.8.1](https://github.com/angular-translate/angular-translate/compare/0.8.0...0.8.1) (2013-05-16)
 
-* shortcuts and links\n\nShortcuts creates a shorter translationId if the last key equals the one before(foo.bar.bar -> foo.bar). Also added support for linking one translationID to another by prepending '@:'. So if foo.bar = '@:chuck.norris', then the value for chuck.norris will be retrieved instead. (f9f2cf2)
 
-### docs
+### Bug Fixes
 
-* Ukrainian docs
+* **translate.js:** corrected typo ([82569f0](https://github.com/angular-translate/angular-translate/commit/82569f0))
 
-## Bug fixes
-### docs
+### Features
 
-* fixes encoding (084f08c)
+* **translateProvider:** add methods to use different missingTranslationHandlers ([f6ed3e3](https://github.com/angular-translate/angular-translate/commit/f6ed3e3))
 
-### grunt
 
-* fixes missing storage-key (635d290)
+### BREAKING CHANGES
 
-### docs
+* S:  missingTranslationHandler is no longer supported since its functionality will be replaced with  useMissingTranslationHandlerLog.
 
-* fixes typo (7e1c4e9)
 
-* fixes typo in landing page (0b999ab)
+<a name="0.8.0"></a>
+# [0.8.0](https://github.com/angular-translate/angular-translate/compare/0.7.1...0.8.0) (2013-05-14)
 
-### translateDirective
 
-* fixes occuring 'translation id undefined' erros (bb5a2c4)
 
-### translatePartialLoader
 
-* introduces setPart() to add static parts on translatePartialLoader
+<a name="0.7.1"></a>
+## [0.7.1](https://github.com/angular-translate/angular-translate/compare/0.7.0...0.7.1) (2013-05-13)
 
-# 1.1.0 (2013-09-02)
 
-## Features
-### translateService
+### Features
 
-* added refresh() method (d41f91e)
+* **chore:** rename ngTranslate folder to src ([65012d9](https://github.com/angular-translate/angular-translate/commit/65012d9))
 
-### translateProvider
 
-* makes methods chainable (cdc9e9e)
 
-### $translatePartialLoader
+<a name="0.7.0"></a>
+# [0.7.0](https://github.com/angular-translate/angular-translate/compare/0.6.0...0.7.0) (2013-05-12)
 
-* Basic implementation (81222bf)
 
+### Bug Fixes
 
+* **directive:** trim off white space around element.text() ([e10173a](https://github.com/angular-translate/angular-translate/commit/e10173a))
+* **tests:** Fix preferredLanguage tests ([73efcfc](https://github.com/angular-translate/angular-translate/commit/73efcfc))
+* **tests:** fix tests for preferredLanguage() ([f1b5084](https://github.com/angular-translate/angular-translate/commit/f1b5084))
+* **tests:** Old values won't be ignored, so they have to be discarded ([625b1d6](https://github.com/angular-translate/angular-translate/commit/625b1d6))
 
-## Bug fixes
-### translateDirective
+### Features
 
-* fixes bug that directive writes into scope (4e06468)
+* nested objects will be transformed when using `$translateProvider.translations`  ([b15cee4](https://github.com/angular-translate/angular-translate/commit/b15cee4))
+* **docs:** add documentation comments ([b1efbca](https://github.com/angular-translate/angular-translate/commit/b1efbca))
+* **storageKey:** add a storageKey method ([dabf822](https://github.com/angular-translate/angular-translate/commit/dabf822))
+* **translateProvider:** add a preferredLanguage property ([563e9bf](https://github.com/angular-translate/angular-translate/commit/563e9bf))
+* **translateProvider:** add storagePrefix() method ([64cd99b](https://github.com/angular-translate/angular-translate/commit/64cd99b))
+* **translateProvider:** add useLoaderFactory() as shortcut method ([2915e8b](https://github.com/angular-translate/angular-translate/commit/2915e8b))
+* **translateProvider:** make translationTable extendable ([8e3a455](https://github.com/angular-translate/angular-translate/commit/8e3a455)), closes [#33](https://github.com/angular-translate/angular-translate/issues/33)
+* **translateProvider:** missingTranslationHandler ([3a5819e](https://github.com/angular-translate/angular-translate/commit/3a5819e))
+* **translateService:** add storage() method ([98c2b12](https://github.com/angular-translate/angular-translate/commit/98c2b12))
 
-* fixes scope handling (c566586)
 
-### translateService
+### BREAKING CHANGES
 
-* reset proposed language if there's no pending loader (6b477fc)
+* The $STORAGE_KEY isn't represent a current storage key
+from now. To discover which key is used now you have to call the storageKey
+method without params.
 
 
-# 1.0.2 (2013-08-07)
+<a name="0.6.0"></a>
+# [0.6.0](https://github.com/angular-translate/angular-translate/compare/0.5.2...0.6.0) (2013-05-03)
 
 
+### Features
 
-## Bug fixes
-### typo
+* **ngmin:** add grunt-ngmin ([f630958](https://github.com/angular-translate/angular-translate/commit/f630958)), closes [#20](https://github.com/angular-translate/angular-translate/issues/20)
 
-* remove unnecessary semicolon (54cb232)
 
 
-# 1.0.1 (2013-07-26)
+<a name="0.5.2"></a>
+## [0.5.2](https://github.com/angular-translate/angular-translate/compare/0.5.1...0.5.2) (2013-04-30)
 
-- Brings default interpolation back to core (you don't have to install it as extra package)
 
-## Bug fixes
-### platolink
+### Bug Fixes
 
-* deep link (d368bf3)
+* **translateDirective:** check for truthy value in watch callback ([98087c7](https://github.com/angular-translate/angular-translate/commit/98087c7)), closes [#18](https://github.com/angular-translate/angular-translate/issues/18)
 
-### dependency
 
-* add 'angular-cookies' as bower devDependency (b6f1426)
 
-### demo
+<a name="0.5.1"></a>
+## [0.5.1](https://github.com/angular-translate/angular-translate/compare/0.5.0...0.5.1) (2013-04-29)
 
-* change src to angular-translate script (4be93b6)
 
+### Features
 
-# 1.0.0 (2013-07-23)
+* **.bowerrc:** add .bowerrc ([42363ee](https://github.com/angular-translate/angular-translate/commit/42363ee)), closes [#16](https://github.com/angular-translate/angular-translate/issues/16)
+* **.jshintrc:** add .jshintrc ([0c8d3da](https://github.com/angular-translate/angular-translate/commit/0c8d3da)), closes [#17](https://github.com/angular-translate/angular-translate/issues/17)
+* **bower.json:** rename component.json to bower.json ([17acd10](https://github.com/angular-translate/angular-translate/commit/17acd10))
 
-## Features
-### translateService
 
-* missingTranslationHandler receives language (6fe6bb1)
 
-* adds method to configure indicators for not found translations (52a039f)
+<a name="0.5.0"></a>
+# [0.5.0](https://github.com/angular-translate/angular-translate/compare/0.4.4...0.5.0) (2013-04-25)
 
-* extracts default interpolation in standalone service (5d8cb56)
 
-* implements usage of different interpolation services (5e20e24)
+### Features
 
-* informs interpolator when locale has changed (e59b141)
+* **conventional-changelogs:** Add grunt-conventional-changelog task ([c8093a7](https://github.com/angular-translate/angular-translate/commit/c8093a7)), closes [#11](https://github.com/angular-translate/angular-translate/issues/11)
 
-* implements proposedLanguage() (6d34792)
 
-### messageformat-interpolation
 
-* implements usage of messageformat (5596e8b)
+<a name="0.4.4"></a>
+## [0.4.4](https://github.com/angular-translate/angular-translate/compare/0.4.2...0.4.4) (2013-04-23)
 
-### translateFilter
 
-* teaches filter to use custom interpolation (46f03cc)
 
-### translateDirective
 
-* teaches directives to use custom interpolation (bf3dbbb)
+<a name="0.4.2"></a>
+## [0.4.2](https://github.com/angular-translate/angular-translate/compare/0.4.0...0.4.2) (2013-04-17)
 
 
 
-## Bug fixes
-### tests
 
-* travis CI (629bb8d)
+<a name="0.4.0"></a>
+# [0.4.0](https://github.com/angular-translate/angular-translate/compare/0.3.0...0.4.0) (2013-04-07)
 
-* travis CI (c8624bf)
 
-### docs
 
-* fixes methodOf declaration of addInterpolation method (f1eeba7)
 
-### gh-pages
+<a name="0.3.0"></a>
+# [0.3.0](https://github.com/angular-translate/angular-translate/compare/0.2.1...0.3.0) (2013-04-06)
 
-* plato report (b85e19b)
 
 
-# 0.9.4 (2013-06-21)
 
-## Features
-### translateService
+<a name="0.2.1"></a>
+## [0.2.1](https://github.com/angular-translate/angular-translate/compare/0.2.0...0.2.1) (2013-04-05)
 
-* removes empty options object requirement for loaders (c09d1dbe)
 
 
 
-## Bug fixes
-### translateService
+<a name="0.2.0"></a>
+# [0.2.0](https://github.com/angular-translate/angular-translate/compare/0.1.2...0.2.0) (2013-04-03)
 
-* fixes missingTranslationHandler-invokation bug (525b3533)
 
 
 
+<a name="0.1.2"></a>
+## [0.1.2](https://github.com/angular-translate/angular-translate/compare/0.1.1...0.1.2) (2013-04-02)
 
-# 0.9.3 (2013-06-10)
 
-## Features
-### translateService
 
-* let translate service handle multiple promises (0e5d6d9d)
 
+<a name="0.1.1"></a>
+## [0.1.1](https://github.com/angular-translate/angular-translate/compare/0.1.0...0.1.1) (2013-04-01)
 
 
 
 
+<a name="0.1.0"></a>
+# [0.1.0](https://github.com/angular-translate/angular-translate/compare/0.0.5...0.1.0) (2013-04-01)
 
-# 0.9.2 (2013-05-30)
 
-## Features
-### translateProvider
 
-* add fallbackLanguage() method (018991e8)
 
+<a name="0.0.5"></a>
+## [0.0.5](https://github.com/angular-translate/angular-translate/compare/0.0.4...0.0.5) (2013-04-01)
 
 
-## Bug fixes
-### translate.js
 
-* Allow blank translation values (97591a8f)
 
-###
+<a name="0.0.4"></a>
+## [0.0.4](https://github.com/angular-translate/angular-translate/compare/0.0.2...0.0.4) (2013-04-01)
 
-* fix bower.json (c3898829)
 
 
 
+<a name="0.0.2"></a>
+## [0.0.2](https://github.com/angular-translate/angular-translate/compare/0.0.1...0.0.2) (2013-03-30)
 
-# 0.9.1 (2013-05-25)
 
-Remove $translateMissingTranslationHandlerLog service
 
 
+<a name="0.0.1"></a>
+## 0.0.1 (2013-03-28)
 
 
-# 0.9.0 (2013-05-23)
 
-## Features
-### translateProvider
 
-* add use*() methods for async loaders (f2329cc2)
-
-
-
-
-
-## Breaking Changes
-### demo
-
-   Old demo files are not available from now.
-
-### extensions
-
-  There are now extensions for loaders and storages
-
-
-
-# 0.8.1 (2013-05-16)
-
-## Features
-### translateProvider
-
-* add methods to use different missingTranslationHandlers (f6ed3e3)
-
-
-
-## Bug fixes
-### docs
-
-* corrected typo (82569f0)
-
-
-# 0.8.0 (2013-05-14)
-
-* rename module ngTranslate to pascalprecht.translate
-
-
-# 0.7.1 (2013-05-13)
-
-## Features
-### chore
-
-* rename ngTranslate folder to src (65012d9)
-
-
-
-
-# 0.7.0 (2013-05-13)
-
-## Features
-### chore
-
-* rename ngTranslate folder to src (65012d9)
-
-
-
-
-# 0.7.0 (2013-05-12)
-
-## Features
-### translateProvider
-
-* missingTranslationHandler (3a5819e)
-
-* add a preferredLanguage property (563e9bf)
-
-* make translationTable extendable (8e3a455)
-
-* add useLoaderFactory() as shortcut method (2915e8b)
-
-* add storagePrefix() method (64cd99b)
-
-### docs
-
-* add documentation comments (b1efbca)
-
-### storageKey
-
-* add a storageKey method (dabf822)
-
-### translateService
-
-* add storage() method (98c2b12)
-
-
-
-## Bug fixes
-### tests
-
-* fix tests for preferredLanguage() (f1b5084)
-
-* Fix preferredLanguage tests (73efcfc)
-
-* Old values won't be ignored, so they have to be discarded (625b1d6)
-
-### directive
-
-* trim off white space around element.text() (e10173a)
-
-
-# 0.6.0 (2013-05-03)
-
-## Features
-### ngmin
-
-* add grunt-ngmin (f630958)
-
-### $translate
-* add support for asynchronous loading
-
-
-# 0.5.2 (2013-04-30)
-
-
-
-## Bug fixes
-### translateDirective
-
-* check for truthy value in watch callback (98087c7)
-
-
-# 0.5.1 (2013-04-29)
-
-## Features
-### .jshintrc
-
-* add .jshintrc (0c8d3da)
-
-### .bowerrc
-
-* add .bowerrc (42363ee)
-
-### bower.json
-
-* rename component.json to bower.json (17acd10)
-
-
-
-
-# 0.5.0 (2013-04-25)
-
-## Features
-### conventional-changelogs
-
-* Add grunt-conventional-changelog task (c8093a7)
-
-
-
-
-# 0.4.4
-
-## Features
-### editorconfig
-  * Added .editorconfig to make contribution as easy as possible
-
-
-# 0.4.3
-
-## Fixes
-### translateDirective
-  * Fixed bug that directive doesn't change contents when language is switched at runtime
-
-
-# 0.4.2
-
-## Fixes
-### karma-dependency
-  * Fixed dependencies (Karma 0.9.x isn't stable!)
-
-
-# 0.4.0
-
-## Features
-### $translateProvider
-  * Introducing $translateProvider.rememberLanguage()
-  * You're now able to tell ngTranslate save lang state cross requests
-
-
-# 0.3.0
-
-## Features
-### $translate
-  * $translate Service now has method uses(key) to ask for currently used language
-  * Language can now be changed at runtime
-
-* v.0.2.1
-  * Revamped test suite structure
-  * Added more tests
-* v.0.2.0
-  * Added translate directive to handle translations
-* v.0.1.2
-  * Fixed unit tests
-  * Fixed karma.conf
-  * Introduced $translateProvider.uses(key);
-  * Implemented multi-lang support
-* v.0.1.1
-  * Added **CONTRIBUTING.md** as guide for contributers
-  * Added **CHANGELOG.md**
-* v.0.1.0
-  * Added automated tests using **karma** and **jasmine**
-  * Added Travis CI support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 #### Bug Fixes
 
 * **directive:** ensure directive's text will be parsed at least once ([49cfef0f](http://github.com/angular-translate/angular-translate/commit/49cfef0f58dd8c8306e6c0d4c6e78854ff2bbd8b))
-* **loader:** under circum understances translation table got lost ([df373811](http://github.com/angular-translate/angular-translate/commit/df3738119677b6834b2d47455bf35161c9b0c588))
+* **loader:** under certain circumstances translation table got lost ([df373811](http://github.com/angular-translate/angular-translate/commit/df3738119677b6834b2d47455bf35161c9b0c588))
 * **messageformat-interpolation:** fix support for messageformat 0.2.* ([ac8d5ed1](http://github.com/angular-translate/angular-translate/commit/ac8d5ed1b43f3db7b269964383528b116ad26283))
 * **service:**
   * fix npe when resolving fallback language for `instant` ([7c09d89d](http://github.com/angular-translate/angular-translate/commit/7c09d89d8b890a1a7018e051ec2491899b6d66f5))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+<a name="2.7.1"></a>
+### 2.7.1 (2015-06-01)
+
+
+#### Bug Fixes
+
+* **docs:** fix typo in $translateChangeSuccess ([89e25692](http://github.com/angular-translate/angular-translate/commit/89e2569217e15809c11bf9dd845532780a9bdc12))
+* **service:**
+  * integrate translationCache into service distribution file ([2fcbc601](http://github.com/angular-translate/angular-translate/commit/2fcbc601e3da82655c263b974448cc1300805f1e))
+  * handle error "this.replace is not a function" ([8616dcad](http://github.com/angular-translate/angular-translate/commit/8616dcad89cc42ab89219c76eb67c616a4c585d6))
+
+
+#### Features
+
+* **$translateProvider:** add a new option to force async reload ([bdee77ff](http://github.com/angular-translate/angular-translate/commit/bdee77ffdbf5e7394c214a5a051097d969501cf9))
+
+
 <a name="2.7.0"></a>
 ## 2.7.0 (2015-05-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="2.10.0"></a>
+# [2.10.0](https://github.com/angular-translate/angular-translate/compare/2.9.2...v2.10.0) (2016-02-28)
+
+
+### Bug Fixes
+
+* **service:** make the fallback $uses / $translate.use work in a correct manner ([7e71a5a](https://github.com/angular-translate/angular-translate/commit/7e71a5a))
+
+
+
 <a name="2.9.2"></a>
 ## [2.9.2](https://github.com/angular-translate/angular-translate/compare/2.9.1...v2.9.2) (2016-02-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+<a name="2.4.2"></a>
+### 2.4.2 (2014-10-21)
+
+
+#### Bug Fixes
+
+* **partialloader:** fix possible circular dependency ([25f252c1](http://github.com/angular-translate/angular-translate/commit/25f252c14aab58b9e2dc61e2765420b584106b6f), closes [#766](http://github.com/angular-translate/angular-translate/issues/766))
+
+
+#### Features
+
+* **directive:** translate-cloak supports optional value for cloaking ([f7ccb7fb](http://github.com/angular-translate/angular-translate/commit/f7ccb7fbdac184b6a8b216966ebf89b4a8d3fb5e))
+
+
 <a name="2.4.1"></a>
 ### 2.4.1 (2014-10-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+# 2.4.0 (2014-09-22)
+
+## Features
+### service
+
+* introduce `versionInfo` function (e37d89c)
+
+* prefer detecting language by `navigator.languages` #722 (2204f4f)
+
+* enrich events with the currently handled language key (73b289d)
+
+* interpolate translationId in case of rejected translation (3efaac5)
+
+### loaders
+
+* introduce loader cache (b685601)
+
+### loader
+
+* apply support for loaderOptions.$http (8613bef)
+
+
+
+## Bug fixes
+### service
+
+* correctly iterate in fallback languages (fixes #690) (ac2f35c)
+
+* `$nextLang` should be not unset parallel loadings (d1745e4)
+
+* avoid possible doubled requested on refresh() (98d429d)
+
+* avoid possible npe in internal getTranslationTable() (9aaa9a0)
+
+### filter
+
+* mark filter being stateful required since Angular 1.3 rc2 (bffbf04)
+
+* interpolated params w/ scope aren't possible starting AJS1.3 (9465318)
+
+
 <a name="2.3.0"></a>
 ## 2.3.0 (2014-09-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+<a name="2.11.0"></a>
+# [2.11.0](https://github.com/angular-translate/angular-translate/compare/2.10.0...v2.11.0) (2016-03-20)
+
+
+### Bug Fixes
+
+* **directive:** reduced number of watchers by applying translateLanguage watcher only when direc ([961fc92](https://github.com/angular-translate/angular-translate/commit/961fc92))
+* **service:** add missing hasOwnProperty check ([823afc0](https://github.com/angular-translate/angular-translate/commit/823afc0))
+* **service:** avoid try to load languages which are explicitly not wanted ([bde935e](https://github.com/angular-translate/angular-translate/commit/bde935e)), closes [#1390](https://github.com/angular-translate/angular-translate/issues/1390)
+* **service:** fix edge-case with .use() and .preferredLanguage() ([02688f2](https://github.com/angular-translate/angular-translate/commit/02688f2))
+* **service:** translations for `forceLanguage` will be loaded on demand ([14bc956](https://github.com/angular-translate/angular-translate/commit/14bc956)), closes [#1389](https://github.com/angular-translate/angular-translate/issues/1389)
+
+### Features
+
+* **depenceny:** Update messageformat.js to current 0.3.0 release ([fb48f78](https://github.com/angular-translate/angular-translate/commit/fb48f78))
+* **directive:** introduce attr translate-keep-content ([b2cf8a3](https://github.com/angular-translate/angular-translate/commit/b2cf8a3))
+* **service:** add `$translate.resolveClientLocale()` (also at provider) ([d0469ac](https://github.com/angular-translate/angular-translate/commit/d0469ac))
+* **service:** add support for uniformLanguageTag('iso639-1') ([1e037ec](https://github.com/angular-translate/angular-translate/commit/1e037ec)), closes [#1181](https://github.com/angular-translate/angular-translate/issues/1181)
+* **service:** improve messageformat.js output caching ([cb31608](https://github.com/angular-translate/angular-translate/commit/cb31608))
+* **service:** introduce getter returning available languages ([3988af0](https://github.com/angular-translate/angular-translate/commit/3988af0)), closes [#1304](https://github.com/angular-translate/angular-translate/issues/1304)
+* **service:** introduce post processing for translations ([f0c4874](https://github.com/angular-translate/angular-translate/commit/f0c4874))
+* **service:** support for default translation in missingTranslationHandler ([8c5044c](https://github.com/angular-translate/angular-translate/commit/8c5044c))
+
+
+
 <a name="2.10.0"></a>
 # [2.10.0](https://github.com/angular-translate/angular-translate/compare/2.9.2...v2.10.0) (2016-02-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+<a name="2.11.1"></a>
+## [2.11.1](https://github.com/angular-translate/angular-translate/compare/2.11.0...v2.11.1) (2016-07-17)
+
+
+### Bug Fixes
+
+* **dependencies:** Update messageformat to ~0.3.1 ([04e11c9](https://github.com/angular-translate/angular-translate/commit/04e11c9))
+* **grunt:** add work-around for uglify preserveComments as expected ([32cdedb](https://github.com/angular-translate/angular-translate/commit/32cdedb)), closes [#1461](https://github.com/angular-translate/angular-translate/issues/1461)
+* **service:** allow instant function to also take care of post process configuration ([b7d7907](https://github.com/angular-translate/angular-translate/commit/b7d7907))
+* **service:** avoid sanitizing of functions ([492d8e5](https://github.com/angular-translate/angular-translate/commit/492d8e5)), closes [#1529](https://github.com/angular-translate/angular-translate/issues/1529)
+* **service:** Correct descriptive ngdocs to match parameters on the service calls ([91711f7](https://github.com/angular-translate/angular-translate/commit/91711f7))
+* **service:** fix interpolation issue with non-string as input ([fa4a80e](https://github.com/angular-translate/angular-translate/commit/fa4a80e)), closes [#1511](https://github.com/angular-translate/angular-translate/issues/1511)
+* **service:** fix lost of data in async loader / error in runtime ([5ee0c3e](https://github.com/angular-translate/angular-translate/commit/5ee0c3e))
+
+
+### Features
+
+* **directive:** introduce a global keepContent setting ([2015f79](https://github.com/angular-translate/angular-translate/commit/2015f79))
+
+
+
 <a name="2.11.0"></a>
 # [2.11.0](https://github.com/angular-translate/angular-translate/compare/2.10.0...v2.11.0) (2016-03-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="2.9.1"></a>
+## [2.9.1](https://github.com/angular-translate/angular-translate/compare/2.9.0...v2.9.1) (2016-02-13)
+
+
+### Bug Fixes
+
+* **package:** redefine dependency version range (AJS 1.5) ([9ccce6b](https://github.com/angular-translate/angular-translate/commit/9ccce6b)), closes [#1394](https://github.com/angular-translate/angular-translate/issues/1394) [#1395](https://github.com/angular-translate/angular-translate/issues/1395) [#1397](https://github.com/angular-translate/angular-translate/issues/1397)
+
+
+
 <a name="2.9.0"></a>
 # [2.9.0](https://github.com/angular-translate/angular-translate/compare/2.8.1...v2.9.0) (2016-01-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<a name="2.5.2"></a>
+### 2.5.2 (2014-12-10)
+
+Internal release. No changes.
+
+
+<a name="2.5.1"></a>
+### 2.5.1 (2014-12-10)
+
+
+#### Bug Fixes
+
+* **directive:** missing watch for expression within elements text nodes ([31c03560](http://github.com/angular-translate/angular-translate/commit/31c03560ddb537734303c41419b147262d511841), closes [#701](http://github.com/angular-translate/angular-translate/issues/701))
+
+
 <a name="2.5.0"></a>
 ## 2.5.0 (2014-12-07)
 

--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -59,7 +59,7 @@ function $translatePartialLoader() {
     else {
       lastLangPromise.then(langDeferred.resolve, tryGettingThisTable);
     }
-    lastLangPromise = this.langPromises[lang] = langDeferred.promise
+    lastLangPromise = this.langPromises[lang] = langDeferred.promise;
     return lastLangPromise;
   };
 

--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -51,8 +51,42 @@ function $translatePartialLoader() {
   };
 
   Part.prototype.getTable = function(lang, $q, $http, $httpOptions, urlTemplate, errorHandler) {
-    var lastLangPromise = this.langPromises[lang], langDeferred = $q.defer(),
-        tryGettingThisTable = tryGetTable.bind(this, urlTemplate, lang, langDeferred, errorHandler, $http, $httpOptions);
+    //private helper
+    function tryGettingThisTable () {
+      //private helper helpers
+      function fetchData () {
+        return $http(
+          angular.extend({
+              method : 'GET',
+              url: self.parseUrl(urlTemplate, lang)
+            },
+            $httpOptions)
+          );
+      }
+      function handleNewData(data) {
+        self.tables[lang] = data;
+        langDeferred.resolve(data);
+      }
+      function rejectDeferredWithPartName() {
+        langDeferred.reject(self.name);
+      }
+      //data fetching logic
+      fetchData().then(
+        function(result){
+          handleNewData(result.data);
+        },
+        function(errorResponse) {
+          if (errorHandler) {
+            errorHandler(self.name, lang, errorResponse).then(handleNewData, rejectDeferredWithPartName);
+          }
+          else {
+            rejectDeferredWithPartName();
+          }
+        });
+    }
+    //locals
+    var self = this, lastLangPromise = this.langPromises[lang], langDeferred = $q.defer();
+    //promise chaining logic
     if (!lastLangPromise) {
       tryGettingThisTable();
     }
@@ -62,44 +96,6 @@ function $translatePartialLoader() {
     lastLangPromise = this.langPromises[lang] = langDeferred.promise;
     return lastLangPromise;
   };
-
-  //These are private helper functions for getTable. They must be used from the Part's context
-  //with function.bind(this), function.call(this, ...), or function.apply(this, args).
-  function tryGetTable (urlTemplate, lang, langDeferred, errorHandler, $http, $httpOptions) {
-    var self = this, handleData = handleNewData.bind(this, lang, langDeferred),
-        handleFailure = rejectDeferredWithName.bind(this, langDeferred);
-    fetchData.call(this, urlTemplate, lang, $http, $httpOptions).then(
-      function(result){
-        handleData(result.data);
-      },
-      function(response) {
-        if (errorHandler) {
-          errorHandler(self.name, lang, response).then(handleData, handleFailure);
-        }
-        else {
-          handleFailure();
-        }
-      });
-  }
-
-  function fetchData (urlTemplate, lang, $http, $httpOptions) {
-    return $http(
-      angular.extend({
-          method : 'GET',
-          url: this.parseUrl(urlTemplate, lang)
-        },
-        $httpOptions)
-      );
-  }
-
-  function handleNewData(lang, langDeferred, data) {
-    this.tables[lang] = data;
-    langDeferred.resolve(data);
-  }
-
-  function rejectDeferredWithName(deferred) {
-    deferred.reject(this.name);
-  }
 
   var parts = {};
 

--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -87,12 +87,18 @@ function $translatePartialLoader() {
     }
     //locals
     var self = this, lastLangPromise = this.langPromises[lang], langDeferred = $q.defer();
-    //promise chaining logic
-    if (!lastLangPromise) {
-      tryGettingThisTable();
+    if (this.tables[lang]) {
+      //the part must have been set statically
+      langDeferred.resolve(this.tables[lang]);
     }
-    else {
-      lastLangPromise.then(langDeferred.resolve, tryGettingThisTable);
+    else {      
+      if (!lastLangPromise) {
+        tryGettingThisTable();
+      }
+      else {
+        //promise chaining logic
+        lastLangPromise.then(langDeferred.resolve, tryGettingThisTable);
+      }
     }
     lastLangPromise = this.langPromises[lang] = langDeferred.promise;
     return lastLangPromise;

--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -27,6 +27,7 @@ function $translatePartialLoader() {
     this.isActive = true;
     this.tables = {};
     this.priority = priority || 0;
+    this.langPromises = {};
   }
 
   /**

--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -90,6 +90,7 @@ function $translatePartialLoader() {
     //loading logic
     if (this.tables[lang]) {
       //the part has already been loaded - if this is the first call to getTable and lastLangPromise is also undefined then the table has been populated using setPart
+      //this breaks the promise chain because we're not attaching langDeferred's outcome to a previous call's promise, but we don't care because there's no asynchronous execution context to keep track of anymore
       langDeferred.resolve(this.tables[lang]);
     }
     else {
@@ -106,7 +107,6 @@ function $translatePartialLoader() {
       }
     }
     //picture the promise chain as a singly-linked list (formed by the .then handler queues) that's traversed by the execution context - we just retain a reference to the last promise so we can continue the chain if another request is made before any succeed
-    //the first call to getTable after a success breaks the chain - see the if (this.tables[lang]) branch - and should allow the promise chain to be garbage collected (assuming other references to the promises have been nulled)
     lastLangPromise = this.langPromises[lang] = langDeferred.promise;
     return lastLangPromise;
   };


### PR DESCRIPTION
I updated the getTable function to chain subsequent calls off of the original HTTP request, passing through the value on success and reattempting the HTTP request on failure. This is pretty well described in my commit message.