### PR TITLE
Example of avoiding FOUC on async load + UI-Router

### DIFF
--- a/docs/content/guide/en/12_asynchronous-loading.ngdoc
+++ b/docs/content/guide/en/12_asynchronous-loading.ngdoc
@@ -395,6 +395,19 @@ $translateProvider.preferredLanguage('en');
 **Note:** An Angular Translate user has been posted a nice solution [using Grunt](https://github.com/angular-translate/angular-translate/issues/921).
 Another user has published a solution [using Gulp](https://www.npmjs.com/package/gulp-ng-lang2js).
 
+If you use [UI-Router](https://ui-router.github.io/), there is a simpler solution 
+to avoid FOUC. Just add a new resolve to your global application state that returns
+a call to `$translate.onReady`, effectively blocking the rendering of the app until
+the first translation file is loaded:
+
+<pre>
+resolve: {
+  translateReady: ['$translate', function($translate) {
+    return $translate.onReady();
+  }]
+}
+</pre>
+
 Let's update our sample app accordingly to use an asynchronous loader! We'll use
 the staticFilesLoader. First, we have to pull the translation tables out of the
 code and put them into separate locale files:


### PR DESCRIPTION
Add an example on how to avoid FOUC on asyncronous loading using UI-Router to documentation

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
Please describe your pull request.

💔Thank you!
