### PR TITLE
fix($translate):  respect case in available languages

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -161,8 +161,9 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
     }
 
     // Check for an exact match in our list of available keys
-    if (indexOf(avail, locale) > -1) {
-      return preferred;
+    i = indexOf(avail, locale);
+    if (i > -1) {
+      return $availableLanguageKeys[i];
     }
 
     if ($languageKeyAliases) {


### PR DESCRIPTION
If a language matches an available language using lowercase comparison, the available language it is returned with case intact.

Test avaliable in separate pull request: https://github.com/angular-translate/angular-translate/pull/1783
