### PR TITLE
feat: throw TypeError for translationId

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1145,6 +1145,8 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
       // trim off any whitespace
       if (translationId) {
         translationId = trim.apply(translationId);
+      } else {
+        throw new TypeError('translationId must be a not empty string');
       }
 
       var promiseToWaitFor = (function () {

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -256,6 +256,10 @@ describe('pascalprecht.translate', function () {
       expect(value).toEqual(translationId);
     });
 
+    it('should throw if id is not a string or array of strings', function () {
+      expect(function () { $translate(undefined); }).toThrowError(TypeError);
+    });
+
     it('should return translation id if translation is null', function () {
       var deferred = $q.defer(),
         promise = deferred.promise,


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
AngularJS 1.6 introduced a new behaviour that caused an exception on unhandled rejections of promises. If you were to pass undefined to to $translate the error message would simply be "Possibly unhandled rejection: undefined". With this change a TypeError is thrown instead so that you can easly find where the invalid translationId was passed from in the stack trace

💔Thank you!
