### PR TITLE
fix($translateSanitizationProvider): fix sanitization of boolean values

### DIFF
--- a/src/service/sanitization.js
+++ b/src/service/sanitization.js
@@ -301,6 +301,8 @@ function $translateSanitizationProvider () {
       return result;
     } else if (angular.isNumber(value)) {
       return value;
+    } else if (value === true || value === false) {
+      return value;
     } else if (!angular.isUndefined(value) && value !== null) {
       return iteratee(value);
     } else {

--- a/test/unit/service/sanitization.spec.js
+++ b/test/unit/service/sanitization.spec.js
@@ -32,7 +32,8 @@ describe('pascalprecht.translate', function () {
           array : [
             {value : 'This is <b>only an example with a <span onclick="alert(\'XSS\')">xss attack</span>!</b>'}
           ],
-          boolean: false
+          falsyBoolean: false,
+          truthyBoolean: true
         },
         text = 'This is <b>only an example with a <span onclick="alert(\'XSS\')">xss attack</span>!</b>',
         expectedParameters,
@@ -98,7 +99,8 @@ describe('pascalprecht.translate', function () {
             array : [
               {value : 'This is <b>only an example with a <span>xss attack</span>!</b>'}
             ],
-            boolean: false
+            falsyBoolean: false,
+            truthyBoolean: true
           };
           expect($translateSanitization.sanitize(parameters, 'params')).toEqual(expectedParameters);
         });
@@ -119,7 +121,8 @@ describe('pascalprecht.translate', function () {
             array : [
               {value : 'This is &lt;b&gt;only an example with a &lt;span onclick="alert(\'XSS\')"&gt;xss attack&lt;/span&gt;!&lt;/b&gt;'}
             ],
-            boolean: false
+            falsyBoolean: false,
+            truthyBoolean: true
           };
           expect($translateSanitization.sanitize(parameters, 'params')).toEqual(expectedParameters);
         });
@@ -166,7 +169,8 @@ describe('pascalprecht.translate', function () {
             array : [
               {value : 'This is &lt;b&gt;only an example with a &lt;span onclick="alert(\'XSS\')"&gt;xss attack&lt;/span&gt;!&lt;/b&gt;'}
             ],
-            boolean: false
+            falsyBoolean: false,
+            truthyBoolean: true
           };
           expect($translateSanitization.sanitize(parameters, 'params')).toEqual(expectedParameters);
         });
@@ -187,7 +191,8 @@ describe('pascalprecht.translate', function () {
             array : [
               {value : 'This is &lt;b&gt;only an example with a &lt;span onclick="alert(\'XSS\')"&gt;xss attack&lt;/span&gt;!&lt;/b&gt;'}
             ],
-            boolean: false
+            falsyBoolean: false,
+            truthyBoolean: true
           };
           expect($translateSanitization.sanitize(parameters, 'params')).toEqual(expectedParameters);
         });

--- a/test/unit/service/sanitization.spec.js
+++ b/test/unit/service/sanitization.spec.js
@@ -31,7 +31,8 @@ describe('pascalprecht.translate', function () {
       var parameters = {
           array : [
             {value : 'This is <b>only an example with a <span onclick="alert(\'XSS\')">xss attack</span>!</b>'}
-          ]
+          ],
+          boolean: false
         },
         text = 'This is <b>only an example with a <span onclick="alert(\'XSS\')">xss attack</span>!</b>',
         expectedParameters,
@@ -96,7 +97,8 @@ describe('pascalprecht.translate', function () {
           expectedParameters = {
             array : [
               {value : 'This is <b>only an example with a <span>xss attack</span>!</b>'}
-            ]
+            ],
+            boolean: false
           };
           expect($translateSanitization.sanitize(parameters, 'params')).toEqual(expectedParameters);
         });
@@ -116,7 +118,8 @@ describe('pascalprecht.translate', function () {
           expectedParameters = {
             array : [
               {value : 'This is &lt;b&gt;only an example with a &lt;span onclick="alert(\'XSS\')"&gt;xss attack&lt;/span&gt;!&lt;/b&gt;'}
-            ]
+            ],
+            boolean: false
           };
           expect($translateSanitization.sanitize(parameters, 'params')).toEqual(expectedParameters);
         });
@@ -162,7 +165,8 @@ describe('pascalprecht.translate', function () {
           expectedParameters = {
             array : [
               {value : 'This is &lt;b&gt;only an example with a &lt;span onclick="alert(\'XSS\')"&gt;xss attack&lt;/span&gt;!&lt;/b&gt;'}
-            ]
+            ],
+            boolean: false
           };
           expect($translateSanitization.sanitize(parameters, 'params')).toEqual(expectedParameters);
         });
@@ -182,7 +186,8 @@ describe('pascalprecht.translate', function () {
           expectedParameters = {
             array : [
               {value : 'This is &lt;b&gt;only an example with a &lt;span onclick="alert(\'XSS\')"&gt;xss attack&lt;/span&gt;!&lt;/b&gt;'}
-            ]
+            ],
+            boolean: false
           };
           expect($translateSanitization.sanitize(parameters, 'params')).toEqual(expectedParameters);
         });


### PR DESCRIPTION
When using `$translateSanitizationProvider` with `escapeParameters` or `sanitizeParameters` strategy boolean values transformed to strings, e.g. `false` becomes `"false"`.
With this fix boolean values are not transformed.

Closes #1747
