### PR TITLE
Fix pull request template link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ### Your checklist for this pull request
-🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.
+🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
 
 - [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
 - [ ] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.


### PR DESCRIPTION
This is a bit meta, but your Github PR template links to a nonexistent `CONTRIBUTING.md`. This PR fixes that.