### PR TITLE
fix($translate): Ignore case when matching wildcards in available lan…

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -174,7 +174,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
             angular.lowercase(langKeyAlias) === angular.lowercase(preferred);
 
           if (langKeyAlias.slice(-1) === '*') {
-            hasWildcardKey = langKeyAlias.slice(0, -1) === preferred.slice(0, langKeyAlias.length - 1);
+            hasWildcardKey = angular.lowercase(langKeyAlias.slice(0, -1)) === angular.lowercase(preferred.slice(0, langKeyAlias.length - 1));
           }
           if (hasExactKey || hasWildcardKey) {
             alias = $languageKeyAliases[langKeyAlias];


### PR DESCRIPTION
fix($translate): Ignore case when matching wildcards in available languages map.

By ignoring case in language map wildcards, there is no longer any need for redundant
entries covering every single combination for each language. I.e. 'en_*' will match 'En-UK',
'eN_UK' as well as 'EN_UK'.

Test avaliable in separate pull request: https://github.com/angular-translate/angular-translate/pull/1785
