### PR TITLE
fix: Allow line breaks in interpolated expressions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3586,6 +3586,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
       "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "nan": "^2.12.1",
         "node-pre-gyp": "^0.12.0"
@@ -3594,22 +3595,26 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -3618,12 +3623,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3632,32 +3639,38 @@
         "chownr": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "debug": {
           "version": "4.1.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -3665,22 +3678,26 @@
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.2.1"
           }
@@ -3688,12 +3705,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -3709,6 +3728,7 @@
           "version": "7.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -3721,12 +3741,14 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -3735,6 +3757,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -3743,6 +3766,7 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -3751,17 +3775,20 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3769,12 +3796,14 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3782,12 +3811,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3797,6 +3828,7 @@
           "version": "1.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.2.1"
           }
@@ -3805,6 +3837,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3812,12 +3845,14 @@
         "ms": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "needle": {
           "version": "2.3.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
@@ -3828,6 +3863,7 @@
           "version": "0.12.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -3845,6 +3881,7 @@
           "version": "4.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -3853,12 +3890,14 @@
         "npm-bundled": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -3868,6 +3907,7 @@
           "version": "4.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -3878,17 +3918,20 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3896,17 +3939,20 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -3915,17 +3961,20 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -3936,7 +3985,8 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -3944,6 +3994,7 @@
           "version": "2.3.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -3958,6 +4009,7 @@
           "version": "2.6.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -3965,37 +4017,44 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.7.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4006,6 +4065,7 @@
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -4014,6 +4074,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4021,12 +4082,14 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tar": {
           "version": "4.4.8",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -4040,12 +4103,14 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
@@ -4053,12 +4118,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7041,7 +7108,8 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "express": "^4.17.1",
     "express-session": "^1.16.2",
     "fbjs-scripts": "^0.8.3",
-    "fsevents": "^1.2.9",
     "grunt": "^1.0.4",
     "grunt-bower-install-simple": "1.2.4",
     "grunt-bump": "^0.8.0",

--- a/src/directive/translate.js
+++ b/src/directive/translate.js
@@ -181,7 +181,7 @@ function translateDirective($translate, $interpolate, $compile, $parse, $rootSco
           }
 
           if (angular.equals(translationId , '') || !angular.isDefined(translationId)) {
-            var iElementText = trim.apply(iElement.text());
+            var iElementText = trim.apply(iElement.text()).replace(/\n/g, ' ');
 
             // Resolve translation id by inner html if required
             var interpolateMatches = iElementText.match(interpolateRegExp);

--- a/test/unit/directive/translate.spec.js
+++ b/test/unit/directive/translate.spec.js
@@ -904,4 +904,68 @@ describe('pascalprecht.translate', function () {
       expect(element.html()).toBe('My content');
     });
   });
+
+  describe('handling newlines in interpolation', function () {
+
+    var $compile, $rootScope, element;
+
+    beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+      $translateProvider
+        .translations('en', {
+          'TRANSLATION_ID' : 'foo',
+          'abcfoodef': 'BOGUS?',
+          'foo': 'FOOGUS?'
+        })
+        .preferredLanguage('en');
+    }));
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+    }));
+
+    it('should handle newlines embedded in interpolation expression', function () {
+      $rootScope.translationId = 'TRANSLATION_ID';
+      element = $compile('<div translate>{{\ntranslationId\n}}</div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.text()).toBe('foo');
+    });
+
+    it('should handle newlines embedded in interpolation expression for translate element', function () {
+      $rootScope.translationId = 'TRANSLATION_ID';
+      element = $compile('<translate>{{\ntranslationId\n}}</translate>')($rootScope);
+      $rootScope.$digest();
+      expect(element.text()).toBe('foo');
+    });
+
+    it('should handle newlines embedded in interpolation expression with surrounding text', function () {
+      $rootScope.translationId = 'TRANSLATION_ID';
+      element = $compile('<div translate>abc{{\ntranslationId\n}}def</div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.text()).toBe('abcfoodef');
+    });
+
+    it('should handle newlines embedded in and surrounding interpolation expression', function () {
+      $rootScope.translationId = 'TRANSLATION_ID';
+      element = $compile('<div translate>abc\n{{\ntranslationId\n}}\ndef</div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.text()).toBe('abc foo def');
+    });
+
+    it('should handle newlines embedded in complex interpolation expression', function () {
+      $rootScope.translationId = 'TRANSLATION_ID';
+      $rootScope.var1 = 'TRANSLATION';
+      $rootScope.var2 = 'ID';
+      element = $compile('<div translate>\nabc{{\n   var1 + \n    "_" + var2\n   }}def\n   </div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.text()).toBe('abcfoodef');
+    });
+
+    it('should handle newlines embedded in interpolation expression in attribute', function () {
+      $rootScope.translationId = 'TRANSLATION_ID';
+      element = $compile('<div translate="{{\ntranslationId\n}}">...</div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.text()).toBe('foo');
+    });
+  });
 });


### PR DESCRIPTION
Line breaks can now appear in interpolated AngularJS expressions inside
the body or translated elements and inside the value of translate
attributes.

Includes unit tests.

Also needed to remove `fsevents` from `package.json` for `npm install`
to work on Linux.  Might want to add that back in as an
"optionalDependancy" if it is really needed.

Closes #1884, #1824

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
See above.

💔Thank you!
