### PR TITLE
fix(unit test)

### DIFF
--- a/test/unit/service/default-interpolation.spec.js
+++ b/test/unit/service/default-interpolation.spec.js
@@ -141,7 +141,7 @@ describe('pascalprecht.translate', function () {
     it('should ignore a date param', inject(function ($translateSanitization) {
       var text = 'Day is: {{day | date:"dd.MM.yyyy"}}';
       var params = {
-        day : new Date('2016-08-21')
+        day : new Date(2016, 7, 21)
       };
       var sanitizedText = 'Day is: 21.08.2016';
 


### PR DESCRIPTION
Call to new Date with ISO8601 string w/o time component yields UTC tz
date object which can be different from the expected date, '2016-08-21',
defined in the unit test. Calling new Date with arguments for year,
month, day will by pass the implicit call to Date.parse and avoid the
potential tz difference.

For example, when running the unit tests with new Date('2016-08-21') I would see the following output:

HeadlessChrome 0.0.0 (Mac OS X 10.12.5) pascalprecht.translate $translateDefaultInterpolation#interpolate should ignore a date param FAILED
	Expected 'Day is: 20.08.2016' to be 'Day is: 21.08.2016'.
	    at Object.<anonymous> (test/unit/service/default-interpolation.spec.js:150:72)
	    at Object.invoke (bower_components/angular/angular.js:3967:17)
	    at Object.workFn (bower_components/angular-mocks/angular-mocks.js:2177:20)

It is possible to use an ISO8601 date w/ time, '2016-08-21T00:00:00', but that also failed for me depending on what version of Chrome I had (v58 failed, v59 win). Date.parse called with an ISO8601 date string will create a date object with different tz depending on the components included in the date string. Avoiding the implicit call to Date.parse seemed to be the most predictable solution.