### PR TITLE
Format bcp47 with script and language only correctly.

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -56,7 +56,29 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
       bcp47 : function (tag) {
         var temp = (tag || '').split('_').join('-');
         var parts = temp.split('-');
-        return parts.length > 1 ? (parts[0].toLowerCase() + '-' + parts[1].toUpperCase()) : temp;
+
+        switch (parts.length) {
+          case 1: // language only
+            parts[0] = parts[0].toLowerCase();
+            break;
+          case 2: // language-script or language-region
+            parts[0] = parts[0].toLowerCase();
+            if (parts[1].length === 4) { // parts[1] is script
+              parts[1] = parts[1].charAt(0).toUpperCase() + parts[1].slice(1).toLowerCase();
+            } else { // parts[1] is region
+              parts[1] = parts[1].toUpperCase();
+            }
+            break;
+          case 3: // language-script-region
+            parts[0] = parts[0].toLowerCase();
+            parts[1] = parts[1].charAt(0).toUpperCase() + parts[1].slice(1).toLowerCase();
+            parts[2] = parts[2].toUpperCase();
+            break;
+          default:
+            return temp;
+        }
+
+        return parts.join('-');
       },
       'iso639-1' : function (tag) {
         var temp = (tag || '').split('_').join('-');
@@ -825,9 +847,12 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
    *     en_US => en_US
    *     en-us => en_US
    * * BCP 47 (RFC 4646 & 4647)
+   *     EN => en
    *     en-US => en-US
    *     en_US => en-US
    *     en-us => en-US
+   *     sr-latn => sr-Latn
+   *     sr-latn-rs => sr-Latn-RS
    *
    * See also:
    * * http://en.wikipedia.org/wiki/IETF_language_tag

--- a/test/unit/service/translate.determineLocale.spec.js
+++ b/test/unit/service/translate.determineLocale.spec.js
@@ -373,6 +373,20 @@ describe('pascalprecht.translate', function () {
       });
 
       describe('using resolver "bcp47"', function () {
+        describe('should resolve to EN to en', function () {
+          beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide, pascalprechtTranslateOverrider) {
+            pascalprechtTranslateOverrider.getLocale = function () {
+              return 'EN';
+            };
+            $translateProvider
+              .uniformLanguageTag('bcp47')
+              .determinePreferredLanguage();
+          }));
+          it('test', inject(function ($window, $translate) {
+            expect($translate.use()).toEqual('en');
+          }));
+        });
+
         describe('should resolve to en-US to en-US', function () {
           beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide, pascalprechtTranslateOverrider) {
             pascalprechtTranslateOverrider.getLocale = function () {
@@ -426,6 +440,34 @@ describe('pascalprecht.translate', function () {
           }));
           it('test', inject(function ($window, $translate) {
             expect($translate.use()).toEqual('en');
+          }));
+        });
+
+        describe('should resolve script without region', function () {
+          beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide, pascalprechtTranslateOverrider) {
+            pascalprechtTranslateOverrider.getLocale = function () {
+              return 'sr-latn';
+            };
+            $translateProvider
+              .uniformLanguageTag('bcp47')
+              .determinePreferredLanguage();
+          }));
+          it('test', inject(function ($window, $translate) {
+            expect($translate.use()).toEqual('sr-Latn');
+          }));
+        });
+
+        describe('should resolve script with region', function () {
+          beforeEach(module('pascalprecht.translate', function ($translateProvider, $provide, pascalprechtTranslateOverrider) {
+            pascalprechtTranslateOverrider.getLocale = function () {
+              return 'sr-latn-rs';
+            };
+            $translateProvider
+              .uniformLanguageTag('bcp47')
+              .determinePreferredLanguage();
+          }));
+          it('test', inject(function ($window, $translate) {
+            expect($translate.use()).toEqual('sr-Latn-RS');
           }));
         });
       });


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

The commit message probably won't fit the correct style. I read through this document, but could not find anything matching in the last commits to adapt it. Can you help me there?

And I am not able to run `npm run test-scopes`. Probably because I am on a Windows machine but the build on Travis CI looks green :)

### Description
As mentionend in #1811 angular-translate ignores the script of a bcp47 language tag. This should fix it.
In addition I saw, that the language part never gets formatted to lowercase, so I also added a test and fix for this.
