### PR TITLE
Refresh translations after changing it. This is a work-around to #1781

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1945,6 +1945,8 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
         useLanguage(key);
       }
 
+      deferred.promise.then(function (lang) { return $translate.refresh().then(function () { return lang; }); });
+
       return deferred.promise;
     };
 


### PR DESCRIPTION
Implemented a work-around as described in #1781. Not very proud of it, but it works.

A propper fix would be to change the language before loading the async parts, whereby also the rest for #1781 should work.

This work-around get's many tests to crash, but I don't have the insight into the project in order to fix them. I'd appreciate it if someone could it pick up from here.