### PR TITLE
feat(loader-partial): addPart specific urlTemplate override

### DIFF
--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -22,12 +22,13 @@ function $translatePartialLoader() {
    * @description
    * Represents Part object to add and set parts at runtime.
    */
-  function Part(name, priority) {
+  function Part(name, priority, urlTemplate) {
     this.name = name;
     this.isActive = true;
     this.tables = {};
     this.priority = priority || 0;
     this.langPromises = {};
+    this.urlTemplate = urlTemplate;
   }
 
   /**
@@ -63,7 +64,7 @@ function $translatePartialLoader() {
       return $http(
         angular.extend({
             method : 'GET',
-            url : self.parseUrl(urlTemplate, lang)
+            url : self.parseUrl(self.urlTemplate || urlTemplate, lang)
           },
           $httpOptions)
       );
@@ -183,13 +184,13 @@ function $translatePartialLoader() {
    * of the wrong type. Please, note that the `name` param has to be a
    * non-empty **string**.
    */
-  this.addPart = function (name, priority) {
+  this.addPart = function (name, priority, urlTemplate) {
     if (!isStringValid(name)) {
       throw new TypeError('Couldn\'t add part, part name has to be a string!');
     }
 
     if (!hasPart(name)) {
-      parts[name] = new Part(name, priority);
+      parts[name] = new Part(name, priority, urlTemplate);
     }
     parts[name].isActive = true;
 
@@ -340,7 +341,7 @@ function $translatePartialLoader() {
           loaders.push(
             part.getTable(options.key, $q, $http, options.$http, options.urlTemplate, errorHandler)
           );
-          part.urlTemplate = options.urlTemplate;
+          part.urlTemplate = part.urlTemplate || options.urlTemplate;
         });
 
         return $q.all(loaders)
@@ -379,13 +380,13 @@ function $translatePartialLoader() {
        * @throws {TypeError} The method could throw a **TypeError** if you pass the param of the wrong
        * type. Please, note that the `name` param has to be a non-empty **string**.
        */
-      service.addPart = function (name, priority) {
+      service.addPart = function (name, priority, urlTemplate) {
         if (!isStringValid(name)) {
           throw new TypeError('Couldn\'t add part, first arg has to be a string');
         }
 
         if (!hasPart(name)) {
-          parts[name] = new Part(name, priority);
+          parts[name] = new Part(name, priority, urlTemplate);
           $rootScope.$emit('$translatePartialLoaderStructureChanged', name);
         } else if (!parts[name].isActive) {
           parts[name].isActive = true;

--- a/test/unit/service/loader-partial.spec.js
+++ b/test/unit/service/loader-partial.spec.js
@@ -538,6 +538,22 @@ describe('pascalprecht.translate', function () {
       });
     });
 
+    it('should parse url template addPart argument', function () {
+      inject(function ($translatePartialLoader, $httpBackend) {
+        $httpBackend.expectGET('/x/locales/part-en.json').respond(200, '{}');
+
+        $translatePartialLoader.addPart('part-x', undefined, '/x/locales/part-{lang}.json');
+        $translatePartialLoader({
+          key : 'en',
+          urlTemplate: '/locales/{part}-{lang}.json'
+        });
+
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+      });
+    });
+
     it('should support function in url template', function () {
       inject(function ($translatePartialLoader, $httpBackend) {
         var getUrlTemplate = jasmine.createSpy('getUrlTemplate')


### PR DESCRIPTION
To accommodate use case in which location of translation table for a
partial is not known at config time and is unique to partial being
requested. For example, app is served as a SPA from s3 bucket, after
initialization and based on route parameters addParts from other s3
buckets and/or paths based on those route parameters.