### PR TITLE
fix: Timezone and DST agnostic Unit test

### DIFF
--- a/test/unit/service/default-interpolation.spec.js
+++ b/test/unit/service/default-interpolation.spec.js
@@ -141,9 +141,9 @@ describe('pascalprecht.translate', function () {
     it('should ignore a date param', inject(function ($translateSanitization) {
       var text = 'Day is: {{day | date:"dd.MM.yyyy"}}';
       var params = {
-        day : new Date('2016-08-21')
+        day : new Date(2016, 1, 21)
       };
-      var sanitizedText = 'Day is: 21.08.2016';
+      var sanitizedText = 'Day is: 21.02.2016';
 
       spyOn($translateSanitization, 'sanitize').and.callThrough();
       $translateSanitization.useStrategy('escapeParameters');


### PR DESCRIPTION
Date generated for use in the unit test ‘should ignore a date param’ changed to be date only, in local time, to avoid having the test fail based on the timezone/DST of the machine the test is run on.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
This fixes a bug that I encountered where the mentioned unit test was failing due to my machine's timezone offset. The evaluated date was off by one day from the provided (hardcoded) test value. As a note, my current timezone as of the fails is PDT. I tested this fix by running it many times and changing my local machine's timezone all around the world.

💔Thank you!
