### PR TITLE
feat(*): support google closure compiler

### DIFF
--- a/src/directive/translate-namespace.js
+++ b/src/directive/translate-namespace.js
@@ -60,7 +60,7 @@ function translateNamespaceDirective() {
     compile: function () {
       return {
         pre: function (scope, iElement, iAttrs) {
-          scope.translateNamespace = getTranslateNamespace(scope);
+          scope.translateNamespace = _getTranslateNamespace(scope);
 
           if (scope.translateNamespace && iAttrs.translateNamespace.charAt(0) === '.') {
             scope.translateNamespace += iAttrs.translateNamespace;
@@ -79,13 +79,13 @@ function translateNamespaceDirective() {
  * @param scope
  * @returns {string}
  */
-function getTranslateNamespace(scope) {
+function _getTranslateNamespace(scope) {
   'use strict';
   if (scope.translateNamespace) {
     return scope.translateNamespace;
   }
   if (scope.$parent) {
-    return getTranslateNamespace(scope.$parent);
+    return _getTranslateNamespace(scope.$parent);
   }
 }
 


### PR DESCRIPTION
Because of duplicate definitions of getTranslateNamespace in the same scope, google
closure compiler returns the following error when minifying the angular-translate.js library:
- Duplicate let / const / class / function declaration in the same scope is not allowed.
Change one of the getTranslateNamespace to be _getTranslateNamespace to avoid error.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
Please describe your pull request.

💔Thank you!
