### PR TITLE
feat(service): add allowNamespace parameter

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -36,6 +36,7 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
     $notFoundIndicatorRight,
     $postCompilingEnabled = false,
     $forceAsyncReloadEnabled = false,
+    $allowNamespaces = true,
     $nestedObjectDelimeter = '.',
     $isReady = false,
     $keepContent = false,
@@ -312,6 +313,27 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
 
   /**
    * @ngdoc function
+   * @name pascalprecht.translate.$translateProvider#allowNamespaces
+   * @methodOf pascalprecht.translate.$translateProvider
+   *
+   * @description
+   * Let's you disable namespaces, if you don't need nested translation
+   * object files. Disabling namespaces can improve performance.
+   *
+   * Default value is `true`. Namespaces are enabled by default.
+   *
+   * @param {boolean} namespacesEnabled - namespaces are enabled or not
+   */
+  this.allowNamespaces = function (namespacesEnabled) {
+    if (namespacesEnabled === undefined) {
+      return $allowNamespaces;
+    }
+    $allowNamespaces = namespacesEnabled;
+    return this;
+  };
+
+  /**
+   * @ngdoc function
    * @name pascalprecht.translate.$translateProvider#nestedObjectDelimeter
    * @methodOf pascalprecht.translate.$translateProvider
    *
@@ -346,6 +368,9 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
     }
     if (!result) {
       result = {};
+    }
+    if (!$allowNamespaces) {
+      return data;
     }
     for (key in data) {
       if (!Object.prototype.hasOwnProperty.call(data, key)) {
@@ -1759,6 +1784,20 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
      */
     $translate.cloakClassName = function () {
       return $cloakClassName;
+    };
+
+    /**
+     * @ngdoc function
+     * @name pascalprecht.translate.$translate#allowNamespaces
+     * @methodOf pascalprecht.translate.$translate
+     *
+     * @description
+     * Returns if namespaces are enabled
+     *
+     * @return {boolean} allowNamespaces value
+     */
+    $translate.allowNamespaces = function () {
+      return $allowNamespaces;
     };
 
     /**

--- a/test/unit/service/translate.spec.js
+++ b/test/unit/service/translate.spec.js
@@ -198,6 +198,17 @@ describe('pascalprecht.translate', function () {
       });
     });
 
+    describe('$translate#allowNamespaces()', function () {
+
+      it('should be a function', function () {
+        expect(typeof $translate.allowNamespaces).toBe('function');
+      });
+
+      it('should return \'true\' if no value is specified', function () {
+        expect($translate.allowNamespaces()).toEqual(true);
+      });
+    });
+
     describe('$translate#nestedObjectDelimeter()', function () {
 
       it('should be a function', function () {
@@ -469,6 +480,23 @@ describe('pascalprecht.translate', function () {
 
       $rootScope.$digest();
       expect(value.FOO).toEqual('faa');
+    });
+  });
+
+  describe('$translate#allowNamespaces()', function () {
+
+    beforeEach(module('pascalprecht.translate', function ($translateProvider) {
+      $translateProvider.allowNamespaces(false);
+    }));
+
+    var $translate;
+
+    beforeEach(inject(function (_$translate_) {
+      $translate = _$translate_;
+    }));
+
+    it('should return \'false\' if namespaces were disabled', function () {
+      expect($translate.allowNamespaces()).toEqual(false);
     });
   });
 


### PR DESCRIPTION
Hi,

I'm using angular-translate on an application with lots of large translation json files.

While profiling the application using chrome performance tool i noticed that the multiple calls to the "flatObject" method is taking a whole second of processing time, which is very costly.
Since i'm not using namespaces at all, flatObject iterates over all the key/values for nothing.

I suggest to add the ability to simply disable the usage of namespaces if you don't need them (by adding an allowNamespaces parameter). In my case, disabling it gives me a noticeable performance boost (1s gained since the flatObject processing is just ignored).